### PR TITLE
fix: prevent non-JSON RF console output from corrupting MCP stdio tra…

### DIFF
--- a/src/robotmcp/components/execution/keyword_executor.py
+++ b/src/robotmcp/components/execution/keyword_executor.py
@@ -2269,11 +2269,8 @@ class KeywordExecutor:
                 logger.info(
                     f"BUILTIN KEYWORD EXECUTION PATH: {keyword} with args: {args}"
                 )
-                print(f"🔍 BUILTIN PATH: {keyword} with args: {args}", file=sys.stderr)
-                print(
-                    f"🔍 BUILTIN ARGS TYPES: {[type(arg).__name__ for arg in args]}",
-                    file=sys.stderr,
-                )
+                logger.debug("BUILTIN PATH: %s with args: %s", keyword, args)
+                logger.debug("BUILTIN ARGS TYPES: %s", [type(arg).__name__ for arg in args])
                 try:
                     processed_args = self.rf_converter.parse_and_convert_arguments(
                         keyword,
@@ -2284,12 +2281,12 @@ class KeywordExecutor:
                     logger.info(
                         f"RF converter processed {keyword} args: {args} → {processed_args}"
                     )
-                    print(f"🔍 RF CONVERTER SUCCESS: {processed_args}", file=sys.stderr)
+                    logger.debug("RF CONVERTER SUCCESS: %s", processed_args)
                 except Exception as converter_error:
                     logger.warning(
                         f"RF converter failed for {keyword}: {converter_error}, falling back to basic processing"
                     )
-                    print(f"🔍 RF CONVERTER FAILED: {converter_error}", file=sys.stderr)
+                    logger.debug("RF CONVERTER FAILED: %s", converter_error)
                     processed_args = args
 
                 # DUAL HANDLING: RequestsLibrary needs object arguments, others need string arguments
@@ -2399,11 +2396,8 @@ class KeywordExecutor:
         """
         keyword_lower = keyword.lower()
 
-        # Debug output
-        print(
-            f"🔍 OBJECT CHECK: keyword={keyword_lower}, arg_index={arg_index}, arg_value={arg_value}, type={type(arg_value).__name__}",
-            file=sys.stderr,
-        )
+        logger.debug("OBJECT CHECK: keyword=%s, arg_index=%s, arg_value=%s, type=%s",
+                     keyword_lower, arg_index, arg_value, type(arg_value).__name__)
 
         # RequestsLibrary keywords that accept object parameters
         requests_keywords_with_objects = {
@@ -2418,19 +2412,13 @@ class KeywordExecutor:
         if keyword_lower in requests_keywords_with_objects:
             # Check if this is a dict or list object that should be preserved
             if isinstance(arg_value, (dict, list)):
-                print(
-                    f"🔍 PRESERVING OBJECT: RequestsLibrary keyword {keyword} detected with {type(arg_value).__name__} argument",
-                    file=sys.stderr,
-                )
                 logger.debug(
-                    f"RequestsLibrary keyword {keyword} detected with {type(arg_value).__name__} argument - preserving as object"
+                    "PRESERVING OBJECT: RequestsLibrary keyword %s with %s argument",
+                    keyword, type(arg_value).__name__,
                 )
                 return True
 
-        print(
-            f"🔍 CONVERTING TO STRING: keyword={keyword}, arg will be converted",
-            file=sys.stderr,
-        )
+        logger.debug("CONVERTING TO STRING: keyword=%s, arg will be converted", keyword)
         # For other complex argument structures that might need objects
         # Add more library-specific logic here as needed
 
@@ -2584,10 +2572,8 @@ class KeywordExecutor:
         for i, arg in enumerate(args):
             if isinstance(arg, ObjectPreservingArgument):
                 # This is a named parameter with an object value
-                print(
-                    f"🔍 PROCESSING OBJECT ARG: {arg.param_name}={arg.value} (type: {type(arg.value).__name__})",
-                    file=sys.stderr,
-                )
+                logger.debug("PROCESSING OBJECT ARG: %s=%s (type: %s)",
+                             arg.param_name, arg.value, type(arg.value).__name__)
 
                 # For Robot Framework, we need to handle named parameters properly
                 # The RF ArgumentResolver expects either:
@@ -2603,10 +2589,7 @@ class KeywordExecutor:
 
                 # For common first positional parameters like 'url', convert to positional
                 if param_name == "url" and i == 0:  # First argument and it's URL
-                    print(
-                        f"🔍 CONVERTING URL TO POSITIONAL: {param_value}",
-                        file=sys.stderr,
-                    )
+                    logger.debug("CONVERTING URL TO POSITIONAL: %s", param_value)
                     processed_args.append(param_value)
                 else:
                     # Keep as named parameter
@@ -2656,9 +2639,7 @@ class KeywordExecutor:
 
         signature = REQUESTS_LIBRARY_SIGNATURES.get(keyword.upper(), [])
 
-        print(
-            f"🔍 REQUESTS SIGNATURE: {keyword.upper()} → {signature}", file=sys.stderr
-        )
+        logger.debug("REQUESTS SIGNATURE: %s -> %s", keyword.upper(), signature)
 
         fixed_args = []
         for i, (orig_arg, resolved_arg) in enumerate(zip(original_args, resolved_args)):
@@ -2674,10 +2655,7 @@ class KeywordExecutor:
                     "=", 1
                 )
 
-                print(
-                    f"🔍 PROCESSING PARAM: {orig_param_name}={orig_param_value}",
-                    file=sys.stderr,
-                )
+                logger.debug("PROCESSING PARAM: %s=%s", orig_param_name, orig_param_value)
 
                 # Handle URL parameter (first positional parameter for session-less methods)
                 if orig_param_name == "url" and keyword_lower in [
@@ -2688,10 +2666,7 @@ class KeywordExecutor:
                     "delete",
                 ]:
                     # URL should be positional, not named
-                    print(
-                        f"🔍 CONVERTING URL TO POSITIONAL: {resolved_param_value}",
-                        file=sys.stderr,
-                    )
+                    logger.debug("CONVERTING URL TO POSITIONAL: %s", resolved_param_value)
                     fixed_args.append(resolved_param_value)
                     continue
 
@@ -2709,10 +2684,8 @@ class KeywordExecutor:
 
                             # If the original value is a dict/list but got stringified, restore it
                             if isinstance(original_value, (dict, list)):
-                                print(
-                                    f"🔍 RESTORING OBJECT FOR {orig_param_name}: {orig_param_value} → object",
-                                    file=sys.stderr,
-                                )
+                                logger.debug("RESTORING OBJECT FOR %s: %s -> object",
+                                             orig_param_name, orig_param_value)
                                 # Keep it as named parameter but with restored object
                                 fixed_args.append(f"{orig_param_name}={original_value}")
                                 continue
@@ -2723,7 +2696,7 @@ class KeywordExecutor:
                 # Non-named parameter, keep as-is
                 fixed_args.append(resolved_arg)
 
-        print(f"🔍 FINAL FIXED ARGS: {fixed_args}", file=sys.stderr)
+        logger.debug("FINAL FIXED ARGS: %s", fixed_args)
         return fixed_args
 
     def _extract_browser_state_updates(

--- a/src/robotmcp/core/dynamic_keyword_orchestrator.py
+++ b/src/robotmcp/core/dynamic_keyword_orchestrator.py
@@ -1984,12 +1984,14 @@ class DynamicKeywordDiscovery:
                 diagnostic_info = self._get_diagnostic_info(
                     effective_keyword_name, session_id, active_library
                 )
-                print(
-                    f"PHASE4_DEBUG: Generated diagnostics for '{effective_keyword_name}': {list(diagnostic_info.keys())}"
+                logger.debug(
+                    "Generated diagnostics for '%s': %s",
+                    effective_keyword_name, list(diagnostic_info.keys()),
                 )
             except Exception as diag_error:
-                print(
-                    f"PHASE4_DEBUG: Diagnostics generation failed for '{effective_keyword_name}': {diag_error}"
+                logger.debug(
+                    "Diagnostics generation failed for '%s': %s",
+                    effective_keyword_name, diag_error,
                 )
                 diagnostic_info = {"diagnostic_error": str(diag_error)}
 
@@ -2003,8 +2005,9 @@ class DynamicKeywordDiscovery:
                 "diagnostics": diagnostic_info,  # Phase 4: Enhanced diagnostics
                 "source": "orchestrator",  # Phase 4: Debug - identify source
             }
-            print(
-                f"PHASE4_DEBUG: Orchestrator returning error response with diagnostics: {list(result.keys())}"
+            logger.debug(
+                "Orchestrator returning error response with diagnostics: %s",
+                list(result.keys()),
             )
             return result
 

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -6890,13 +6890,62 @@ except Exception as _mem_exc:
 # ── End ADR-014 ────────────────────────────────────────────────────
 
 
+def _protect_mcp_stdout() -> None:
+    """Redirect sys.__stdout__ to stderr to prevent RF console output from
+    corrupting the MCP stdio transport.
+
+    The MCP SDK captures ``sys.stdout.buffer`` once at startup for JSON-RPC
+    responses.  Robot Framework's ``Log To Console`` keyword and any library
+    ``print()`` call write to ``sys.__stdout__`` instead.  By replacing
+    ``sys.__stdout__`` with a stderr-backed wrapper, those writes go to
+    stderr while MCP's captured buffer reference remains on fd 1.
+
+    Additionally monkey-patches ``robot.output.librarylogger.write_to_console``
+    to force ``stream='stderr'`` as a defence-in-depth measure.
+    """
+    import sys as _sys
+    from io import TextIOWrapper
+
+    # Phase 2: Replace sys.__stdout__ with stderr wrapper.
+    # MCP uses sys.stdout.buffer (captured at mcp.run() time) — unaffected.
+    # RF uses sys.__stdout__ (resolved at call time) — now goes to stderr.
+    try:
+        stderr_fd = _sys.stderr.fileno()
+        _sys.__stdout__ = TextIOWrapper(
+            open(stderr_fd, "wb", closefd=False),
+            encoding="utf-8",
+            line_buffering=True,
+        )
+    except (OSError, AttributeError):
+        # Non-fd stderr (e.g., pytest capture) — use stderr object directly
+        _sys.__stdout__ = _sys.stderr
+
+    # Phase 3: Monkey-patch RF's write_to_console to force stderr stream.
+    try:
+        import robot.output.librarylogger as _rll
+
+        _original_w2c = _rll.write_to_console
+
+        def _safe_write_to_console(msg, newline=True, stream="stdout"):
+            return _original_w2c(msg, newline=newline, stream="stderr")
+
+        _rll.write_to_console = _safe_write_to_console
+    except (ImportError, AttributeError):
+        pass  # RF not installed or API changed
+
+
 def main(argv: List[str] | None = None) -> None:
     """Start the RobotMCP server, optionally booting the Django frontend."""
 
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
 
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, stream=__import__("sys").stderr)
+
+    # Protect MCP stdio transport from RF console output contamination.
+    # Must run before mcp.run() so sys.__stdout__ is redirected before any
+    # RF keyword execution, but after MCP can still capture sys.stdout.buffer.
+    _protect_mcp_stdout()
 
     try:
         _log_attach_banner()

--- a/tests/unit/test_mcp_stdout_protection.py
+++ b/tests/unit/test_mcp_stdout_protection.py
@@ -1,0 +1,94 @@
+"""Tests for MCP stdout protection (non-JSON log message fix).
+
+Verifies that _protect_mcp_stdout() prevents RF console output and
+bare print() calls from contaminating the MCP stdio transport (fd 1).
+"""
+import io
+import os
+import sys
+
+import pytest
+
+
+class TestProtectMcpStdout:
+    """Verify _protect_mcp_stdout redirects sys.__stdout__ to stderr."""
+
+    def test_dunder_stdout_redirected_to_stderr(self):
+        """After _protect_mcp_stdout, sys.__stdout__ should write to stderr, not stdout."""
+        from robotmcp.server import _protect_mcp_stdout
+
+        saved = sys.__stdout__
+        try:
+            _protect_mcp_stdout()
+            # sys.__stdout__ should no longer be the original
+            assert sys.__stdout__ is not saved
+            # Writing to __stdout__ should NOT go to fd 1
+            # We verify by checking it's a TextIOWrapper pointing to stderr fd
+            if hasattr(sys.__stdout__, 'buffer') and hasattr(sys.__stdout__.buffer, 'fileno'):
+                try:
+                    assert sys.__stdout__.buffer.fileno() == sys.stderr.fileno()
+                except io.UnsupportedOperation:
+                    pass  # pytest captures may not support fileno
+        finally:
+            sys.__stdout__ = saved
+
+    def test_sys_stdout_unchanged(self):
+        """sys.stdout must remain unchanged for MCP transport."""
+        from robotmcp.server import _protect_mcp_stdout
+
+        original_stdout = sys.stdout
+        saved_dunder = sys.__stdout__
+        try:
+            _protect_mcp_stdout()
+            # sys.stdout should be untouched (MCP captures sys.stdout.buffer)
+            assert sys.stdout is original_stdout
+        finally:
+            sys.__stdout__ = saved_dunder
+
+    def test_rf_write_to_console_patched(self):
+        """write_to_console should be monkey-patched to force stderr."""
+        from robotmcp.server import _protect_mcp_stdout
+
+        saved_dunder = sys.__stdout__
+        try:
+            _protect_mcp_stdout()
+            import robot.output.librarylogger as rll
+            # Capture what write_to_console does
+            captured = io.StringIO()
+            original_stderr = sys.__stderr__
+            sys.__stderr__ = captured
+            try:
+                rll.write_to_console("test_message", newline=False, stream="stdout")
+            except Exception:
+                pass  # encoding issues in StringIO are OK
+            finally:
+                sys.__stderr__ = original_stderr
+            # The message should have been redirected to stderr (our captured StringIO)
+            # or at minimum, NOT written to sys.__stdout__ (which is now stderr anyway)
+        finally:
+            sys.__stdout__ = saved_dunder
+
+
+class TestNoPrintCallsInSource:
+    """Verify no bare print() calls exist in production source code."""
+
+    def test_no_stdout_print_in_orchestrator(self):
+        """dynamic_keyword_orchestrator.py should have no bare print() calls."""
+        import robotmcp.core.dynamic_keyword_orchestrator as mod
+        import inspect
+        source = inspect.getsource(mod)
+        # Find print( calls that DON'T have file=sys.stderr
+        import re
+        bare_prints = re.findall(r'^\s*print\([^)]*\)\s*$', source, re.MULTILINE)
+        # Filter out any that are in docstrings or comments
+        real_prints = [p for p in bare_prints if 'file=' not in p and '#' not in p.split('print')[0]]
+        assert len(real_prints) == 0, f"Found bare print() calls: {real_prints}"
+
+    def test_no_stderr_print_in_keyword_executor(self):
+        """keyword_executor.py should use logger.debug() not print(file=stderr)."""
+        import robotmcp.components.execution.keyword_executor as mod
+        import inspect
+        source = inspect.getsource(mod)
+        import re
+        stderr_prints = re.findall(r'print\(.*file=sys\.stderr', source)
+        assert len(stderr_prints) == 0, f"Found print(file=sys.stderr) calls: {stderr_prints}"


### PR DESCRIPTION
…nsport

MCP clients (Claude Desktop, Cline) reported JSON parse errors like "Unexpected Token 'C', 'Comments:...' is not valid JSON" because RF keywords that write to console (Log To Console, Log console=True) sent plain text to stdout (fd 1), which is the MCP JSON-RPC transport.

Root cause: _suppress_stdout() was removed from the keyword execution path due to a race condition with the asyncio event loop. The assumption that console='none' was sufficient was incorrect — it only suppresses RF progress output, not Log To Console or library print() calls.

Fix (3 phases):

Phase 1: Replace all bare print() calls with logger.debug()
- 3 PHASE4_DEBUG print() to stdout in dynamic_keyword_orchestrator.py
- 4 debug print(file=sys.stderr) in keyword_executor.py

Phase 2: Redirect sys.__stdout__ to stderr after MCP captures sys.stdout
- MCP SDK captures sys.stdout.buffer once at startup for JSON-RPC
- RF's write_to_console uses sys.__stdout__ (resolved at call time)
- Replacing sys.__stdout__ with a stderr wrapper separates the two
- No fd-level tricks, no race conditions

Phase 3: Monkey-patch robot.output.librarylogger.write_to_console
- Forces stream="stderr" as defence-in-depth
- Catches any RF code path that uses sys.__stdout__ before Phase 2

Also: logging.basicConfig() now explicitly targets stderr.