### PR TITLE
Improve suite_file_path execution handling

### DIFF
--- a/src/robotmcp/components/execution/execution_coordinator.py
+++ b/src/robotmcp/components/execution/execution_coordinator.py
@@ -674,6 +674,7 @@ class ExecutionCoordinator:
         suite_file_path: str,
         validation_level: str = "standard",
         include_warnings: bool = True,
+        execution_options: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Run test suite from file in dry run mode for validation.
@@ -682,23 +683,24 @@ class ExecutionCoordinator:
             suite_file_path: Path to .robot file
             validation_level: Validation depth ('minimal', 'standard', 'strict')
             include_warnings: Include warnings in validation report
+            execution_options: Optional Robot CLI-oriented options (variables, tags,
+                test selection, pythonpath, dry_run_timeout / timeout, loglevel, etc.)
 
         Returns:
             Structured validation results
         """
         try:
-            # Read suite content from file
-            with open(suite_file_path, "r", encoding="utf-8") as f:
-                suite_content = f.read()
+            abs_path = os.path.abspath(suite_file_path)
 
-            # Execute dry run using suite execution service
-            options = {
-                "validation_level": validation_level,
-                "include_warnings": include_warnings,
-            }
+            merged_opts: Dict[str, Any] = dict(execution_options or {})
+            merged_opts["validation_level"] = validation_level
+            merged_opts["include_warnings"] = include_warnings
 
             result = await self.suite_execution_service.execute_dry_run(
-                suite_content, f"file_{os.path.basename(suite_file_path)}", options
+                "",
+                f"file_{os.path.basename(suite_file_path)}",
+                merged_opts,
+                existing_suite_path=abs_path,
             )
 
             # Update result with file information
@@ -837,11 +839,8 @@ class ExecutionCoordinator:
             if execution_options is None:
                 execution_options = {}
 
-            # Read suite content from file
-            with open(suite_file_path, "r", encoding="utf-8") as f:
-                suite_content = f.read()
+            abs_path = os.path.abspath(suite_file_path)
 
-            # Prepare execution options
             options = execution_options.copy()
             options.update(
                 {
@@ -850,23 +849,15 @@ class ExecutionCoordinator:
                 }
             )
 
-            # ADR-019: Detect companion data files next to the suite file
-            import glob as glob_mod
-
-            suite_dir = os.path.dirname(os.path.abspath(suite_file_path))
-            data_extensions = ["*.csv", "*.xlsx", "*.xls", "*.json"]
-            companion_files: List[str] = []
-            for ext_pattern in data_extensions:
-                companion_files.extend(
-                    glob_mod.glob(os.path.join(suite_dir, ext_pattern))
-                )
-
-            # Execute suite using suite execution service
+            # companion_files is only needed when executing from a temp copy;
+            # existing_suite_path runs from the original location so adjacent
+            # data files are already reachable via normal relative paths.
             result = await self.suite_execution_service.execute_normal(
-                suite_content,
+                "",
                 f"file_{os.path.basename(suite_file_path)}",
                 options,
-                companion_files=companion_files if companion_files else None,
+                companion_files=None,
+                existing_suite_path=abs_path,
             )
 
             # Update result with file information

--- a/src/robotmcp/components/execution/suite_execution_service.py
+++ b/src/robotmcp/components/execution/suite_execution_service.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime
 import json
 import io
+import subprocess
 import sys
 from contextlib import redirect_stdout, redirect_stderr
 
@@ -39,7 +40,7 @@ class SuiteExecutionService:
         self.active_executions = {}  # Track active executions for cleanup
         
         # Execution timeouts
-        self.dry_run_timeout = getattr(config, 'DRY_RUN_TIMEOUT', 30)
+        self.dry_run_timeout = int(getattr(config, 'DRY_RUN_TIMEOUT', 180))
         self.execution_timeout = getattr(config, 'EXECUTION_TIMEOUT', 300)
         
         logger.info(f"SuiteExecutionService initialized with temp dir: {self.temp_dir}")
@@ -53,33 +54,96 @@ class SuiteExecutionService:
             return temp_dir
         else:
             return tempfile.mkdtemp(prefix="rf_mcp_execution_")
+
+    _DRY_RUN_TIMEOUT_CAP_S = 7200
+
+    def _effective_dry_run_timeout_seconds(self, options: Dict[str, Any]) -> int:
+        """Resolve subprocess timeout for dry-run (per-call overrides supported)."""
+        base = int(self.dry_run_timeout)
+        if base < 1:
+            base = 1
+        for key in ("dry_run_timeout", "dryrun_timeout"):
+            if key not in options or options[key] is None:
+                continue
+            try:
+                v = int(float(options[key]))
+                return max(1, min(v, self._DRY_RUN_TIMEOUT_CAP_S))
+            except (TypeError, ValueError):
+                pass
+        if "timeout" in options and options["timeout"] is not None:
+            try:
+                v = int(float(options["timeout"]))
+                return max(1, min(v, self._DRY_RUN_TIMEOUT_CAP_S))
+            except (TypeError, ValueError):
+                pass
+        return max(1, min(base, self._DRY_RUN_TIMEOUT_CAP_S))
+
+    def _append_dry_run_cli_execution_options(self, rf_options: List[str], options: Dict) -> None:
+        """Append Robot CLI flags from execution options (shared shape with normal runs)."""
+        if options.get("variables"):
+            for key, value in options["variables"].items():
+                rf_options.extend(["--variable", f"{key}:{value}"])
+        if options.get("include_tags"):
+            for tag in options["include_tags"]:
+                rf_options.extend(["--include", str(tag)])
+        if options.get("exclude_tags"):
+            for tag in options["exclude_tags"]:
+                rf_options.extend(["--exclude", str(tag)])
+        test_names: List[str] = []
+        if options.get("test"):
+            test_names.append(str(options["test"]))
+        tests = options.get("tests")
+        if isinstance(tests, str):
+            test_names.append(tests)
+        elif isinstance(tests, (list, tuple)):
+            test_names.extend(str(t) for t in tests)
+        for name in test_names:
+            rf_options.extend(["--test", name])
+        pp = options.get("pythonpath")
+        if isinstance(pp, str):
+            pp = [pp]
+        if isinstance(pp, (list, tuple)):
+            for p in pp:
+                rf_options.extend(["--pythonpath", str(p)])
     
     async def execute_dry_run(
-        self, 
-        suite_content: str, 
+        self,
+        suite_content: str,
         session_id: str,
-        options: Dict[str, Any] = None
+        options: Dict[str, Any] = None,
+        existing_suite_path: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Execute suite in dry run mode and parse validation results.
-        
+
         Args:
-            suite_content: Robot Framework suite content (.robot format)
+            suite_content: Robot Framework suite content (.robot format); ignored when
+                ``existing_suite_path`` is set.
             session_id: Session identifier for tracking
             options: Execution options including validation_level, include_warnings
-            
-        Returns:
-            Structured validation results
+            existing_suite_path: If set, run Robot against this absolute on-disk suite
+                (preserves suite-relative ``Resource`` / file paths). Otherwise a temp
+                file is created from ``suite_content`` (generated suites).
         """
         if options is None:
             options = {}
-        
+
         execution_id = f"dry_{session_id}_{uuid.uuid4().hex[:8]}"
-        
+
         try:
-            # Create temporary suite file
-            suite_file = await self._create_temp_suite_file(suite_content, execution_id)
-            
+            if existing_suite_path:
+                suite_file = os.path.abspath(existing_suite_path)
+                if not os.path.isfile(suite_file):
+                    return {
+                        "success": False,
+                        "tool": "run_test_suite_dry",
+                        "session_id": session_id,
+                        "error": f"Suite file not found: {suite_file}",
+                        "error_type": "file_not_found",
+                    }
+            else:
+                suite_file = await self._create_temp_suite_file(suite_content, execution_id)
+
             # Execute Robot Framework dry run
             return_code, stdout, stderr = await self._execute_rf_dry_run(suite_file, options)
             
@@ -92,7 +156,7 @@ class SuiteExecutionService:
                 "session_id": session_id,
                 "tool": "run_test_suite_dry",
                 "execution_time": validation_results.get("execution_time", 0),
-                "suite_file_generated": os.path.basename(suite_file)
+                "suite_file_generated": os.path.basename(suite_file),
             })
             
             return validation_results
@@ -115,15 +179,19 @@ class SuiteExecutionService:
         session_id: str,
         options: Dict[str, Any] = None,
         companion_files: List[str] = None,
+        existing_suite_path: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Execute suite normally and parse execution results.
 
         Args:
-            suite_content: Robot Framework suite content (.robot format)
+            suite_content: Robot Framework suite content (.robot format); ignored when
+                ``existing_suite_path`` is set.
             session_id: Session identifier for tracking
             options: Execution options including variables, tags, output settings
-            companion_files: Optional list of data file paths to copy alongside the suite
+            companion_files: Optional list of data file paths to copy alongside a **temp**
+                generated suite (ignored when ``existing_suite_path`` is set).
+            existing_suite_path: If set, run Robot against this absolute on-disk suite.
 
         Returns:
             Comprehensive execution results
@@ -134,22 +202,39 @@ class SuiteExecutionService:
         execution_id = f"normal_{session_id}_{uuid.uuid4().hex[:8]}"
 
         try:
-            # Create temporary suite file
-            suite_file = await self._create_temp_suite_file(suite_content, execution_id)
+            cleanup_tracking_id: Optional[str] = None
+            if existing_suite_path:
+                suite_file = os.path.abspath(existing_suite_path)
+                if not os.path.isfile(suite_file):
+                    return {
+                        "success": False,
+                        "tool": "run_test_suite",
+                        "session_id": session_id,
+                        "error": f"Suite file not found: {suite_file}",
+                        "error_type": "file_not_found",
+                    }
+                if execution_id not in self.active_executions:
+                    self.active_executions[execution_id] = {"files": [], "dirs": []}
+                cleanup_tracking_id = execution_id
+            else:
+                suite_file = await self._create_temp_suite_file(suite_content, execution_id)
 
-            # ADR-019: Copy companion data files to temp dir
-            if companion_files:
-                import shutil
-                for src_path in companion_files:
-                    if os.path.isfile(src_path):
-                        dst = os.path.join(
-                            os.path.dirname(suite_file), os.path.basename(src_path)
-                        )
-                        shutil.copy2(src_path, dst)
-                        logger.debug(f"Copied companion file: {src_path} -> {dst}")
-            
+                # ADR-019: Copy companion data files to temp dir
+                if companion_files:
+                    import shutil
+
+                    for src_path in companion_files:
+                        if os.path.isfile(src_path):
+                            dst = os.path.join(
+                                os.path.dirname(suite_file), os.path.basename(src_path)
+                            )
+                            shutil.copy2(src_path, dst)
+                            logger.debug(f"Copied companion file: {src_path} -> {dst}")
+
             # Execute Robot Framework normally
-            return_code, stdout, stderr, output_dir = await self._execute_rf_normal(suite_file, options)
+            return_code, stdout, stderr, output_dir = await self._execute_rf_normal(
+                suite_file, options, cleanup_tracking_id=cleanup_tracking_id
+            )
             
             # Parse execution results
             execution_results = await self._parse_execution_results(output_dir, return_code, stdout, stderr, options)
@@ -203,30 +288,30 @@ class SuiteExecutionService:
         """Execute Robot Framework dry run using native API."""
         if not ROBOT_AVAILABLE:
             raise Exception("Robot Framework not available for dry run execution")
-        
+
+        timeout_s = self._effective_dry_run_timeout_seconds(options)
+        # Allow the worker thread to surface subprocess.TimeoutExpired before asyncio aborts.
+        asyncio_cap = timeout_s + 60
+
         try:
             start_time = datetime.now()
             
             # Prepare Robot Framework options
             rf_options = ["--dryrun", "--output", "NONE", "--report", "NONE", "--log", "NONE"]
             
-            # Add validation level options
-            validation_level = options.get("validation_level", "standard")
-            if validation_level == "strict":
-                rf_options.extend(["--loglevel", "DEBUG"])
-            elif validation_level == "minimal":
-                rf_options.extend(["--loglevel", "WARN"])
+            # Add validation level options (execution_options may override loglevel)
+            if options.get("loglevel"):
+                rf_options.extend(["--loglevel", str(options["loglevel"])])
             else:
-                rf_options.extend(["--loglevel", "INFO"])
-            
-            # Add custom options if provided
-            if options.get("include_tags"):
-                for tag in options["include_tags"]:
-                    rf_options.extend(["--include", tag])
-            
-            if options.get("exclude_tags"):
-                for tag in options["exclude_tags"]:
-                    rf_options.extend(["--exclude", tag])
+                validation_level = options.get("validation_level", "standard")
+                if validation_level == "strict":
+                    rf_options.extend(["--loglevel", "DEBUG"])
+                elif validation_level == "minimal":
+                    rf_options.extend(["--loglevel", "WARN"])
+                else:
+                    rf_options.extend(["--loglevel", "INFO"])
+
+            self._append_dry_run_cli_execution_options(rf_options, options)
             
             # Set output directory
             rf_options.extend(["--outputdir", self.temp_dir])
@@ -235,58 +320,70 @@ class SuiteExecutionService:
             rf_options.append(suite_file)
             
             logger.debug(f"Executing dry run with options: {rf_options}")
-            
-            # Capture stdout and stderr
-            stdout_capture = io.StringIO()
-            stderr_capture = io.StringIO()
-            
-            # Execute Robot Framework dry run in executor to avoid blocking
+
+            # Use subprocess so Robot console output is captured reliably (run_cli may
+            # write to the underlying stdout fd and bypass contextlib.redirect_stdout).
             def run_robot_dry():
-                with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
-                    try:
-                        # Use run_cli which properly handles command line arguments
-                        return run_cli(rf_options, exit=False)
-                    except SystemExit as e:
-                        return e.code if hasattr(e, 'code') else (e.args[0] if e.args else 1)
-                    except Exception as e:
-                        logger.error(f"Robot Framework dry run error: {e}")
-                        return 252  # Invalid test data
-            
-            # Run in thread to avoid blocking
+                cmd = [sys.executable, "-m", "robot", *rf_options]
+                try:
+                    proc = subprocess.run(
+                        cmd,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        timeout=timeout_s,
+                    )
+                    return proc.returncode, proc.stdout or "", proc.stderr or ""
+                except subprocess.TimeoutExpired:
+                    raise
+                except Exception as e:
+                    logger.error(f"Robot Framework dry run error: {e}")
+                    return 252, "", str(e)
+
             loop = asyncio.get_event_loop()
-            return_code = await asyncio.wait_for(
+            return_code, stdout_content, stderr_content = await asyncio.wait_for(
                 loop.run_in_executor(None, run_robot_dry),
-                timeout=self.dry_run_timeout
+                timeout=asyncio_cap,
             )
-            
+
             execution_time = (datetime.now() - start_time).total_seconds()
-            stdout_content = stdout_capture.getvalue()
-            stderr_content = stderr_capture.getvalue()
-            
-            logger.debug(f"Dry run completed in {execution_time:.2f}s with return code {return_code}")
-            
+
+            logger.debug(
+                f"Dry run completed in {execution_time:.2f}s with return code {return_code}"
+            )
+
             return return_code, stdout_content, stderr_content
             
-        except asyncio.TimeoutError:
-            logger.error(f"Dry run execution timed out after {self.dry_run_timeout}s")
-            raise Exception(f"Dry run execution timed out after {self.dry_run_timeout}s")
+        except (asyncio.TimeoutError, subprocess.TimeoutExpired):
+            logger.error(f"Dry run execution timed out after {timeout_s}s")
+            raise Exception(f"Dry run execution timed out after {timeout_s}s")
         
         except Exception as e:
             logger.error(f"Error executing dry run: {e}")
             raise
     
-    async def _execute_rf_normal(self, suite_file: str, options: Dict) -> Tuple[int, str, str, str]:
+    async def _execute_rf_normal(
+        self,
+        suite_file: str,
+        options: Dict,
+        cleanup_tracking_id: Optional[str] = None,
+    ) -> Tuple[int, str, str, str]:
         """Execute Robot Framework normal run using native API."""
         if not ROBOT_AVAILABLE:
             raise Exception("Robot Framework not available for normal execution")
-        
-        execution_id = os.path.basename(suite_file).replace("suite_", "").replace(".robot", "")
-        output_dir = os.path.join(self.temp_dir, f"output_{execution_id}")
+
+        track_id = (
+            cleanup_tracking_id
+            if cleanup_tracking_id is not None
+            else os.path.basename(suite_file).replace("suite_", "").replace(".robot", "")
+        )
+        output_dir = os.path.join(self.temp_dir, f"output_{track_id}")
         os.makedirs(output_dir, exist_ok=True)
-        
+
         # Track output directory for cleanup
-        if execution_id in self.active_executions:
-            self.active_executions[execution_id]["dirs"].append(output_dir)
+        if track_id in self.active_executions:
+            self.active_executions[track_id]["dirs"].append(output_dir)
         
         try:
             start_time = datetime.now()
@@ -431,6 +528,11 @@ class SuiteExecutionService:
             (r"No keyword with name '(.+)' found", "missing_keyword", "error"),
             (r"Importing library '(.+)' failed", "import_error", "error"),
             (r"Importing resource '(.+)' failed", "resource_error", "error"),
+            (
+                r"Resource file ['\"](.+)['\"] does not exist",
+                "resource_error",
+                "error",
+            ),
             (r"Invalid number of arguments", "argument_error", "error"),
             (r"Keyword name cannot be empty", "syntax_error", "error"),
             (r"Variable '(.+)' not found", "variable_error", "error"),
@@ -737,6 +839,87 @@ class SuiteExecutionService:
         extract_from_suite(suite)
         return failed_tests
     
+    @staticmethod
+    def _try_parse_full_test_summary_line(line: str) -> Optional[int]:
+        """Parse 'N test[s], X passed, Y failed' from one line (flexible whitespace)."""
+        parts = [p.strip() for p in line.strip().split(",")]
+        if len(parts) < 3:
+            return None
+        head, mid, tail = parts[0], parts[1], parts[2]
+        hl, ml, tl = head.lower(), mid.lower(), tail.lower()
+        if not (hl.endswith(" test") or hl.endswith(" tests")):
+            return None
+        if not ml.endswith(" passed"):
+            return None
+        if not tl.endswith(" failed"):
+            return None
+        s = head.strip()
+        i = 0
+        while i < len(s) and s[i].isspace():
+            i += 1
+        j = i
+        while j < len(s) and s[j].isdigit():
+            j += 1
+        if j == i:
+            return None
+        rest = s[j:].strip().lower()
+        if rest not in ("test", "tests"):
+            return None
+        return int(s[i:j])
+
+    @staticmethod
+    def _combined_has_zero_failed(combined: str) -> bool:
+        """True if output contains a phrase '<n> failed' with n == 0 (not 10, 20, …)."""
+        lower = combined.lower()
+        marker = " failed"
+        pos = 0
+        while True:
+            i = lower.find(marker, pos)
+            if i == -1:
+                return False
+            j = i - 1
+            while j >= 0 and lower[j].isspace():
+                j -= 1
+            end = j
+            while j >= 0 and lower[j].isdigit():
+                j -= 1
+            if end > j:
+                num = int(lower[j + 1 : end + 1])
+                if num == 0 and (j < 0 or not lower[j].isdigit()):
+                    return True
+            pos = i + len(marker)
+
+    @staticmethod
+    def _fallback_tests_count_on_line(line: str) -> Optional[int]:
+        """First integer before a standalone 'test' / 'tests' token on this line."""
+        s = line.strip()
+        lower = s.lower()
+        for needle in (" tests", " test"):
+            idx = lower.find(needle)
+            if idx == -1:
+                continue
+            j = idx - 1
+            while j >= 0 and s[j].isspace():
+                j -= 1
+            end = j
+            while j >= 0 and s[j].isdigit():
+                j -= 1
+            if end > j:
+                return int(s[j + 1 : end + 1])
+        return None
+
+    def _parse_robot_test_count_from_output(self, combined: str) -> int:
+        for line in combined.splitlines():
+            n = self._try_parse_full_test_summary_line(line)
+            if n is not None:
+                return n
+        if self._combined_has_zero_failed(combined):
+            for line in combined.splitlines():
+                n = self._fallback_tests_count_on_line(line)
+                if n is not None:
+                    return n
+        return 0
+
     def _extract_suite_info(self, stdout: str, stderr: str) -> Dict[str, Any]:
         """Extract suite information from Robot Framework output."""
         suite_info = {
@@ -745,17 +928,16 @@ class SuiteExecutionService:
             "keyword_count": 0,
             "libraries_used": []
         }
-        
+
+        combined = f"{stdout}\n{stderr}"
+
         # Try to extract suite name
-        name_match = re.search(r"^(.+?) :: ", stdout, re.MULTILINE)
+        name_match = re.search(r"^(.+?) :: ", combined, re.MULTILINE)
         if name_match:
             suite_info["name"] = name_match.group(1).strip()
-        
-        # Try to extract test count from dry run output
-        test_match = re.search(r"(\d+) test[s]?, (\d+) passed, (\d+) failed", stdout)
-        if test_match:
-            suite_info["test_count"] = int(test_match.group(1))
-        
+
+        suite_info["test_count"] = self._parse_robot_test_count_from_output(combined)
+
         return suite_info
     
     def _format_error_message(self, error_type: str, context: str) -> str:

--- a/src/robotmcp/models/config_models.py
+++ b/src/robotmcp/models/config_models.py
@@ -43,6 +43,8 @@ class ExecutionConfig:
     CAPTURE_PAGE_SOURCE_ON_DOM_CHANGE: bool = True
     CAPTURE_PAGE_SOURCE_ON_ERROR: bool = True
     MAX_EXECUTION_TIME: int = 300  # seconds
+    # Subprocess timeout for ``robot --dryrun`` when validating suites (seconds)
+    DRY_RUN_TIMEOUT: int = 180
     
     # Filtering settings
     REMOVE_SCRIPTS_IN_STANDARD: bool = True

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -5789,6 +5789,7 @@ async def run_test_suite_dry(
     suite_file_path: str = None,
     validation_level: str = "standard",
     include_warnings: bool = True,
+    execution_options: Dict[str, Any] = None,
 ) -> Dict[str, Any]:
     """Validate test suite using Robot Framework dry run mode.
 
@@ -5813,10 +5814,14 @@ async def run_test_suite_dry(
         suite_file_path: Direct path to .robot file (optional, overrides session)
         validation_level: Validation depth ('minimal', 'standard', 'strict')
         include_warnings: Include warnings in validation report
+        execution_options: Optional Robot CLI-oriented options when validating a file path
 
     Returns:
         Structured validation results with issues, warnings, and suggestions
     """
+
+    if execution_options is None:
+        execution_options = {}
 
     # Session resolution with same logic as build_test_suite
     from robotmcp.utils.session_resolution import SessionResolver
@@ -5827,7 +5832,10 @@ async def run_test_suite_dry(
         # Direct file validation mode
         logger.info(f"Running dry run validation on file: {suite_file_path}")
         return await execution_engine.run_suite_dry_run_from_file(
-            suite_file_path, validation_level, include_warnings
+            suite_file_path,
+            validation_level,
+            include_warnings,
+            execution_options,
         )
     else:
         # Session-based validation mode
@@ -5890,7 +5898,12 @@ async def run_test_suite(
         mode: "dry"/"validate" for dry run; "full" to execute. Defaults to "full".
         validation_level: Dry-run validation depth ("minimal", "standard", "strict"). Default "standard".
         include_warnings: Whether to include warnings in validation output.
-        execution_options: RF execution options (variables, tags, loglevel, timeout, etc.).
+        execution_options: RF execution options (variables, tags, loglevel, etc.). For
+            ``suite_file_path`` with dry/validate mode, these are forwarded to Robot (e.g.
+            ``variables``, ``include_tags``, ``exclude_tags``, ``test`` / ``tests``,
+            ``pythonpath``, ``loglevel``). Subprocess cap: ``dry_run_timeout`` (preferred),
+            ``dryrun_timeout``, or ``timeout`` (seconds); default comes from config
+            ``DRY_RUN_TIMEOUT``.
         output_level: Response verbosity ("minimal", "standard", "detailed").
         capture_screenshots: Enable screenshot capture on failures (if supported).
 
@@ -5917,7 +5930,10 @@ async def run_test_suite(
         if mode_norm in {"dry", "validate", "validation"}:
             logger.info(f"Running dry run validation on file: {suite_file_path}")
             result = await execution_engine.run_suite_dry_run_from_file(
-                suite_file_path, validation_level, include_warnings
+                suite_file_path,
+                validation_level,
+                include_warnings,
+                execution_options,
             )
             result["mode"] = "dry"
             return result

--- a/tests/unit/test_dry_run_from_file_options.py
+++ b/tests/unit/test_dry_run_from_file_options.py
@@ -1,0 +1,126 @@
+"""Dry-from-file: execution_options and subprocess timeout reach Robot."""
+
+from __future__ import annotations
+
+import pytest
+
+from robotmcp.components.execution.execution_coordinator import ExecutionCoordinator
+from robotmcp.components.execution import suite_execution_service as ses_mod
+
+
+def _minimal_suite(root) -> str:
+    p = root / "t.robot"
+    p.write_text(
+        "*** Settings ***\n"
+        "Library    BuiltIn\n"
+        "*** Test Cases ***\n"
+        "T\n"
+        "    Log    x\n",
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_from_file_default_subprocess_timeout(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run(*_args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(ses_mod.subprocess, "run", fake_run)
+    suite = _minimal_suite(tmp_path)
+    ec = ExecutionCoordinator()
+    await ec.run_suite_dry_run_from_file(suite)
+    assert captured["timeout"] == 180
+
+
+@pytest.mark.asyncio
+async def test_dry_run_from_file_passes_subprocess_timeout(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run(*_args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(ses_mod.subprocess, "run", fake_run)
+    suite = _minimal_suite(tmp_path)
+    ec = ExecutionCoordinator()
+    await ec.run_suite_dry_run_from_file(
+        suite,
+        execution_options={"dry_run_timeout": 97},
+    )
+    assert captured["timeout"] == 97
+
+
+@pytest.mark.asyncio
+async def test_dry_run_from_file_timeout_alias(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run(*_args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(ses_mod.subprocess, "run", fake_run)
+    suite = _minimal_suite(tmp_path)
+    ec = ExecutionCoordinator()
+    await ec.run_suite_dry_run_from_file(suite, execution_options={"timeout": 88})
+    assert captured["timeout"] == 88
+
+
+@pytest.mark.asyncio
+async def test_dry_run_from_file_forwards_cli_options(tmp_path, monkeypatch):
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd, **_kwargs):
+        captured["cmd"] = list(cmd)
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(ses_mod.subprocess, "run", fake_run)
+    suite = _minimal_suite(tmp_path)
+    ec = ExecutionCoordinator()
+    await ec.run_suite_dry_run_from_file(
+        suite,
+        execution_options={
+            "variables": {"SUT_NAME": "acme"},
+            "include_tags": ["solo"],
+            "exclude_tags": ["slow"],
+            "test": "T",
+            "pythonpath": [str(tmp_path)],
+            "loglevel": "ERROR",
+        },
+    )
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list), cmd
+    assert "--variable" in cmd
+    assert "SUT_NAME:acme" in cmd
+    assert cmd.count("--include") >= 1 and "solo" in cmd
+    assert cmd.count("--exclude") >= 1 and "slow" in cmd
+    assert "--test" in cmd and "T" in cmd
+    assert "--pythonpath" in cmd
+    assert "--loglevel" in cmd and "ERROR" in cmd

--- a/tests/unit/test_suite_relative_resource_from_file.py
+++ b/tests/unit/test_suite_relative_resource_from_file.py
@@ -1,0 +1,89 @@
+"""Regression: on-disk suite files must keep suite-relative Resource paths.
+
+Uses a synthetic layout only (no product-specific names).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robotmcp.components.execution.execution_coordinator import ExecutionCoordinator
+
+
+def _write_relative_resource_fixture(root) -> str:
+    res = root / "Resources" / "Common.robot"
+    res.parent.mkdir(parents=True, exist_ok=True)
+    res.write_text(
+        "*** Keywords ***\n"
+        "Common Keyword\n"
+        "    Log    hello from common\n",
+        encoding="utf-8",
+    )
+    suite = root / "TestSuites" / "SmokeLike.robot"
+    suite.parent.mkdir(parents=True, exist_ok=True)
+    suite.write_text(
+        "*** Settings ***\n"
+        "Resource    ../Resources/Common.robot\n"
+        "\n"
+        "*** Test Cases ***\n"
+        "Example\n"
+        "    Common Keyword\n",
+        encoding="utf-8",
+    )
+    return str(suite.resolve())
+
+
+@pytest.mark.asyncio
+async def test_dry_run_from_file_resolves_relative_resource(tmp_path):
+    suite_path = _write_relative_resource_fixture(tmp_path)
+    ec = ExecutionCoordinator()
+    result = await ec.run_suite_dry_run_from_file(suite_path)
+
+    assert result.get("return_code") == 0, result
+    assert result.get("success") is True
+    vr = result.get("validation_results", {})
+    issue_types = {i.get("type") for i in vr.get("issues", [])}
+    assert "resource_error" not in issue_types
+    assert "missing_keyword" not in issue_types
+    assert vr.get("imports_valid") is True
+    assert result.get("suite_info", {}).get("test_count") == 1
+
+
+@pytest.mark.asyncio
+async def test_full_run_from_file_resolves_relative_resource(tmp_path):
+    suite_path = _write_relative_resource_fixture(tmp_path)
+    ec = ExecutionCoordinator()
+    result = await ec.run_suite_execution_from_file(suite_path)
+
+    rc = result.get("return_code")
+    if rc is None:
+        rc = (result.get("execution_details") or {}).get("return_code")
+    assert rc == 0, result
+    assert result.get("success") is True
+    stats = result.get("statistics", {})
+    assert stats.get("total") == 1
+    assert stats.get("failed") == 0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_from_file_missing_file_returns_error(tmp_path):
+    missing = str(tmp_path / "does_not_exist.robot")
+    ec = ExecutionCoordinator()
+    result = await ec.run_suite_dry_run_from_file(missing)
+
+    assert result.get("success") is False
+    assert "file_not_found" == result.get("error_type")
+    assert result.get("session_id"), "error payload must include session_id"
+    assert result.get("suite_file_path") == missing
+
+
+@pytest.mark.asyncio
+async def test_full_run_from_file_missing_file_returns_error(tmp_path):
+    missing = str(tmp_path / "does_not_exist.robot")
+    ec = ExecutionCoordinator()
+    result = await ec.run_suite_execution_from_file(missing)
+
+    assert result.get("success") is False
+    assert "file_not_found" == result.get("error_type")
+    assert result.get("session_id"), "error payload must include session_id"
+    assert result.get("suite_file_path") == missing


### PR DESCRIPTION
## Summary

This PR improves handling for existing on-disk Robot Framework suite files passed via `suite_file_path`.

File-based execution now runs Robot against the original absolute suite path instead of executing a temp-copied suite file. This preserves suite-relative imports like `Resource    ../Resources/Common.robot`.

Generated/in-memory suites keep the existing temp-file behavior.

This PR also forwards dry-run execution options for file-based suites so MCP dry-runs can be closer to normal Robot CLI usage.

## Problem

Real Robot Framework projects commonly keep suites and resources in separate directories. If RobotMCP copies only the suite file content into a temp directory and executes that temp file, relative imports resolve from the temp directory instead of the original suite location.

Minimal repro:

- `TestSuites/SmokeLike.robot`
  - imports `../Resources/Common.robot`
  - has one test case calling `Common Keyword`
- `Resources/Common.robot`
  - defines `Common Keyword`

Native Robot dry-run runs the suite from its original path and resolves the resource correctly. The previous file-based RobotMCP path could fail because the suite was executed from a temp location.

## Fix

- For existing `suite_file_path` inputs, pass the original absolute suite path to Robot.
- Keep using temp directories for output artifacts.
- Preserve temp-file behavior for generated/in-memory suites.
- Forward dry-run execution options for file-based suites, including test selection, tags, variables, pythonpath, loglevel, and timeout options.
- Capture dry-run output via subprocess so stdout/stderr parsing is reliable.
- Parse suite info from combined stdout/stderr.

## Tests

```text
uv run pytest tests/unit/test_suite_relative_resource_from_file.py tests/unit/test_dry_run_from_file_options.py -q --tb=short
```