### PR TITLE
feat: expose structured diagnostics on dry-run subprocess timeout

### DIFF
--- a/src/robotmcp/components/execution/suite_execution_service.py
+++ b/src/robotmcp/components/execution/suite_execution_service.py
@@ -30,6 +30,37 @@ from robotmcp.models.config_models import ExecutionConfig
 
 logger = logging.getLogger(__name__)
 
+_DRY_RUN_TIMEOUT_OUTPUT_TAIL_MAX = 8000
+
+
+class DryRunSubprocessTimeoutError(Exception):
+    """Raised when the ``robot --dryrun`` subprocess exceeds its timeout."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        timeout_seconds: int,
+        command: List[str],
+        cwd: str,
+        stdout_tail: str,
+        stderr_tail: str,
+    ) -> None:
+        super().__init__(message)
+        self.timeout_seconds = timeout_seconds
+        self.command = command
+        self.cwd = cwd
+        self.stdout_tail = stdout_tail
+        self.stderr_tail = stderr_tail
+
+
+def _truncate_output_tail(text: Optional[str], max_len: int = _DRY_RUN_TIMEOUT_OUTPUT_TAIL_MAX) -> str:
+    if not text:
+        return ""
+    if len(text) <= max_len:
+        return text
+    return text[-max_len:]
+
 
 class SuiteExecutionService:
     """Service for executing Robot Framework test suites in dry run and normal modes."""
@@ -160,7 +191,22 @@ class SuiteExecutionService:
             })
             
             return validation_results
-            
+
+        except DryRunSubprocessTimeoutError as exc:
+            logger.error("Dry run subprocess timeout: %s", exc)
+            return {
+                "success": False,
+                "tool": "run_test_suite_dry",
+                "session_id": session_id,
+                "error": str(exc),
+                "error_type": "execution_error",
+                "timeout": True,
+                "timeout_seconds": exc.timeout_seconds,
+                "command": exc.command,
+                "cwd": exc.cwd,
+                "timeout_stdout_tail": exc.stdout_tail,
+                "timeout_stderr_tail": exc.stderr_tail,
+            }
         except Exception as e:
             logger.error(f"Error in dry run execution for session {session_id}: {e}")
             return {
@@ -318,16 +364,17 @@ class SuiteExecutionService:
             
             # Add the suite file
             rf_options.append(suite_file)
-            
+
+            dry_cmd = [sys.executable, "-m", "robot", *rf_options]
+
             logger.debug(f"Executing dry run with options: {rf_options}")
 
             # Use subprocess so Robot console output is captured reliably (run_cli may
             # write to the underlying stdout fd and bypass contextlib.redirect_stdout).
             def run_robot_dry():
-                cmd = [sys.executable, "-m", "robot", *rf_options]
                 try:
                     proc = subprocess.run(
-                        cmd,
+                        dry_cmd,
                         capture_output=True,
                         text=True,
                         encoding="utf-8",
@@ -335,8 +382,18 @@ class SuiteExecutionService:
                         timeout=timeout_s,
                     )
                     return proc.returncode, proc.stdout or "", proc.stderr or ""
-                except subprocess.TimeoutExpired:
-                    raise
+                except subprocess.TimeoutExpired as exc:
+                    cwd = os.getcwd()
+                    out = _truncate_output_tail(getattr(exc, "output", None))
+                    err = _truncate_output_tail(getattr(exc, "stderr", None))
+                    raise DryRunSubprocessTimeoutError(
+                        f"Dry run subprocess timed out after {timeout_s}s",
+                        timeout_seconds=timeout_s,
+                        command=list(dry_cmd),
+                        cwd=cwd,
+                        stdout_tail=out,
+                        stderr_tail=err,
+                    ) from exc
                 except Exception as e:
                     logger.error(f"Robot Framework dry run error: {e}")
                     return 252, "", str(e)
@@ -354,11 +411,25 @@ class SuiteExecutionService:
             )
 
             return return_code, stdout_content, stderr_content
-            
-        except (asyncio.TimeoutError, subprocess.TimeoutExpired):
-            logger.error(f"Dry run execution timed out after {timeout_s}s")
-            raise Exception(f"Dry run execution timed out after {timeout_s}s")
-        
+
+        except DryRunSubprocessTimeoutError:
+            raise
+        except asyncio.TimeoutError as exc:
+            cwd = os.getcwd()
+            logger.error(
+                "Dry run asyncio wait exceeded outer limit (timeout_s=%s asyncio_cap=%s)",
+                timeout_s,
+                asyncio_cap,
+            )
+            raise DryRunSubprocessTimeoutError(
+                f"Dry run execution timed out after {timeout_s}s",
+                timeout_seconds=timeout_s,
+                command=list(dry_cmd),
+                cwd=cwd,
+                stdout_tail="",
+                stderr_tail="",
+            ) from exc
+
         except Exception as e:
             logger.error(f"Error executing dry run: {e}")
             raise

--- a/tests/unit/test_dry_run_timeout_diagnostics.py
+++ b/tests/unit/test_dry_run_timeout_diagnostics.py
@@ -1,0 +1,52 @@
+"""Dry-run subprocess timeout returns structured diagnostic fields."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from robotmcp.components.execution.execution_coordinator import ExecutionCoordinator
+from robotmcp.components.execution import suite_execution_service as ses_mod
+
+
+def _minimal_suite(root) -> str:
+    p = root / "t.robot"
+    p.write_text(
+        "*** Settings ***\n"
+        "Library    BuiltIn\n"
+        "*** Test Cases ***\n"
+        "T\n"
+        "    Log    x\n",
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_subprocess_timeout_payload_includes_streams(tmp_path, monkeypatch):
+    long_out = "O" * 9000
+    long_err = "E" * 9000
+
+    def fake_run(cmd, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd, timeout=3, output=long_out, stderr=long_err)
+
+    monkeypatch.setattr(ses_mod.subprocess, "run", fake_run)
+    suite = _minimal_suite(tmp_path)
+    ec = ExecutionCoordinator()
+    result = await ec.run_suite_dry_run_from_file(
+        suite,
+        execution_options={"dry_run_timeout": 3},
+    )
+    assert result.get("timeout") is True
+    assert result.get("timeout_seconds") == 3
+    assert isinstance(result.get("command"), list)
+    assert "-m" in result["command"] and "robot" in result["command"]
+    assert result.get("cwd")
+    out = result.get("timeout_stdout_tail") or ""
+    err = result.get("timeout_stderr_tail") or ""
+    assert len(out) == ses_mod._DRY_RUN_TIMEOUT_OUTPUT_TAIL_MAX
+    assert len(err) == ses_mod._DRY_RUN_TIMEOUT_OUTPUT_TAIL_MAX
+    assert out == long_out[-ses_mod._DRY_RUN_TIMEOUT_OUTPUT_TAIL_MAX :]
+    assert err == long_err[-ses_mod._DRY_RUN_TIMEOUT_OUTPUT_TAIL_MAX :]
+    assert "Dry run subprocess timed out" in (result.get("error") or "")


### PR DESCRIPTION
## Summary
Currently when the `robot --dryrun` subprocess hits its timeout, callers only
see a generic timeout error with no insight into what Robot was doing when it
hung. This makes hung dry-runs hard to diagnose — especially when the timeout
fires inside library import or resource resolution.

This PR introduces a `DryRunSubprocessTimeoutError` and threads its diagnostic
fields through `run_suite_dry_run_from_file`, so the returned result now
includes:

- `timeout: true` and `timeout_seconds`
- `command` — the exact `python -m robot …` invocation used
- `cwd` — the working directory at the time
- `timeout_stdout_tail` / `timeout_stderr_tail` — last 8000 chars of each stream

The output tails are capped (`_DRY_RUN_TIMEOUT_OUTPUT_TAIL_MAX = 8000`) so the
payload stays bounded even when Robot prints a lot before hanging.

## Why

Without these fields, "dry-run timed out" gives the caller no way to tell
whether Robot got stuck importing a library, parsing a resource, or somewhere
else. With the command + cwd + last bytes of stderr you can usually pinpoint
the cause without re-running.

## Test plan
- [x] Added `tests/unit/test_dry_run_timeout_diagnostics.py` — monkeypatches
      `subprocess.run` to raise `TimeoutExpired` with long stdout/stderr and
      asserts the returned payload contains all new fields and the tails are
      truncated to the cap.
- [x] Existing `test_dry_run_from_file_options.py` and
      `test_suite_relative_resource_from_file.py` still pass.

## Notes
- Stacked on top of #65 (`pr-file-based-dry-run-handling`). Once that
  merges, this PR's diff will collapse to just the diagnostics commit.
- No public API removed; all new fields are additive on the existing result dict.
