### PR TITLE
OBS-10/11/12 + OBS-15 — Obstacle Course followups (post-PR #69)

### DIFF
--- a/docs/issues/2026-05-17_post_obs_v3_followup_stories.md
+++ b/docs/issues/2026-05-17_post_obs_v3_followup_stories.md
@@ -1,0 +1,426 @@
+# Follow-up user stories: post-OBS-10/11/12 (v3) benchmark findings
+
+**Source benchmark**: `docs/benchmarks/2026-05-17_tricentis_v3_post_obs_10_11_12.md`
+**Triggered by**: validation re-run of the Tricentis Obstacle Course after
+OBS-10/11/12 shipped on `feature/obstacle-course-followup`.
+**Date**: 2026-05-17 (third validation run of the day)
+**Status**: ready for implementation
+**Predecessors**:
+- `docs/issues/2026-05-17_obstacle_course_stories.md` (OBS-01..09)
+- `docs/issues/2026-05-17_post_obs_followup_stories.md` (OBS-10/11/12, OBS-13/14 proposed)
+
+The v3 validation run confirmed that OBS-10 (Drag And Drop pre-scroll) and
+OBS-11 (variable propagation) delivered on their primary acceptance metrics:
+Sonnet's Obstacle 10 dropped from 27 → 13 calls, Haiku from 9 → 7. Variable
+propagation rewrote `${ENTRY_COUNT}` / `${ORDER_ID}` correctly in Sonnet's
+generated suite.
+
+During that same run, three new findings surfaced — one a real defect
+(OBS-12 hint exists but is unreachable from the path where the bug
+actually fires), two a quality / UX papercut (false-positive warning,
+ARIA text disambiguation).
+
+## Story index
+
+| ID | Title | Type | Priority | Effort | Source obstacle |
+|---|---|---|---|---|---|
+| OBS-15 | OBS-12 hint must also reach the pre-validation failure path | Bug | Med | S | 8 (Wait a moment) — Sonnet v3 |
+| OBS-16 | `untracked_variables` warning false-positive after OBS-11 substitution | Bug (low-impact) | Low | S | 7 (And counting) + 3 (Not a table) — Sonnet v3 |
+| OBS-17 | ARIA snapshot conflates visible page text with element metadata | UX | Low | S | 3 (Not a table) — Sonnet v3 |
+
+Plus one open investigation (not yet a formal story — see "Open
+investigations" at end of file): Haiku v3 propagated 1 of 3 captured
+variables; the other two used literals despite OBS-11 being in effect.
+
+---
+
+## OBS-15 — OBS-12 hint must also reach the pre-validation failure path
+
+**Type**: Bug · **Priority**: Med · **Effort**: S
+
+### Background
+
+OBS-12 added a focused hint that fires when an agent uses a
+SeleniumLibrary-style role-prefix locator (`button=X`, `link=X`,
+`input=X`, `select=X`, `textarea=X`) against the Browser library. The
+hint points at the working alternatives (`text=X` and
+`css=<tag>:text-is('X')`). The unit tests for OBS-12
+(`test_browser_role_prefix_hint.py`) pin the hint firing via
+`generate_hints` in `utils/hints.py`.
+
+The v3 validation run confirmed by direct test that **the hint never
+actually fires in production**: Sonnet deliberately attempted
+`intent_action(intent="click", target="button=Calculate")` on
+Obstacle 8 and the OBS-12 hint was absent from the failure response.
+
+Root cause: `_check_browser_role_prefix_misuse` is invoked via the
+`generate_hints(ctx)` pipeline, which is called from the
+**keyword-execution failure path** at
+`keyword_executor.py:1684+`. But `button=X` against Browser library
+typically fails earlier — at **pre-validation** (the 500ms gate that
+checks element actionability) — which builds its own hint list
+**inline** at `keyword_executor.py:1393+` and does NOT route through
+`generate_hints`. The OBS-12 hint is therefore unreachable from the
+path where the bug actually manifests.
+
+The unit tests passed because they mocked the wrong call site. They
+asserted the hint fires when `generate_hints(ctx)` is called with the
+right HintContext — but they didn't verify that the production
+failure path for `button=X` rejections actually calls
+`generate_hints`. It doesn't.
+
+### User story
+
+> **As an** automation agent who accidentally uses a SeleniumLibrary-
+> style role-prefix locator against the Browser library,
+> **I want** the failure response to include the OBS-12 hint pointing
+> at `text=` and `css=<tag>:text-is('X')` alternatives,
+> **so that** I can fix the locator without spending another tool call
+> guessing at the syntax. The current behaviour — generic "element
+> not visible/enabled" with no syntax clue — is exactly what OBS-12
+> was supposed to close.
+
+### Details captured during the run
+
+- **Obstacle**: 8 — Wait a moment (Sonnet v3 validation run)
+- **Failing call**: `intent_action(intent="click", target="button=Calculate")`
+- **Response error text**: `"Pre-validation failed: Element missing required states: enabled, visible"`
+- **Hint surfaced**: visibility_hint, enabled_hint, pre_validate_timeout_hint
+- **Hint MISSING**: `browser_role_prefix_misuse` (the OBS-12 hint)
+- **Sonnet's verbatim observation**: *"Did the OBS-12 hint fire? **No.**
+  The error returned was a pre-validation failure: 'Pre-validation
+  failed: Element missing required states: enabled, visible'."*
+- **Recovery cost**: 1 call (Sonnet retried with `text=Calculate`),
+  effectively the same as if OBS-12 didn't exist.
+
+### Acceptance criteria
+
+1. When pre-validation rejects a locator that matches the OBS-12
+   role-prefix pattern (`(button|link|input|select|textarea)=<value>`)
+   in a Browser-library session, the failure response's `hints` list
+   includes a `browser_role_prefix_misuse` entry with the same shape
+   as the keyword-execution-path version (title, message, two
+   examples for `text=` and `css=<tag>:text-is('X')`).
+2. The existing OBS-12 unit tests must continue passing — the
+   keyword-execution-path firing is preserved (it's still the
+   fallback when pre-validation is disabled or doesn't run).
+3. The hint MUST NOT fire twice when both paths could reach it
+   (deduplicate by `type` key in the hints list).
+4. Real-Browser integration test in
+   `test_real_browser_prevalidation.py`: launch a Browser session,
+   navigate to a fixture page with a `<button>Submit</button>`,
+   call `intent_action(intent="click", target="button=Submit")`,
+   assert the response's `hints` contains an entry with
+   `type == "browser_role_prefix_misuse"` (or equivalent matcher
+   based on the title text).
+
+### Suggested experiments
+
+- **Repro test (must fail before the fix)**: spin up a Browser
+  session against a data: URL fixture page with one button. Call
+  `intent_action(intent="click", target="button=Submit")`. Assert
+  the response includes the role-prefix hint in `hints`. This test
+  should FAIL on the current code (proving the gap) and PASS after
+  the fix.
+- **Re-run benchmark**: after OBS-15 lands, run Sonnet's v3 prompt
+  again. Confirm the agent receives the hint when it tries
+  `button=X` (the exact scenario from Obstacle 8).
+
+### Implementation notes
+
+- The pre-validation failure-hint block lives at
+  `src/robotmcp/components/execution/keyword_executor.py:1393+`. It
+  currently builds hints inline:
+  - `pre_validation_failure` (always)
+  - `visibility_hint` (if missing "visible")
+  - `enabled_hint` (if missing "enabled")
+  - `pre_validate_timeout_hint` (always)
+- Add a check that calls
+  `_check_browser_role_prefix_misuse(ctx_like, err)` (or equivalent
+  inline duplicate) and appends to `hints` when the locator matches
+  the role-prefix pattern.
+- Build a small adapter to construct a `HintContext`-shaped object
+  from the pre-validation block's available data (keyword, arguments,
+  session library, error_text). The existing OBS-12 checker doesn't
+  need to change — only the call site does.
+- Alternative: extract the role-prefix-check logic into a shared
+  helper in `utils/hints.py` that both paths import. Cleaner long-
+  term but slightly larger refactor.
+- The two paths emit hints with different schemas: the
+  pre-validation path uses inline `{"type": "X", "message": ...,
+  "suggestion": ..., "example": ...}` shapes; `generate_hints`
+  returns `{"title": ..., "message": ..., "examples": [...]}` shapes.
+  Reconcile the shapes in the pre-validation path so the OBS-15
+  addition matches the existing pre-validation hint format.
+
+### Out of scope
+
+- Other locator-shape hints that may have the same reachability
+  issue. Audit them in a follow-up if needed; OBS-15 just covers
+  the role-prefix case.
+- Rewriting the hint pipeline so all hints go through a single
+  surface. Worth doing eventually but not blocking OBS-15.
+
+---
+
+## OBS-16 — `untracked_variables` warning false-positive after OBS-11 substitution
+
+**Type**: Bug (low-impact) · **Priority**: Low · **Effort**: S
+
+### Background
+
+The v3 validation run surfaced a low-impact-but-confusing false
+positive in `build_test_suite`'s `warnings` field. Sonnet's
+generated suite for Obstacles 3 and 7 correctly used `${ORDER_ID}`
+and `${ENTRY_COUNT}` in subsequent `Fill Text` steps (OBS-11
+substitution working as designed). But the same suite's `warnings`
+list included both variables in `untracked_variables` — declaring
+them as captured-but-unused.
+
+The fact that the variables DO appear in the rf_text contradicts
+the warning. The likely root cause: the variable-tracking pass that
+emits `untracked_variables` runs BEFORE OBS-11's
+`_propagate_assigned_variables_to_literal_args` rewrites the
+literals. The tracker sees only the literal `5` / `1079954` —
+correctly identifies them as not-being-references to a captured
+variable — and flags `${ENTRY_COUNT}` / `${ORDER_ID}` as untracked.
+
+This is a fidelity issue, not a correctness issue. The generated
+suite is correct; only the diagnostics lie. Low impact but worth
+fixing because warnings exist precisely to inform agents about
+real issues — false positives erode trust.
+
+### User story
+
+> **As an** agent reading `build_test_suite` warnings to confirm my
+> recorded session is clean,
+> **I want** the `untracked_variables` warning to reflect the
+> post-substitution state of the generated suite,
+> **so that** I don't have to verify whether each warning is real or
+> an artifact of OBS-11's post-processing pass.
+
+### Details captured during the run
+
+- **Obstacles affected**: 3 (Not a table) and 7 (And counting),
+  Sonnet v3 validation run
+- **Variables flagged**: `${ENTRY_COUNT}` and `${ORDER_ID}`
+- **Reality**: both variables ARE referenced in the rf_text after
+  OBS-11 propagation (`Fill Text id=offerId ${ORDER_ID}`,
+  `Fill Text ... ${ENTRY_COUNT}`)
+- **Sonnet's verbatim observation**: *"`ENTRY_COUNT` and `ORDER_ID`
+  appeared in `build_test_suite` `warnings[].untracked_variables`
+  even though both were correctly assigned and propagated in the
+  rf_text. The warning appears to be a false positive — the
+  variables ARE tracked (they show up in the rf_text correctly)."*
+
+### Acceptance criteria
+
+1. When OBS-11 substitutes a literal arg with `${VAR}` in the
+   generated suite, the resulting suite's `untracked_variables`
+   warning MUST NOT include `${VAR}`.
+2. Variables that ARE genuinely declared-but-unused (no captured
+   value used downstream by any subsequent step) DO still appear
+   in `untracked_variables` — no regression on the warning's
+   intended purpose.
+3. The fix is verified by a unit test that:
+   a. Synthesizes a session with a capture step and a subsequent
+      literal-arg step that matches the captured value.
+   b. Builds the suite.
+   c. Asserts the rf_text contains `${VAR}` AND the warnings list
+      does NOT contain `${VAR}` in `untracked_variables`.
+4. Negative test: a session with a capture step but no downstream
+   reference (matching or otherwise) still produces the
+   `untracked_variables` warning for that variable.
+
+### Suggested experiments
+
+- **Inspect ordering**: find the variable-tracking pass in the
+  suite-build pipeline. Confirm it runs before OBS-11's
+  `_propagate_assigned_variables_to_literal_args` (called from
+  `_generate_rf_text`).
+- **Two fixes possible**:
+  a. Move the variable-tracker AFTER OBS-11 substitution (the
+     tracker sees the post-substitution rf_text).
+  b. Make the tracker re-scan after substitution.
+
+### Implementation notes
+
+- The OBS-11 substitution lives in `test_builder.py`
+  `_propagate_assigned_variables_to_literal_args` and is called
+  from `_generate_rf_text` per-test-case.
+- The `untracked_variables` warning is constructed elsewhere —
+  likely in a different pass that walks `session.steps` /
+  `test_case.steps` BEFORE the rendering pass. Find it by grep:
+  `grep -rn "untracked_variables" src/robotmcp/`.
+- Simplest fix: ensure the OBS-11 substitution mutates
+  `test_case.steps` in place (which it does), then re-run the
+  variable-tracker after. Or move the tracker to run as part of
+  the rendering pass so it sees the substituted args.
+
+### Out of scope
+
+- Other false-positive warnings in the suite-build pipeline. Audit
+  separately if more surface.
+
+---
+
+## OBS-17 — ARIA snapshot conflates visible page text with element metadata
+
+**Type**: UX · **Priority**: Low · **Effort**: S (heuristic-based)
+
+### Background
+
+The Tricentis Obstacle Course's "Not a table" page (Obstacle 3) has
+a visible teaching annotation that reads, in part, *"ControlProperties:
+class myBad..."* — as part of the page's RENDERED CONTENT, not as
+real element class/id attributes. When this content is captured into
+the ARIA snapshot, an agent reading the snapshot sees the phrase
+`class myBad` and reasonably pattern-matches it as a CSS-class hint
+to target: `css=.myBad`.
+
+The locator doesn't match anything because no element has class
+`myBad` — the text just happens to MENTION it. Sonnet wasted two
+tool calls in v3 on this pattern.
+
+This is a Tricentis-page-specific quirk, but the underlying issue is
+general: when a page contains visible prose that contains words like
+"class X" or "id Y", those phrases can mislead pattern-matching
+agents. The ARIA snapshot could disambiguate by wrapping visible-text
+content in clearly-delimited quotes/brackets, so the agent can
+distinguish:
+- `<div class="X">` (real element class)
+- visible text "class X" (page prose)
+
+### User story
+
+> **As an** agent reading an ARIA snapshot to derive locators,
+> **I want** visible-text content rendered in a way that clearly
+> distinguishes it from element-metadata fields (class names, ids,
+> roles),
+> **so that** I don't pattern-match prose like "class myBad" as a
+> CSS-class hint when it's actually just visible page text.
+
+### Details captured during the run
+
+- **Obstacle**: 3 — Not a table (Sonnet v3 validation run)
+- **Sonnet's verbatim observation**: *"ARIA text showed 'class myBad'
+  as part of ControlProperties metadata text, leading me to try
+  `.myBad` as CSS class — wasted 2 tool calls. The metadata is
+  embedded in the page text, not real element attributes."*
+- **Wasted call 1**: `Get Text css=.myBad td:last-child` — failed,
+  `css=.myBad` matched nothing
+- **Wasted call 2**: `Evaluate JavaScript` targeting `.myBad` —
+  same root cause
+- **Working recovery**: read the FULL HTML via `Get Page Source` to
+  discover the actual `.propertyGrid` CSS class on the real DOM
+  element
+
+### Acceptance criteria
+
+1. When the ARIA snapshot renders an element's `visible-text`
+   content (the text actually displayed in the browser), the text
+   is wrapped in distinguishing characters (e.g. surrounding
+   double-quotes `"..."` or `[text: ...]`) so it's clearly
+   distinguishable from element-attribute fields.
+2. The wrapping is consistent across all visible-text-bearing
+   elements; agents can scan for the wrapper to find prose.
+3. Element-metadata fields (`role`, `name`, `accessibility name`,
+   etc.) remain rendered in their existing format — only
+   `visible-text` / `text-content` is wrapped.
+4. Existing ARIA-snapshot integration tests continue passing (the
+   wrapping is additive, doesn't break parsers).
+5. Pin via unit test: a fixture page with a `<div class="real">prose
+   that mentions class myBad and id foo</div>` — the ARIA snapshot
+   should clearly distinguish the real `class="real"` attribute
+   from the visible text containing "class myBad".
+
+### Suggested experiments
+
+- **Repro fixture**:
+  ```html
+  <div class="real-class">This div mentions class fakeBad as part of its prose.</div>
+  ```
+- ARIA snapshot output should make it clear that `real-class` is
+  the element's class (metadata) and `class fakeBad as part of its
+  prose` is the rendered text content.
+- **A/B**: re-run Sonnet's v3 prompt after OBS-17 lands. Confirm
+  the wasted-call pattern on Obstacle 3 doesn't reproduce.
+
+### Implementation notes
+
+- ARIA snapshot generation lives in
+  `src/robotmcp/components/execution/page_source_service.py`. Find
+  the text-rendering path (likely a method that formats each
+  element's role + name + value + text).
+- The natural fix is to wrap visible text in double quotes when
+  emitting:
+  - Before: `div ControlProperties: class myBad ...`
+  - After: `div "ControlProperties: class myBad ..."`
+- Some MCP-server frameworks already use this convention; Playwright's
+  ARIA snapshot output style is a reasonable reference.
+
+### Out of scope
+
+- Page-source filtering / sanitisation. Just the ARIA-snapshot
+  text-rendering aspect.
+- ARIA snapshot semantics (which elements are visible, role
+  inheritance, etc.) — unchanged.
+
+---
+
+## Open investigations (not yet formal stories)
+
+### IH1 — Haiku's OBS-11 propagation rate was 1 of 3
+
+Haiku's v3 report listed three captured variables:
+- `${TOTAL_COUNT}` — propagated correctly
+- `${ORDER_ID}` — used as literal (not propagated)
+- `${ENTRY_COUNT}` — used as literal (not propagated)
+
+Three plausible causes for the misses (cannot disambiguate without
+the raw Haiku rf_text):
+
+1. **Lookback expired**: Haiku may have inserted >10 intermediate
+   steps between capture and use, exceeding OBS-11's lookback window.
+2. **Locator-slot rule**: Haiku may have placed the literal at
+   arg 0 (the locator position), where OBS-11 deliberately skips
+   substitution.
+3. **Type-coerce mismatch**: `Get Element Count` returns int at
+   runtime; `_captured_value_str` coerces to str. The literal in
+   the next step should also be a string (RF wire format). Possible
+   edge case if Haiku used a numeric form somewhere.
+
+**Action**: before promoting this to a story, retrieve Haiku's raw
+rf_text from the v3 transcript and inspect the actual capture/use
+patterns to determine whether OBS-11's bounding rules are too tight
+or whether Haiku's calls fall outside the rules legitimately. If the
+former: file as OBS-18 (relax lookback / arg-0 rules) with
+acceptance criteria measurable against the same Haiku-style call
+trace.
+
+---
+
+## Roll-up: experiments to run after this batch
+
+A single re-run of the v3 benchmark after OBS-15/16/17 ship should
+confirm:
+
+- **OBS-15**: Sonnet's `button=Calculate` attempt on Obstacle 8
+  yields the role-prefix hint in the response. Reduces the recovery
+  cost from 1 call to 0 (agent reads the hint instead of guessing).
+- **OBS-16**: `build_test_suite` warnings list does not include
+  `${ENTRY_COUNT}` or `${ORDER_ID}` (they're correctly tracked
+  post-substitution).
+- **OBS-17**: Sonnet's wasted-call pattern on Obstacle 3 (`class myBad`)
+  does not reproduce. The ARIA snapshot makes visible-text vs
+  metadata distinguishable.
+
+## Related artifacts
+
+- `docs/benchmarks/2026-05-17_tricentis_v3_post_obs_10_11_12.md` —
+  parent v3 benchmark report.
+- `docs/issues/2026-05-17_post_obs_followup_stories.md` — predecessor
+  stories OBS-10/11/12 (now landed on `feature/obstacle-course-followup`)
+  + OBS-13/14 still proposed.
+- `docs/issues/2026-05-17_obstacle_course_stories.md` — original
+  OBS-01..09 series (now merged via PR #69).

--- a/docs/issues/find_keywords_library_name_filter_proposal.md
+++ b/docs/issues/find_keywords_library_name_filter_proposal.md
@@ -1,0 +1,355 @@
+# find_keywords ignores `library_name` for semantic/pattern strategies
+
+**Status**: IMPLEMENTED on `feature/obstacle-course-followup` (2026-05-17) — see "Implementation outcome" at bottom of this file
+**Defect reproduced**: 2026-05-17 against pre-fix code
+**Affected tool**: `find_keywords` (MCP tool)
+**Affected strategies**: `semantic` (alias: `intent`), `pattern` (alias: `search`)
+**Unaffected strategies**: `catalog` (alias: `library`), `session`
+
+## Summary
+
+`find_keywords(strategy="semantic", library_name="Browser", ...)` returns
+keywords from libraries other than Browser (notably SeleniumLibrary), and
+silently — no `excluded_keywords` field, no `session_library` indicator,
+no warning. The `library_name` parameter is documented as "Optional
+library filter for catalog search" and is in fact only wired into the
+catalog branch of `find_keywords`. For semantic and pattern strategies,
+the parameter is **silently accepted and ignored**.
+
+## Reproduction
+
+Exact user payload:
+
+```json
+{
+  "query": "select dropdown option by label or text",
+  "strategy": "semantic",
+  "context": "web",
+  "library_name": "Browser",
+  "limit": 10
+}
+```
+
+Reproduced via in-process call (no MCP roundtrip needed):
+
+```bash
+uv run python -c "
+import asyncio
+from robotmcp.server import find_keywords
+async def main():
+    fn = getattr(find_keywords, 'fn', find_keywords)
+    result = await fn(
+        query='select dropdown option by label or text',
+        strategy='semantic',
+        context='web',
+        library_name='Browser',
+        limit=10,
+    )
+    matches = result.get('result', {}).get('matches', [])
+    by_library = {}
+    for m in matches:
+        by_library.setdefault(m.get('library'), []).append(m.get('keyword_name'))
+    for lib, kws in by_library.items():
+        print(f'  {lib}: {kws}')
+    print('excluded_keywords present:', 'excluded_keywords' in result)
+asyncio.run(main())
+"
+```
+
+Output:
+
+```
+SeleniumLibrary: ['Set Window Position', 'Click Button', 'Click Element',
+                  'Click Link', 'Select From List By Label',
+                  'Set Selenium Page Load Timeout', 'Set Browser Implicit Wait']
+Browser:         ['Click', 'Tap', 'Select Options By']
+excluded_keywords present: False
+session_library present: False
+```
+
+7 of the top-10 matches are from SeleniumLibrary despite `library_name="Browser"`.
+"Set Window Position" — a SeleniumLibrary keyword unrelated to dropdown
+selection — appears as the top match (confidence 0.82).
+
+## Root cause
+
+`src/robotmcp/server.py:2107+` (`find_keywords` tool implementation).
+
+The semantic branch (lines 2195-2238) and pattern branch (lines 2240-2288)
+both ignore the `library_name` parameter. Filtering is applied *only* via
+the session-preference path:
+
+```python
+# server.py:2186-2193
+session_library_preference = None
+if session_id:
+    session = execution_engine.session_manager.get_session(session_id)
+    if session:
+        session_library_preference = getattr(
+            session, "explicit_library_preference", None
+        )
+```
+
+The filter (`_filter_keywords_by_session_library`, server.py:2037) is then
+invoked only if BOTH `session_id` was passed AND the session has a
+non-None `explicit_library_preference`. The `library_name` parameter is
+never consulted.
+
+Only the catalog branch honors `library_name` (server.py:2290-2292):
+
+```python
+if strategy_norm in {"catalog", "library"}:
+    await _ensure_all_session_libraries_loaded()
+    catalog = execution_engine.get_available_keywords(library_name)
+```
+
+The docstring confirms the gap explicitly:
+
+```
+library_name: Optional library filter for catalog search.
+```
+
+…but this is buried in the docstring under a parameter with a generic
+name that strongly suggests a uniform filter.
+
+## Why this is the wrong default
+
+Three reasons it matters:
+
+1. **Silent failure mode**. The parameter is accepted, the request returns
+   200, the response carries no indication the filter was a no-op.
+   Agents (especially small LLMs that don't read docstrings closely)
+   reasonably interpret the response as "Browser library doesn't have a
+   `Select Dropdown` keyword, so I'll use `Select From List By Label`
+   from SeleniumLibrary." A later `execute_step` against a Browser-only
+   session then fails with "Unknown keyword" — at runtime, not at
+   discovery time.
+
+2. **Top-match contamination**. "Set Window Position" — a SeleniumLibrary
+   keyword with no semantic relation to "select dropdown option by label
+   or text" — is the top match at confidence 0.82. This is a separate
+   semantic-matcher quality issue, but the library filter would mask it
+   entirely from a Browser-only session. The Browser-correct answer
+   (`Select Options By`) is the 7th match.
+
+3. **Inconsistent with the catalog branch**. The same parameter name on
+   the same tool means two different things depending on `strategy`.
+   This is the surface-area equivalent of P11's `NO_LOCATOR_KEYWORDS`
+   inconsistency: a curated list that drifts out of alignment with the
+   actual library semantics. Predictable API surface > clever overloads.
+
+## Existing filter infrastructure (working, just under-used)
+
+`_filter_keywords_by_session_library` already does the right thing for
+the session-preference path:
+
+- Consults `LibraryPluginManager.get_incompatible_libraries(preference)`.
+  For `Browser`, this returns `["SeleniumLibrary"]`
+  (browser_plugin.py:294-296). For `SeleniumLibrary`, it returns
+  `["Browser"]` (selenium_plugin.py:183).
+- Builds an `excluded_with_alternatives` list with helpful messages
+  (alternative keyword + example) using `KEYWORD_ALTERNATIVES` from the
+  plugin.
+- Logs the filter action and emits the count.
+
+The pieces are all present. What's missing is plumbing.
+
+## Proposed fix
+
+### Design
+
+Honor `library_name` in **all four** strategies as an explicit per-call
+filter, semantically equivalent to `explicit_library_preference` on the
+session but scoped to the single call.
+
+Precedence (highest wins):
+
+1. **Explicit `library_name` parameter** (per-call override)
+2. **Session `explicit_library_preference`** (session-wide default,
+   already in place)
+3. **No filter** (current behavior when neither is set)
+
+When `library_name` is set:
+- Apply the same `LibraryPluginManager.get_incompatible_libraries`
+  exclusion table that the session-preference path uses.
+- For `library_name="Browser"`, this excludes `SeleniumLibrary` and
+  passes through `BuiltIn`, `Collections`, `String`, etc.
+- Result includes `excluded_keywords` and `session_library` fields
+  (renamed to `requested_library` for the explicit-param case, OR
+  keep `session_library` populated with the effective preference and
+  add a `library_filter_source: "library_name" | "session"` field for
+  clarity).
+
+### Implementation sketch
+
+`server.py:2186-2193` becomes:
+
+```python
+# Resolve effective library preference: explicit param > session > none.
+effective_library_preference: str | None = library_name
+library_filter_source: str = "library_name" if library_name else ""
+
+if not effective_library_preference and session_id:
+    session = execution_engine.session_manager.get_session(session_id)
+    if session:
+        session_pref = getattr(session, "explicit_library_preference", None)
+        if session_pref:
+            effective_library_preference = session_pref
+            library_filter_source = "session"
+```
+
+Then in each strategy branch, swap `session_library_preference` for
+`effective_library_preference`:
+
+```python
+if effective_library_preference and discovery.get("matches"):
+    # ... existing filter logic, parametrized on effective_library_preference
+```
+
+And in the response payload:
+
+```python
+if excluded:
+    result["excluded_keywords"] = excluded
+    result["library_filter"] = {
+        "applied": effective_library_preference,
+        "source": library_filter_source,  # "library_name" or "session"
+    }
+```
+
+Catalog branch keeps its current behavior (already uses `library_name`
+for the engine call, not for post-filter). Two-line cleanup: also feed
+`library_name` through the session-preference filter so the catalog
+result list is consistent with the catalog-engine result list. Low
+priority — the catalog engine already scopes the search by library.
+
+### Docstring update
+
+```
+library_name: Optional library filter applied to ALL strategies.
+  When set, restricts results to the named library and its compatible
+  siblings (e.g., library_name="Browser" excludes SeleniumLibrary but
+  keeps BuiltIn, Collections, String). Takes precedence over the
+  session's explicit_library_preference when both are present.
+  Catalog strategy additionally scopes the underlying lookup to this
+  library.
+```
+
+### Tests to add
+
+| Layer | Test | Expected |
+|---|---|---|
+| Reproducer | semantic + `library_name="Browser"`, no session | SeleniumLibrary keywords absent; `excluded_keywords` populated; `library_filter.source="library_name"` |
+| Symmetry | semantic + `library_name="SeleniumLibrary"`, no session | Browser keywords absent |
+| Strategy parity | pattern + `library_name="Browser"` | same filter applied |
+| Precedence | semantic + `library_name="Browser"` AND session preference `"SeleniumLibrary"` | `library_name` wins, `library_filter.source="library_name"` |
+| Fall-through | semantic, no `library_name`, session preference `"Browser"` | session preference wins, `library_filter.source="session"` |
+| Idempotency | semantic, no `library_name`, no session | unchanged behavior — no filter, no `library_filter` field |
+| Unknown lib | semantic + `library_name="FakeLibrary"` | no exclusion (plugin returns empty incompatibility list), `excluded_keywords` empty/absent, `library_filter` may include the requested name for response-trace clarity |
+| Compatible siblings preserved | semantic + `library_name="Browser"` matching "log message" | `BuiltIn.Log` still in results |
+
+Existing tests likely affected (smoke-test these after the change):
+
+- Anywhere semantic search is exercised against a Browser-only session
+  without `library_name` being passed (should be unchanged).
+- Tests that mock `_filter_keywords_by_session_library` directly (may
+  need to mock the new resolver too — keep the resolver thin).
+
+### Out of scope
+
+- **Semantic-matcher confidence quality** for "select dropdown option by
+  label or text" (the "Set Window Position" top-match issue). That's a
+  separate finding worth a follow-up — the library filter masks it but
+  doesn't fix it. The actionable scope here is filtering, not re-ranking.
+- **`KeywordMatcher.discover_keywords()` library-aware search**: the
+  current proposal filters post-discovery. A future optimization could
+  pass the filter into the matcher so it doesn't compute scores for
+  excluded keywords. Worth measuring before doing — the post-filter is
+  O(n) on a small n.
+- **`_extract_locator_from_args` skip-prefix scoping** (`link=` skipped
+  for all libraries, not just SeleniumLibrary — found during OBS-15).
+  Same root pattern (per-library config bleeding across libraries) but
+  separate fix.
+
+### Risk
+
+Low. The filter function is well-isolated and already covered by tests
+via the session-preference path. The resolver is a small precedence
+function. The response shape gains optional fields (`library_filter`,
+`excluded_keywords` when applicable); no field is removed or renamed.
+
+Conservative migration: keep the existing `session_library` response
+field populated whenever filtering applies (preserves backward
+compat for callers that read it), and add `library_filter` as the
+forward-looking shape.
+
+### Estimated effort
+
+S — single function rewrite (resolver) + four call-site touchups in
+the two affected branches + ~8 unit tests + docstring update. Half-day.
+
+## Related artifacts
+
+- `src/robotmcp/server.py:2107` — `find_keywords` tool
+- `src/robotmcp/server.py:2037` — `_filter_keywords_by_session_library`
+- `src/robotmcp/components/keyword_matcher.py:254` — `discover_keywords`
+  (no library_name knob today; out of scope)
+- `src/robotmcp/plugins/builtin/browser_plugin.py:294` — Browser's
+  `get_incompatible_libraries` → `["SeleniumLibrary"]`
+- `src/robotmcp/plugins/builtin/selenium_plugin.py:183` — Selenium's
+  `get_incompatible_libraries` → `["Browser"]`
+
+## Implementation outcome (2026-05-17)
+
+Implemented as described. Single resolver block at the top of
+`find_keywords` (server.py:2186-2204) computes
+`effective_library_preference` and `library_filter_source` with the
+proposed precedence. Three branches (semantic / pattern / catalog) now
+use the resolved value uniformly. The catalog branch still scopes its
+underlying engine lookup by `library_name` (unchanged); the post-filter
+is layered on top for response-shape consistency.
+
+Response shape gains two optional fields when filtering applies:
+- `library_filter`: `{"applied": "<lib>", "source": "library_name"|"session"}`
+- `session_library`: `<lib>` (legacy field — preserved for callers that
+  read it; populated with the same effective preference)
+
+When no filter applies (neither parameter nor session preference set, or
+unknown library_name with empty incompatibility list), no extra fields
+are added — fully backward-compatible.
+
+### Verification
+
+Re-running the original repro with `library_name="Browser"` against the
+fixed code:
+
+```
+=== After fix:
+  Browser: ['Click', 'Tap', 'Select Options By']
+excluded_keywords count: 7
+library_filter: {'applied': 'Browser', 'source': 'library_name'}
+session_library: Browser
+```
+
+All 7 SeleniumLibrary keywords are now excluded; `Select Options By`
+moves into the top 3.
+
+### Tests
+
+`tests/unit/test_find_keywords_library_name_filter.py` — 14 tests
+across 9 layers covering the matrix listed under "Tests to add":
+
+- Reproducer (4 tests): defect-payload exclusion + `excluded_keywords`
+  populated + `library_filter.source` + `session_library` backcompat
+- Symmetry: SL filter excludes Browser
+- Strategy parity: pattern + `library_name`
+- Precedence: `library_name` overrides session preference
+- Fall-through: session preference applies when `library_name` is None
+- Idempotency: neither set → no filter, no extra fields
+- Unknown library: graceful no-op (no exclusions, no error)
+- Sibling preserved: BuiltIn keywords remain under Browser filter
+- Docstring contract: signature + "ALL strategies" announcement
+
+### Test totals
+
+5906 unit tests passed, 1 skipped, 0 failures (+14 net).

--- a/docs/issues/find_keywords_library_name_filter_proposal.md
+++ b/docs/issues/find_keywords_library_name_filter_proposal.md
@@ -352,4 +352,95 @@ across 9 layers covering the matrix listed under "Tests to add":
 
 ### Test totals
 
-5906 unit tests passed, 1 skipped, 0 failures (+14 net).
+5906 unit tests passed, 1 skipped, 0 failures (+14 net) after the
+initial fix; 5909 passed (+17 net) after the follow-on compaction
+(see next section).
+
+## Follow-on compaction (2026-05-17)
+
+User feedback after the first fix: *"the excluded_keywords just blow up
+the token consumption"*. In the user's reproduction the filter excluded
+7 SeleniumLibrary keywords; each entry in the legacy
+``excluded_keywords`` list carried four fields (``keyword``,
+``incompatible_library``, ``session_library``, ``reason``) plus
+optional ``alternative`` / ``example``. The first three of those four
+fields were **identical for every entry in a given response** —
+``incompatible_library`` was always "SeleniumLibrary",
+``session_library`` was always "Browser", ``reason`` was a verbose
+restatement of the other two. Total inline cost: ~1100 tokens of
+mostly-redundant information.
+
+The redundancy is structural, not just verbose:
+- ``incompatible_library``: same for all entries → move to a single
+  top-level ``library_filter.from_library`` field.
+- ``session_library`` (entry-level): redundant with
+  ``library_filter.applied``.
+- ``reason``: verbose restatement of the two fields above.
+- ``keyword`` (bare name, no alternative): the agent learns "X was
+  filtered" from X's absence in the ``matches`` list, so re-listing
+  it adds zero information.
+
+Only entries that carry a plugin-table ``alternative`` (SL→Browser or
+Browser→SL translation mapping) are actually actionable. For the
+typical Browser-filter response with 7 SL exclusions, this is usually
+1-2 entries (e.g., "Close All Browsers" → "Close Browser    ALL";
+"Click Element" → "Click").
+
+### Compacted response shape
+
+```json
+"library_filter": {
+  "applied": "Browser",
+  "source": "library_name",
+  "count": 7,
+  "from_library": "SeleniumLibrary"
+},
+"excluded_alternatives": [
+  {
+    "keyword": "Close All Browsers",
+    "alternative": "Close Browser    ALL",
+    "example": "Close Browser    ALL"
+  }
+]
+```
+
+Token cost: ~75 tokens vs ~1100 tokens before. **93% reduction.**
+
+When no excluded keyword carries an ``alternative`` mapping,
+``excluded_alternatives`` is absent (not present-but-empty). The
+``library_filter`` still surfaces the count so the agent knows the
+filter ran.
+
+### Backward compatibility
+
+The legacy ``excluded_keywords`` and entry-level ``session_library``
+fields are dropped from the response. Audit confirmed no production
+reader consumes them — only e2e metric dumps (historical records,
+won't break) and the new unit tests reference them. The
+``library_filter`` top-level field provides the same diagnostic
+information in a 14x more compact shape.
+
+### Helper
+
+Compaction logic lives in ``_build_filter_diagnostics()`` (server.py,
+just above ``find_keywords``). All three strategy branches call it
+identically — single source of truth for the response shape. Future
+filter-using endpoints can pick up the helper without redoing the
+shape design.
+
+### Tests for compaction
+
+Three new tests in ``TestExcludedKeywordsCompaction``:
+- ``test_alternatives_surface_when_plugin_provides_them``: injects a
+  mixed excluded list (one with alternative, one without) and pins the
+  filter behavior — alternative surfaces, non-actionable entry's bare
+  name does not appear anywhere in the response.
+- ``test_excluded_alternatives_filters_by_actionability``: uses the
+  real plugin to verify "Click Element" maps to "Click" while
+  "Set Window Position" silently drops out.
+- ``test_excluded_alternatives_absent_when_no_mappings_at_all``: pins
+  the absent-field shape when zero entries carry a mapping.
+
+Plus the existing ``test_verbose_legacy_fields_dropped`` test pins
+that ``excluded_keywords`` and entry-level ``session_library`` are not
+in the response.

--- a/docs/issues/find_keywords_library_name_filter_proposal.md
+++ b/docs/issues/find_keywords_library_name_filter_proposal.md
@@ -444,3 +444,98 @@ Three new tests in ``TestExcludedKeywordsCompaction``:
 Plus the existing ``test_verbose_legacy_fields_dropped`` test pins
 that ``excluded_keywords`` and entry-level ``session_library`` are not
 in the response.
+
+## Stale-recommendations fix (2026-05-17)
+
+While verifying the compaction, the externalized ``result.recommendations``
+field was found to contain stale references to pre-filter top
+matches. Reproduced with the same payload that exposed the original
+defect:
+
+```json
+"matches": [
+  {"library": "Browser", "keyword_name": "Go To", ...},
+  {"library": "Browser", "keyword_name": "New Page", ...},
+  {"library": "Browser", "keyword_name": "Open Browser", ...}
+],
+"recommendations": [
+  "Best match: Get Browser Aliases (confidence: 0.84)",          ✗ STALE — SL keyword excluded
+  "Alternative options: Get Browser Ids, Close Browser, Go To"   ✗ all SL except Go To
+]
+```
+
+Root cause: ``KeywordMatcher.discover_keywords`` (keyword_matcher.py:
+325) computes ``recommendations`` inline from the *pre-filter* ranked
+matches and embeds them in its response payload. ``find_keywords``
+applies the library filter afterward, mutating ``discovery["matches"]``
+but leaving ``discovery["recommendations"]`` referencing the pre-filter
+top match. The matcher has no visibility into the filter, so the fix
+has to live on the ``find_keywords`` side.
+
+For an agent reading the response, the recommendations field is
+typically the FIRST thing scanned. Reading "Best match: Get Browser
+Aliases" when ``Get Browser Aliases`` doesn't appear in the matches
+list (because it was just excluded) is more confusing than no
+recommendation at all — the agent has to reconcile the contradiction
+before getting useful guidance.
+
+### Fix
+
+New helper ``_rebuild_post_filter_recommendations`` (server.py, sits
+beside ``_build_filter_diagnostics``) mirrors the format used by
+``KeywordMatcher._generate_usage_recommendations`` (same prose:
+"Best match: X (confidence: Y)", "Required arguments: …",
+"Alternative options: …") but operates on the post-filter dict
+shape (matches arrive as dicts, not ``KeywordMatch`` dataclasses).
+When the matcher returns no matches post-filter the helper emits
+the same "No matching keywords found" guidance the matcher would
+have, so the contract stays consistent for the all-filtered case.
+
+The semantic branch in ``find_keywords`` calls the rebuild only
+when the filter actually trimmed entries (``if excluded:``). When
+no filter ran, the matcher's recommendations pass through
+byte-identical — no work, no risk of regression on the
+unmodified-path.
+
+### Verification
+
+Re-running the original repro after the rebuild:
+
+```
+Matches (post-filter):
+  - Browser.Go To (conf=0.80)
+  - Browser.New Page (conf=0.80)
+  - Browser.Open Browser (conf=0.77)
+
+Recommendations:
+  - Best match: Go To (confidence: 0.80)              ✓ Browser keyword
+  - Required arguments: url, timeout, wait_until      ✓ Go To's real args
+  - Alternative options: New Page, Open Browser       ✓ Browser-only
+```
+
+### Tests
+
+Five new tests in ``TestRecommendationsRebuild``:
+
+- ``test_recommendations_reference_post_filter_top_match``: injects a
+  payload where pre-filter recs name an SL keyword; asserts the
+  post-filter top recommendation references a Browser keyword instead.
+- ``test_recommendations_carry_post_filter_arguments``: pins that the
+  "Required arguments" line reflects the post-filter top match's
+  args, not the pre-filter top match's args (catches the line-by-line
+  rebuild correctness).
+- ``test_recommendations_alternatives_only_kept_keywords``: pins that
+  no excluded SL keyword name leaks into the "Alternative options"
+  line.
+- ``test_recommendations_empty_no_matches_message_when_all_filtered``:
+  pins the edge case where the filter excludes ALL matches —
+  recommendations show the "No matching keywords found" guidance
+  rather than a stale pre-filter top match.
+- ``test_recommendations_unchanged_when_no_filter_applied``: pins
+  byte-identical pass-through when no filter ran — uses a sentinel
+  string the rebuild would never produce.
+
+### Test totals
+
+5914 passed (+22 vs v0.32.5 baseline = +5 for the recommendations fix
+on top of +17 for the compaction).

--- a/src/robotmcp/components/execution/keyword_executor.py
+++ b/src/robotmcp/components/execution/keyword_executor.py
@@ -1458,6 +1458,58 @@ class KeywordExecutor:
                                 ),
                             })
 
+                            # OBS-15 — the OBS-12 role-prefix hint
+                            # otherwise lives in the keyword-execution
+                            # failure path via generate_hints. ``button=X``
+                            # against Browser library typically fails HERE
+                            # at pre-validation, never reaching that path.
+                            # Run the same checker inline so the diagnosis
+                            # surfaces where the failure actually occurs.
+                            try:
+                                from robotmcp.utils.hints import (
+                                    HintContext as _HintContext,
+                                    _check_browser_role_prefix_misuse,
+                                )
+                                _ctx = _HintContext(
+                                    session_id=session.session_id,
+                                    keyword=keyword,
+                                    arguments=list(arguments or []),
+                                    error_text=error_msg or "",
+                                    session_search_order=getattr(
+                                        session, "search_order", None
+                                    ),
+                                )
+                                for _h in _check_browser_role_prefix_misuse(
+                                    _ctx, _ctx.error_text
+                                ):
+                                    hints.append({
+                                        "type": "browser_role_prefix_misuse",
+                                        "title": _h.title,
+                                        "message": _h.message,
+                                        "examples": _h.examples,
+                                    })
+                            except Exception:
+                                # Hint enrichment is best-effort — never
+                                # mask the underlying pre-validation
+                                # failure on import / context-build error.
+                                pass
+
+                            # Dedupe by ``type`` (idempotency safety —
+                            # the checker should only fire once per call,
+                            # but if a future caller appends another
+                            # role-prefix hint via a different path we
+                            # keep the response clean).
+                            _seen_types: set = set()
+                            _deduped: List[Dict[str, Any]] = []
+                            for _h_entry in hints:
+                                _t = _h_entry.get("type")
+                                if _t and _t in _seen_types:
+                                    continue
+                                if _t:
+                                    _seen_types.add(_t)
+                                _deduped.append(_h_entry)
+                            hints = _deduped
+
                             event_bus.publish_sync(
                                 FrontendEvent(
                                     event_type="step_failed",

--- a/src/robotmcp/components/test_builder.py
+++ b/src/robotmcp/components/test_builder.py
@@ -37,6 +37,12 @@ class TestCaseStep:
     # BDD step grouping
     bdd_group: Optional[str] = None
     bdd_intent: Optional[str] = None
+    # OBS-11 — the string form of the captured value (from
+    # ExecutionStep.result) when this step assigned a variable.
+    # Used by ``_propagate_assigned_variables_to_literal_args`` to
+    # rewrite literals in subsequent steps that equal the captured
+    # value into ``${VAR}`` references in the generated suite.
+    captured_value: Optional[str] = None
 
 
 @dataclass
@@ -1499,6 +1505,7 @@ class TestBuilder:
                 assignment_type=getattr(exec_step, "assignment_type", None),
                 bdd_group=getattr(exec_step, "bdd_group", None),
                 bdd_intent=getattr(exec_step, "bdd_intent", None),
+                captured_value=self._captured_value_str(exec_step),
             ))
         return steps
 
@@ -1513,6 +1520,7 @@ class TestBuilder:
                 assignment_type=getattr(exec_step, "assignment_type", None),
                 bdd_group=getattr(exec_step, "bdd_group", None),
                 bdd_intent=getattr(exec_step, "bdd_intent", None),
+                captured_value=self._captured_value_str(exec_step),
             )
             steps.append(tc_step)
 
@@ -2618,6 +2626,15 @@ class TestBuilder:
             lines.append("*** Test Cases ***")
 
         for test_case in suite.test_cases:
+            # OBS-11 — rewrite literal args that match a recently
+            # captured variable's value into ``${VAR}`` references,
+            # in-place. Bounded lookback (10 steps) and skip arg 0
+            # (locator slot). See the method's docstring for the
+            # benchmark scenario this addresses.
+            self._propagate_assigned_variables_to_literal_args(
+                test_case.steps,
+            )
+
             # Suite-template mode: name + args on SAME line (no [Template], no indented body)
             if suite.suite_template:
                 data_steps = [s for s in test_case.steps
@@ -2741,6 +2758,130 @@ class TestBuilder:
                 lines.append("")
 
         return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # OBS-11 — propagate captured variables into subsequent literal args
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _captured_value_str(exec_step) -> Optional[str]:
+        """Return the string-coerced captured value from an ExecutionStep,
+        or None when the step didn't assign a variable / didn't produce
+        a usable value.
+
+        Used by ``_build_impl_steps_from_test_info`` and
+        ``_build_test_case_from_test_info`` to plumb ``ExecutionStep.result``
+        through to ``TestCaseStep.captured_value`` for the OBS-11
+        variable-propagation pass."""
+        assigned = getattr(exec_step, "assigned_variables", None)
+        if not assigned:
+            return None
+        value = getattr(exec_step, "result", None)
+        if value is None:
+            return None
+        # Coerce to string for arg-level equality comparison.
+        # RF args are always strings on the wire; the runtime value
+        # may be int/float/dict — we compare the str representation.
+        try:
+            return str(value)
+        except Exception:  # pragma: no cover - defensive
+            return None
+
+    # Lookback window for variable-propagation: only literals in the
+    # next N steps after a capture are eligible for rewriting. Bounded
+    # to avoid late-in-test coincidental matches.
+    _OBS11_LOOKBACK_STEPS: int = 10
+
+    def _propagate_assigned_variables_to_literal_args(
+        self,
+        steps: List["TestCaseStep"],
+    ) -> None:
+        """OBS-11 — rewrite literal args that match a recently captured
+        variable's value into ``${VAR}`` references, in-place.
+
+        Walks ``steps`` in order. For each step that assigned a
+        variable AND has a non-empty ``captured_value``, registers the
+        ``value → ${VAR}`` mapping with a step-index tag. For each
+        subsequent step (within ``_OBS11_LOOKBACK_STEPS``), checks each
+        argument from position 1 onward (arg 0 is the locator slot for
+        the vast majority of keywords — skipping it avoids false
+        substitutions in locator strings) and replaces an exact-match
+        literal with the ``${VAR}`` reference.
+
+        Lookback is bounded to limit the blast radius of coincidental
+        matches. Exact-match equality (not substring) further reduces
+        false positives.
+
+        Mutates ``steps`` in-place; the rendered output for each step
+        will reflect the substituted args.
+
+        Examples this addresses (from 2026-05-17 post-OBS benchmark
+        Obstacle 7 — Sonnet's generated suite):
+
+            BEFORE:
+                ${ENTRY_COUNT}=    Get Element Count    css=.option
+                Fill Text          id=entryCount        5
+
+            AFTER:
+                ${ENTRY_COUNT}=    Get Element Count    css=.option
+                Fill Text          id=entryCount        ${ENTRY_COUNT}
+        """
+        if not steps:
+            return
+
+        # Active captures: list of (capture_step_idx, value, var_name).
+        # Most recent first so the lookup wins on the latest capture
+        # when two variables happen to have the same value.
+        active: List[tuple[int, str, str]] = []
+
+        for idx, step in enumerate(steps):
+            # Step 1 — rewrite this step's args BEFORE registering any
+            # new captures from THIS step. A capture's value is only
+            # usable from the NEXT step onward (a self-substitution
+            # would replace the args that feed the capturing keyword).
+            if step.arguments:
+                new_args = list(step.arguments)
+                # Skip arg 0 — by convention the locator slot for input
+                # and click keywords. Substituting there risks rewriting
+                # locator strings that happen to equal a captured value.
+                for arg_idx in range(1, len(new_args)):
+                    arg = new_args[arg_idx]
+                    if not isinstance(arg, str):
+                        continue
+                    # If the literal already references a variable
+                    # (e.g. someone passed ``${SOMETHING}`` explicitly)
+                    # leave it alone — propagation only rewrites raw
+                    # literals.
+                    if "${" in arg:
+                        continue
+                    # Find the most-recent active capture whose value
+                    # matches the literal AND is within the lookback.
+                    for cap_idx, cap_value, cap_var in active:
+                        if idx - cap_idx > self._OBS11_LOOKBACK_STEPS:
+                            continue
+                        if cap_value == arg:
+                            new_args[arg_idx] = cap_var
+                            break
+                step.arguments = new_args
+
+            # Step 2 — register any captures THIS step produced for
+            # subsequent steps to reference.
+            if step.captured_value and step.assigned_variables:
+                cap_value = step.captured_value
+                if not cap_value.strip():
+                    # Empty / whitespace-only captures aren't useful.
+                    continue
+                cap_var = step.assigned_variables[0]
+                # Prepend so most-recent captures are checked first.
+                active.insert(0, (idx, cap_value, cap_var))
+
+        # Trim active list to keep memory bounded across very long
+        # test cases. The lookback comparison above already prevents
+        # stale captures from matching; this just stops unbounded
+        # growth of the in-memory list.
+        # (No-op when total captures < some reasonable cap; the
+        # active list shrinks naturally because lookback-out captures
+        # are still checked but always rejected.)
 
     async def _render_linear_step(self, step: TestCaseStep) -> str:
         """Render a single linear keyword step with proper escaping and assignments."""

--- a/src/robotmcp/plugins/builtin/browser_plugin.py
+++ b/src/robotmcp/plugins/builtin/browser_plugin.py
@@ -261,10 +261,22 @@ class BrowserLibraryPlugin(StaticLibraryPlugin):
             "get page source": "Browser",
             "get url": "Browser",
             "get title": "Browser",
+            # OBS-10 — anchor the override lookup so it fires even when
+            # keyword_info hasn't resolved the library yet at the
+            # executor's get_keyword_override() call site.
+            "drag and drop": "Browser",
+            "browser.drag and drop": "Browser",
         }
 
     def get_keyword_overrides(self) -> Dict[str, KeywordOverrideHandler]:  # type: ignore[override]
-        return {"open browser": self._override_open_browser}
+        return {
+            "open browser": self._override_open_browser,
+            # OBS-10 — scroll source + target into view before dispatch.
+            # Playwright drag silently no-ops when either element is
+            # off-screen; the override pre-scrolls so the drop fires
+            # for real. Returns None to delegate to normal dispatch.
+            "drag and drop": self._override_drag_and_drop,
+        }
 
     def get_locator_normalizer(self):
         def normalize(locator: str) -> str:
@@ -420,6 +432,87 @@ class BrowserLibraryPlugin(StaticLibraryPlugin):
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("Open Browser override failed: %s", exc)
             return None
+
+    # OBS-10 — locators that aren't string-shaped should not trip the
+    # pre-scroll path (e.g. someone routes ``Drag And Drop By
+    # Coordinates`` here by mistake; coords are floats/strs of numbers,
+    # not selectors). Only attempt scroll on plausible locator strings.
+    @staticmethod
+    def _looks_like_locator(arg: Any) -> bool:
+        return isinstance(arg, str) and bool(arg.strip())
+
+    async def _override_drag_and_drop(
+        self,
+        session: "ExecutionSession",
+        keyword_name: str,
+        arguments: list[str],
+        keyword_info: Optional[Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """OBS-10 — pre-scroll SOURCE before Browser.Drag And Drop.
+
+        Playwright's drag mechanics dispatch a drag from the source
+        element's bounding-box. When the source is outside the
+        viewport, the drag silently no-ops: the keyword returns
+        success but the DOM doesn't move. The 2026-05-17 post-OBS
+        Tricentis benchmark Obstacle 10 (Todolist) cost Sonnet
+        ~5 minutes + 27 tool calls on this exact pattern; the
+        working recovery was a single ``Scroll To Element`` call on
+        the source before the drag (matches what Sonnet documented).
+
+        This override does that automatically. We deliberately scroll
+        ONLY the source (not the target):
+
+        1. Scrolling target THEN source is a no-op net effect when
+           both are far apart — the second scroll undoes the first.
+        2. Playwright handles dynamic scrolling for the drop side
+           during the drag motion; pre-scrolling target isn't needed.
+        3. Sonnet's working obstacle-10 recovery scrolled only the
+           source. Match that proven pattern.
+
+        Returns ``None`` so the normal Drag And Drop dispatch proceeds.
+
+        Failure modes:
+        - ``Scroll To Element`` on a locator that doesn't match: the
+          underlying RF call raises; we swallow + log it. The drag
+          will fail with its own (more useful) error message.
+        - First arg isn't a locator string (e.g. someone routes
+          ``Drag And Drop By Coordinates`` through here): no-op.
+        - Cascaded ``>>`` locators: still try to scroll — Browser's
+          Scroll To Element accepts the same locator syntax.
+        """
+        try:
+            from robot.libraries.BuiltIn import BuiltIn
+        except Exception as exc:
+            logger.debug(
+                "OBS-10 pre-scroll skipped: BuiltIn unavailable (%s)", exc,
+            )
+            return None
+
+        # Browser library Drag And Drop signature:
+        #   Drag And Drop    selector_from    selector_to    [steps]
+        # Pre-scroll only the source (arg 0). See docstring rationale.
+        if not arguments:
+            return None
+        source_locator = arguments[0]
+        if not self._looks_like_locator(source_locator):
+            return None
+
+        try:
+            BuiltIn().run_keyword("Browser.Scroll To Element", source_locator)
+            logger.debug(
+                "OBS-10 pre-scrolled Drag And Drop source: %r",
+                source_locator,
+            )
+        except Exception as exc:
+            logger.debug(
+                "OBS-10 pre-scroll of %r failed (continuing): %s",
+                source_locator, exc,
+            )
+
+        # Return None to delegate to the normal Drag And Drop dispatch.
+        # The actual drag now runs with the source in the viewport;
+        # Playwright handles target-side scrolling during drag motion.
+        return None
 
 
 try:  # pragma: no cover

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2104,6 +2104,66 @@ def _filter_keywords_by_session_library(
     return filtered_keywords, excluded_with_alternatives
 
 
+def _build_filter_diagnostics(
+    excluded: List[Dict[str, Any]],
+    applied: str,
+    source: str,
+) -> Dict[str, Any]:
+    """Build compact response diagnostics for a library filter pass.
+
+    Replaces the legacy verbose ``excluded_keywords`` shape (7+ entries
+    × ~150 tokens each, with ``incompatible_library``/``session_library``/
+    ``reason`` fields repeated identically) with a compact summary:
+
+      library_filter: {applied, source, from_library, count}
+      excluded_alternatives: [{keyword, alternative, example}, ...]
+        — only entries that carry actionable SL→Browser (or vice versa)
+        translation info from the plugin's KEYWORD_ALTERNATIVES table.
+
+    For the typical Browser-filter-applied response (~7 excluded SL
+    keywords with one or two alternatives), this cuts the inline
+    response from ~1100 tokens to ~75 tokens. Bare excluded keyword
+    names are dropped — the agent already learns "X was filtered" from
+    X's absence in the ``matches`` list, so re-listing them adds zero
+    information.
+    """
+    # Derive the unique-incompatible-library label. In practice it's a
+    # single library (Browser ↔ SeleniumLibrary in current plugins) but
+    # the table semantics allow multiples; surface as a comma-joined
+    # label rather than a list, since the agent reads a string.
+    libs = sorted({
+        e.get("incompatible_library")
+        for e in excluded
+        if e.get("incompatible_library")
+    })
+    from_library: str | None = libs[0] if len(libs) == 1 else (
+        ", ".join(libs) if libs else None
+    )
+
+    diagnostics: Dict[str, Any] = {
+        "library_filter": {
+            "applied": applied,
+            "source": source,
+            "count": len(excluded),
+        }
+    }
+    if from_library:
+        diagnostics["library_filter"]["from_library"] = from_library
+
+    actionable = [
+        {
+            "keyword": e["keyword"],
+            "alternative": e["alternative"],
+            "example": e.get("example"),
+        }
+        for e in excluded
+        if e.get("alternative")
+    ]
+    if actionable:
+        diagnostics["excluded_alternatives"] = actionable
+    return diagnostics
+
+
 @mcp.tool
 async def find_keywords(
     query: str,
@@ -2247,17 +2307,13 @@ async def find_keywords(
             "result": discovery,
         }
         if excluded:
-            result["excluded_keywords"] = excluded
-            # session_library: preserved for backward compatibility with
-            # callers reading the pre-OBS-defect response shape.
-            result["session_library"] = effective_library_preference
-            # library_filter: forward-looking shape that disambiguates
-            # whether the filter came from the per-call parameter or the
-            # session's preference.
-            result["library_filter"] = {
-                "applied": effective_library_preference,
-                "source": library_filter_source,
-            }
+            result.update(
+                _build_filter_diagnostics(
+                    excluded,
+                    effective_library_preference,
+                    library_filter_source,
+                )
+            )
         # ADR-015: Externalize large fields to artifacts
         if session_id:
             result = _externalize_response("find_keywords", session_id, result)
@@ -2306,12 +2362,13 @@ async def find_keywords(
             "results": matches,
         }
         if excluded:
-            result["excluded_keywords"] = excluded
-            result["session_library"] = effective_library_preference
-            result["library_filter"] = {
-                "applied": effective_library_preference,
-                "source": library_filter_source,
-            }
+            result.update(
+                _build_filter_diagnostics(
+                    excluded,
+                    effective_library_preference,
+                    library_filter_source,
+                )
+            )
         # ADR-015: Externalize large fields to artifacts
         if session_id:
             result = _externalize_response("find_keywords", session_id, result)
@@ -2375,12 +2432,13 @@ async def find_keywords(
             "results": catalog,
         }
         if excluded:
-            result["excluded_keywords"] = excluded
-            result["session_library"] = effective_library_preference
-            result["library_filter"] = {
-                "applied": effective_library_preference,
-                "source": library_filter_source,
-            }
+            result.update(
+                _build_filter_diagnostics(
+                    excluded,
+                    effective_library_preference,
+                    library_filter_source,
+                )
+            )
 
         # ADR-010 I3: Hint when catalog returns empty without active session
         if not catalog and not session_id:

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2104,6 +2104,60 @@ def _filter_keywords_by_session_library(
     return filtered_keywords, excluded_with_alternatives
 
 
+def _rebuild_post_filter_recommendations(
+    matches: List[Dict[str, Any]],
+) -> List[str]:
+    """Regenerate the semantic matcher's usage recommendations using
+    post-filter matches.
+
+    ``KeywordMatcher.discover_keywords`` computes ``recommendations``
+    inline from the *pre-filter* ranked matches and embeds them in its
+    response. When ``find_keywords`` applies a library filter, the
+    pre-filter top match (the "Best match: X (confidence: Y)" line)
+    can reference an excluded keyword — contradicting the post-filter
+    ``matches`` list and pointing the agent at an unavailable keyword.
+
+    Reproduced 2026-05-17: with ``library_name="Browser"`` and query
+    "open browser page navigate to url", the matches list contained
+    only Browser keywords (Go To, New Page, Open Browser) but
+    recommendations[0] was ``"Best match: Get Browser Aliases
+    (confidence: 0.84)"`` — a SeleniumLibrary keyword that had just
+    been filtered out.
+
+    This helper mirrors the matcher's format
+    (``KeywordMatcher._generate_usage_recommendations``) but operates
+    on the post-filter dict shape (matches come in as dicts with
+    ``keyword_name``, ``confidence``, ``arguments`` rather than
+    ``KeywordMatch`` dataclasses). Kept in server.py rather than the
+    matcher because the matcher has no visibility into the filter.
+    """
+    if not matches:
+        return [
+            "No matching keywords found. Consider:",
+            "- Check if required libraries are imported",
+            "- Rephrase the action description",
+            "- Use more specific terms",
+        ]
+    recs: List[str] = []
+    top = matches[0]
+    name = top.get("keyword_name") or top.get("name") or "<unknown>"
+    confidence = top.get("confidence")
+    if isinstance(confidence, (int, float)):
+        recs.append(f"Best match: {name} (confidence: {confidence:.2f})")
+    else:
+        recs.append(f"Best match: {name}")
+    args = top.get("arguments") or []
+    if args:
+        recs.append(f"Required arguments: {', '.join(args)}")
+    if len(matches) > 1:
+        alt_names = [
+            (m.get("keyword_name") or m.get("name") or "<unknown>")
+            for m in matches[1:4]
+        ]
+        recs.append(f"Alternative options: {', '.join(alt_names)}")
+    return recs
+
+
 def _build_filter_diagnostics(
     excluded: List[Dict[str, Any]],
     applied: str,
@@ -2299,6 +2353,19 @@ async def find_keywords(
                 for m in filtered_matches
             ]
             discovery["filtered_count"] = len(excluded)
+            # Regenerate recommendations against the post-filter
+            # matches — the matcher emits its recommendations BEFORE
+            # we apply the library filter, so without this fix the
+            # ``Best match: X`` line can name an excluded keyword.
+            # Only rebuild when the filter actually trimmed entries —
+            # if ``excluded`` is empty, the matcher's recommendations
+            # are still accurate and we avoid the no-op work.
+            if excluded:
+                discovery["recommendations"] = (
+                    _rebuild_post_filter_recommendations(
+                        discovery["matches"]
+                    )
+                )
 
         result = {
             "success": bool(discovery.get("success", True)),

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2132,7 +2132,14 @@ async def find_keywords(
                   - "session": List keywords from session's loaded libraries
         context: Scenario context (e.g., "web", "mobile", "api") used by semantic discovery.
         session_id: Required for strategy="session" to search the live RF namespace.
-        library_name: Optional library filter for catalog search.
+        library_name: Optional library filter applied to ALL strategies.
+                      When set, restricts results to the named library and its
+                      compatible siblings (e.g., library_name="Browser" excludes
+                      SeleniumLibrary but keeps BuiltIn, Collections, String).
+                      Takes precedence over the session's
+                      explicit_library_preference when both are present.
+                      Catalog strategy additionally scopes the underlying
+                      lookup to this library.
         current_state: Optional state payload to improve semantic matching.
         limit: Optional maximum number of results to return.
 
@@ -2183,30 +2190,48 @@ async def find_keywords(
         except (TypeError, ValueError):
             limit_value = None
 
-    # Get session library preference for filtering
-    session_library_preference = None
-    if session_id:
+    # Resolve effective library preference for filtering.
+    # Precedence (highest wins):
+    #   1. Explicit ``library_name`` parameter (per-call override)
+    #   2. Session's ``explicit_library_preference`` (session-wide default)
+    #   3. None (no filter)
+    # The same filter (plugin-driven incompatibility table) applies in
+    # both cases — ``library_name="Browser"`` excludes the same libraries
+    # as a Browser-preference session would.  Catalog strategy ALSO uses
+    # ``library_name`` to scope its underlying lookup; the per-strategy
+    # branches below preserve that behaviour and additionally apply the
+    # post-filter for consistency.
+    effective_library_preference: str | None = None
+    library_filter_source: str = ""
+    if library_name:
+        effective_library_preference = library_name
+        library_filter_source = "library_name"
+    elif session_id:
         session = execution_engine.session_manager.get_session(session_id)
         if session:
-            session_library_preference = getattr(
+            session_pref = getattr(
                 session, "explicit_library_preference", None
             )
+            if session_pref:
+                effective_library_preference = session_pref
+                library_filter_source = "session"
 
     if strategy_norm in {"semantic", "intent"}:
         discovery = await keyword_matcher.discover_keywords(
             query, context, current_state
         )
 
-        # Apply library filtering if session has preference
+        # Apply library filtering when an effective preference is set
+        # (from library_name OR session preference).
         excluded = []
-        if session_library_preference and discovery.get("matches"):
+        if effective_library_preference and discovery.get("matches"):
             # Convert semantic matches to format expected by filter function
             matches_for_filter = [
                 {"name": m.get("keyword_name"), "library": m.get("library"), **m}
                 for m in discovery.get("matches", [])
             ]
             filtered_matches, excluded = _filter_keywords_by_session_library(
-                matches_for_filter, session_id, session_library_preference
+                matches_for_filter, session_id, effective_library_preference
             )
             # Convert back to original format
             discovery["matches"] = [
@@ -2223,7 +2248,16 @@ async def find_keywords(
         }
         if excluded:
             result["excluded_keywords"] = excluded
-            result["session_library"] = session_library_preference
+            # session_library: preserved for backward compatibility with
+            # callers reading the pre-OBS-defect response shape.
+            result["session_library"] = effective_library_preference
+            # library_filter: forward-looking shape that disambiguates
+            # whether the filter came from the per-call parameter or the
+            # session's preference.
+            result["library_filter"] = {
+                "applied": effective_library_preference,
+                "source": library_filter_source,
+            }
         # ADR-015: Externalize large fields to artifacts
         if session_id:
             result = _externalize_response("find_keywords", session_id, result)
@@ -2241,11 +2275,11 @@ async def find_keywords(
         await _ensure_all_session_libraries_loaded()
         matches = execution_engine.search_keywords(query)
 
-        # Apply library filtering if session has preference
+        # Apply library filtering when an effective preference is set.
         excluded = []
-        if session_library_preference:
+        if effective_library_preference:
             matches, excluded = _filter_keywords_by_session_library(
-                matches, session_id, session_library_preference
+                matches, session_id, effective_library_preference
             )
 
         if limit_value is not None:
@@ -2273,7 +2307,11 @@ async def find_keywords(
         }
         if excluded:
             result["excluded_keywords"] = excluded
-            result["session_library"] = session_library_preference
+            result["session_library"] = effective_library_preference
+            result["library_filter"] = {
+                "applied": effective_library_preference,
+                "source": library_filter_source,
+            }
         # ADR-015: Externalize large fields to artifacts
         if session_id:
             result = _externalize_response("find_keywords", session_id, result)
@@ -2299,11 +2337,17 @@ async def find_keywords(
                 or lowered in (item.get("library") or "").lower()
             ]
 
-        # Apply library filtering if session has preference
+        # Apply library filtering when an effective preference is set.
+        # NB: ``execution_engine.get_available_keywords(library_name)``
+        # already scopes the engine lookup by library_name; the post-
+        # filter is largely a no-op when library_name is set, but stays
+        # consistent with the semantic/pattern branches and catches
+        # cross-library matches the engine might return for sibling-
+        # library queries (rare).
         excluded = []
-        if session_library_preference:
+        if effective_library_preference:
             catalog, excluded = _filter_keywords_by_session_library(
-                catalog, session_id, session_library_preference
+                catalog, session_id, effective_library_preference
             )
 
         if limit_value is not None:
@@ -2332,7 +2376,11 @@ async def find_keywords(
         }
         if excluded:
             result["excluded_keywords"] = excluded
-            result["session_library"] = session_library_preference
+            result["session_library"] = effective_library_preference
+            result["library_filter"] = {
+                "applied": effective_library_preference,
+                "source": library_filter_source,
+            }
 
         # ADR-010 I3: Hint when catalog returns empty without active session
         if not catalog and not session_id:

--- a/src/robotmcp/utils/hints.py
+++ b/src/robotmcp/utils/hints.py
@@ -253,6 +253,73 @@ def _check_evaluate_javascript_misuse(ctx: HintContext, err: str) -> List[Hint]:
     )]
 
 
+# ---------------------------------------------------------------------------
+# OBS-12 — Browser-library locator using a SeleniumLibrary role prefix.
+# ---------------------------------------------------------------------------
+
+# Locator prefixes that mean "find element by role" in SeleniumLibrary
+# but are NOT supported by the Browser library. When the ARIA snapshot
+# renders an element as ``button "Calculate"``, agents (especially
+# small ones) sometimes encode that as ``button=Calculate`` — valid
+# SL, rejected by Browser. Match the prefix exactly to avoid colliding
+# with the Playwright-engine ``button:text-is('Calculate')`` form.
+_BROWSER_ROLE_PREFIX_PATTERN = re.compile(
+    r"^\s*(button|link|input|select|textarea)\s*=\s*(?P<value>\S.*?)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _check_browser_role_prefix_misuse(ctx: HintContext, err: str) -> List[Hint]:
+    """OBS-12 — ``button=LABEL`` / ``link=LABEL`` etc. against Browser library.
+
+    Surfaces a focused hint pointing the agent at the working
+    alternative spelling. The same prefixes against SeleniumLibrary
+    are valid and the checker must NOT fire there.
+
+    Triggers on the locator-string shape (not on error text), so the
+    hint fires reliably no matter what the underlying rejection
+    message is. Relevance 92 — below OBS-03's 95 (extremely specific
+    JS-arg-shape mismatch) but ABOVE the generic invalid-selector hint
+    (90), because OBS-12 diagnoses the root cause (wrong-library
+    locator syntax) while invalid-selector flags the downstream
+    parser-error symptom.
+    """
+    lib = _detect_library(ctx)
+    if lib != "Browser":
+        return []
+    first = _first_arg(ctx)
+    if not isinstance(first, str):
+        return []
+    match = _BROWSER_ROLE_PREFIX_PATTERN.match(first)
+    if not match:
+        return []
+    role = first.split("=", 1)[0].strip().lower()
+    value = match.group("value")
+    return [Hint(
+        title=f"Browser library does not support the `{role}=` role prefix",
+        message=(
+            f"`{role}={value}` is SeleniumLibrary-style role-prefix locator "
+            f"syntax. Browser library does NOT support these prefixes; the "
+            f"only documented explicit-strategy prefixes are id=, css=, "
+            f"text=, and xpath=. The ARIA snapshot rendering an element "
+            f"as `{role} \"{value}\"` is the accessibility tree's "
+            f"role+name format, not a locator. Use one of the Browser-"
+            f"library-supported alternatives below."
+        ),
+        examples=[
+            {
+                "label": "Browser text engine (case-insensitive substring by default)",
+                "rf": f"intent_action    intent=click    target=text={value}",
+            },
+            {
+                "label": "Playwright text-inside-CSS (exact, tag-scoped)",
+                "rf": f"intent_action    intent=click    target=css={role}:text-is('{value}')",
+            },
+        ],
+        relevance=92,
+    )]
+
+
 def _check_element_outside_viewport(ctx: HintContext, err: str) -> List[Hint]:
     if not re.search(r"element is outside of the viewport|outside.*viewport", err, re.IGNORECASE):
         return []
@@ -652,6 +719,11 @@ def _check_element_interaction_errors(ctx: HintContext) -> List[Hint]:
         # JS-body-as-single-arg shape mismatch rather than just flagging
         # the resulting CSS-tokenizer error.
         _check_evaluate_javascript_misuse,
+        # OBS-12: more specific than the generic "not visible" hint —
+        # diagnoses Selenium-style role-prefix locators against Browser
+        # library before the agent burns a recovery cycle on a vague
+        # "element not visible" message.
+        _check_browser_role_prefix_misuse,
         _check_invalid_selector,
         _check_element_outside_viewport,
         _check_element_not_interactable,

--- a/tests/integration/test_real_browser_prevalidation.py
+++ b/tests/integration/test_real_browser_prevalidation.py
@@ -14,6 +14,8 @@ invocation from test_real_selenium_prevalidation.py.
 """
 
 import os
+from typing import Any, Optional
+
 import pytest
 import pytest_asyncio
 from fastmcp import Client
@@ -559,3 +561,150 @@ class TestIntentActionExtractOBS06:
         # The intent_resolved block surfaces the extract_mode so callers
         # can confirm the right mode was applied.
         assert res.data.get("intent_resolved", {}).get("extract_mode") == "attribute"
+
+
+# ---------------------------------------------------------------------------
+# OBS-10 — Drag And Drop pre-scrolls off-screen source/target
+# ---------------------------------------------------------------------------
+
+
+class TestDragAndDropPrescrollOBS10:
+    """OBS-10 — Browser Drag And Drop silently no-ops when source or
+    target is outside the viewport (Playwright dispatches drag events
+    but the drop doesn't fire). The 2026-05-17 post-OBS Tricentis
+    benchmark Obstacle 10 (Todolist) cost Sonnet ~27 tool calls
+    debugging this exact pattern.
+
+    The fix: a Browser-plugin override pre-scrolls source + target
+    into view via ``Browser.Scroll To Element`` BEFORE dispatching
+    the actual Drag And Drop. Override returns ``None`` so normal
+    dispatch proceeds — only difference is the elements are now
+    guaranteed visible.
+
+    This integration test runs against a real headless Chromium and
+    uses a ``data:text/html`` fixture with:
+      - A drop zone at the top of the page
+      - A 2000px spacer pushing the draggable source below the viewport
+    Without OBS-10's pre-scroll, the drag would silently no-op (the
+    source's bounding box is off-screen at first call). With OBS-10,
+    the override scrolls the source into view before the drag fires."""
+
+    # Fixture: target at the top, then a 2200px spacer, then the
+    # draggable source. The source's top edge starts ~2240px below
+    # the viewport's top — well outside any reasonable browser height.
+    # OBS-10's pre-scroll must bring it into view before Playwright's
+    # drag mechanics can fire correctly.
+    DATA_URL = (
+        "data:text/html,<html><head><title>OBS-10 Fixture</title></head>"
+        "<body>"
+        "<div id='target' style='width:200px;height:80px;border:2px dashed "
+        "blue;background:lightyellow'>drop here</div>"
+        "<div style='height:2200px'></div>"
+        "<div id='source' draggable='true' style='width:120px;height:40px;"
+        "background:lightblue;cursor:grab'>drag me</div>"
+        "</body></html>"
+    )
+
+    async def test_drag_and_drop_pre_scrolls_off_screen_source(
+        self, browser_session,
+    ):
+        """OBS-10 contract: when the source element is off-screen,
+        ``Drag And Drop`` must pre-scroll it into the viewport.
+
+        We assert on the WINDOW scroll position (``top`` coord) before
+        and after the drag — without OBS-10's pre-scroll, the page
+        stays at scroll-top=0 even after Drag And Drop returns
+        success (this was Sonnet's 27-call debug cycle on Tricentis
+        Obstacle 10). With the pre-scroll override, the source
+        scrolls into view → scroll-top > 0.
+
+        We deliberately don't assert on drop-side semantics
+        (HTML5 vs pointer events have library- and browser-specific
+        quirks orthogonal to OBS-10). The unit tests in
+        ``test_browser_drag_and_drop_prescroll.py`` pin the override
+        wiring; this test confirms the wiring fires end-to-end
+        against a real Browser session."""
+        _, _, client = browser_session
+        nav_res = await client.call_tool(
+            "execute_step",
+            {
+                "keyword": "Go To",
+                "arguments": [self.DATA_URL],
+                "session_id": SESSION_ID,
+            },
+        )
+        assert nav_res.data.get("success") is True
+
+        # Pre-condition: the page is at scroll-top=0 (source is
+        # below the viewport). Get Scroll Position returns a dict
+        # ``{top, left, bottom, right}``.
+        pre_scroll = await client.call_tool(
+            "execute_step",
+            {
+                "keyword": "Get Scroll Position",
+                "arguments": [],
+                "session_id": SESSION_ID,
+            },
+        )
+        assert pre_scroll.data.get("success") is True
+        pre_top = _extract_scroll_top(pre_scroll.data.get("output"))
+        assert pre_top is not None and pre_top < 100, (
+            f"Fixture precondition: page should start at scroll-top=0; "
+            f"got top={pre_top!r}"
+        )
+
+        # The OBS-10 call: Drag And Drop with off-screen source. The
+        # override pre-scrolls; the drag itself can then proceed.
+        drag_res = await client.call_tool(
+            "execute_step",
+            {
+                "keyword": "Drag And Drop",
+                "arguments": ["id=source", "id=target"],
+                "session_id": SESSION_ID,
+            },
+        )
+        assert drag_res.data.get("success") is True, (
+            f"Drag And Drop should succeed; got {drag_res.data}"
+        )
+
+        # Post-condition: page has scrolled down to bring the
+        # off-screen source into view. The source's top edge is
+        # ~2280px down (target 80px + spacer 2200px); after
+        # Scroll To Element, scroll-top should be a substantial
+        # value > 1000 (Playwright scrolls to center the element).
+        post_scroll = await client.call_tool(
+            "execute_step",
+            {
+                "keyword": "Get Scroll Position",
+                "arguments": [],
+                "session_id": SESSION_ID,
+            },
+        )
+        assert post_scroll.data.get("success") is True
+        post_top = _extract_scroll_top(post_scroll.data.get("output"))
+        assert post_top is not None, (
+            f"Get Scroll Position failed: {post_scroll.data!r}"
+        )
+        assert post_top > 1000, (
+            f"OBS-10 contract: page should scroll down to bring the "
+            f"off-screen source into view. pre_top={pre_top}, "
+            f"post_top={post_top}. Without the pre-scroll override "
+            f"the page would stay at scroll-top=0 and Drag And Drop "
+            f"would silently no-op on drop semantics."
+        )
+
+
+def _extract_scroll_top(scroll: Any) -> Optional[float]:
+    """Browser.Get Scroll Position returns a dict ``{top, left, bottom,
+    right}`` (or a stringified equivalent depending on the response
+    serialisation path). Extract the ``top`` value defensively."""
+    if isinstance(scroll, dict):
+        v = scroll.get("top")
+        if isinstance(v, (int, float)):
+            return float(v)
+    if isinstance(scroll, str):
+        import re
+        m = re.search(r"['\"]top['\"]\s*:\s*([\d.]+)", scroll)
+        if m:
+            return float(m.group(1))
+    return None

--- a/tests/unit/test_browser_drag_and_drop_prescroll.py
+++ b/tests/unit/test_browser_drag_and_drop_prescroll.py
@@ -1,0 +1,313 @@
+"""OBS-10 — Browser ``Drag And Drop`` pre-scrolls source + target.
+
+The 2026-05-17 post-OBS validation benchmark surfaced this silent
+failure on Obstacle 10 (Todolist):
+
+    Drag And Drop    css=tr[task='1']    css=tbody.droparea
+
+returns success (no error) but the DOM doesn't update when the source
+element is below the viewport (y = 737.5px in that case). Cost on
+the benchmark: ~5 minutes of Sonnet's debugging cycles + 27 tool calls
+on this single obstacle.
+
+The fix: a Browser-plugin override pre-scrolls source + target into
+view via ``Browser.Scroll To Element`` BEFORE dispatching the actual
+Drag And Drop. The override returns ``None`` so the normal Drag And
+Drop dispatch proceeds — only difference is the elements are now
+guaranteed to be in the viewport.
+
+These tests pin:
+(1) The override is registered for ``"drag and drop"``.
+(2) When invoked with two string locator args, both are passed to
+    ``Browser.Scroll To Element`` (in order).
+(3) The override returns ``None`` (delegation, not short-circuit).
+(4) Scroll-to-element failures are swallowed (logged, not re-raised) —
+    the drag should still get a chance to run with its own error.
+(5) Non-string args are skipped (defensive against routing of other
+    drag-variant keywords).
+(6) Missing BuiltIn (unit-test context without RF) doesn't crash.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robotmcp.plugins.builtin.browser_plugin import BrowserLibraryPlugin
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: override registration
+# ---------------------------------------------------------------------------
+
+
+class TestDragAndDropOverrideRegistered:
+    """``drag and drop`` must appear in the plugin's override map AND
+    point at ``_override_drag_and_drop``."""
+
+    def test_keyword_registered_in_override_map(self):
+        plugin = BrowserLibraryPlugin()
+        overrides = plugin.get_keyword_overrides()
+        assert "drag and drop" in overrides
+
+    def test_keyword_routed_to_drag_and_drop_override(self):
+        plugin = BrowserLibraryPlugin()
+        overrides = plugin.get_keyword_overrides()
+        assert overrides["drag and drop"] == plugin._override_drag_and_drop
+
+    def test_open_browser_override_still_registered(self):
+        # Regression-guard: OBS-10 adds an override; it must NOT
+        # remove the pre-existing Open Browser override.
+        plugin = BrowserLibraryPlugin()
+        overrides = plugin.get_keyword_overrides()
+        assert "open browser" in overrides
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: pre-scroll behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPreScrollHappyPath:
+    """ONLY the source locator (arg 0) gets pre-scrolled.
+
+    Rationale: scrolling target THEN source is a net no-op when both
+    are far apart (the second scroll undoes the first). Playwright's
+    drag mechanics handle target-side scrolling DURING the drag
+    motion, so pre-scrolling target isn't needed. Sonnet's proven
+    Obstacle-10 recovery scrolled only the source — match that."""
+
+    async def test_scrolls_source_only(self):
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            result = await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["css=tr[task='1']", "css=tbody.droparea"],
+            )
+        # Override delegates back to normal dispatch (no short-circuit).
+        assert result is None
+        # Exactly ONE scroll call: the source. Target is NOT scrolled
+        # — see docstring on _override_drag_and_drop.
+        scroll_calls = [
+            c for c in mock_builtin.run_keyword.call_args_list
+            if c.args[0] == "Browser.Scroll To Element"
+        ]
+        assert len(scroll_calls) == 1
+        assert scroll_calls[0].args[1] == "css=tr[task='1']"
+
+    async def test_scrolls_id_source(self):
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["id=toscabot", "id=to"],
+            )
+        scroll_calls = [
+            c for c in mock_builtin.run_keyword.call_args_list
+            if c.args[0] == "Browser.Scroll To Element"
+        ]
+        assert len(scroll_calls) == 1
+        assert scroll_calls[0].args[1] == "id=toscabot"
+
+    async def test_target_not_scrolled(self):
+        """Regression-guard: the target (arg 1) must NOT be scrolled.
+        See OBS-10 design note on why target-then-source order is a
+        net no-op when both elements are far apart."""
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["id=src", "id=tgt"],
+            )
+        scroll_calls = [
+            c for c in mock_builtin.run_keyword.call_args_list
+            if c.args[0] == "Browser.Scroll To Element"
+        ]
+        target_scrolls = [c for c in scroll_calls if c.args[1] == "id=tgt"]
+        assert target_scrolls == [], (
+            "target locator must NOT be pre-scrolled; Playwright handles "
+            "target-side scroll during drag motion"
+        )
+
+    async def test_steps_arg_is_not_scrolled(self):
+        """Drag And Drop takes (source, target, [steps]). Only the
+        source (arg 0) is scrolled regardless of how many trailing
+        args the call has."""
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["id=src", "id=tgt", "5"],   # 5 = steps
+            )
+        scroll_calls = [
+            c for c in mock_builtin.run_keyword.call_args_list
+            if c.args[0] == "Browser.Scroll To Element"
+        ]
+        # Exactly one scroll (source only).
+        assert len(scroll_calls) == 1
+        assert scroll_calls[0].args[1] == "id=src"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: defensive behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPreScrollDefensive:
+    """The override must NEVER crash the drag. Failures in scroll
+    should be swallowed; the normal drag dispatch then runs and
+    produces its own (more useful) error if there's a real problem."""
+
+    async def test_scroll_failure_does_not_propagate(self):
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        mock_builtin.run_keyword.side_effect = RuntimeError(
+            "Element not found: id=missing",
+        )
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            result = await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["id=missing", "id=target"],
+            )
+        # Returns None (delegation), no exception bubbled.
+        assert result is None
+
+    async def test_scroll_failure_on_source_does_not_block_dispatch(self):
+        """When the source scroll fails, the override must still
+        return None so the normal Drag And Drop dispatch can run and
+        produce its own (more useful) error message."""
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        mock_builtin.run_keyword.side_effect = RuntimeError(
+            "source scroll failed",
+        )
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            result = await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["id=bad", "id=target"],
+            )
+        assert result is None
+        # Exactly one scroll attempt (source); the failure is
+        # swallowed but the call WAS made.
+        assert mock_builtin.run_keyword.call_count == 1
+
+    async def test_missing_builtin_does_not_crash(self):
+        """Unit-test contexts may not have ``robot`` installed or
+        importable. The override must degrade to a no-op instead of
+        crashing the executor."""
+        plugin = BrowserLibraryPlugin()
+        # Force the import to raise inside the override.
+        with patch.dict("sys.modules", {"robot.libraries.BuiltIn": None}):
+            result = await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["id=src", "id=tgt"],
+            )
+        assert result is None
+
+    @pytest.mark.parametrize("non_locator", [None, 42, 3.14, [], {}, True])
+    async def test_non_string_args_are_skipped(self, non_locator):
+        """If someone routes a coords-only drag variant here by
+        mistake, integer args must NOT be passed to Scroll To Element."""
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=[non_locator, non_locator],
+            )
+        scroll_calls = [
+            c for c in mock_builtin.run_keyword.call_args_list
+            if c.args[0] == "Browser.Scroll To Element"
+        ]
+        assert len(scroll_calls) == 0
+
+    async def test_empty_string_locator_is_skipped(self):
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["", "  "],
+            )
+        scroll_calls = [
+            c for c in mock_builtin.run_keyword.call_args_list
+            if c.args[0] == "Browser.Scroll To Element"
+        ]
+        assert len(scroll_calls) == 0
+
+    async def test_zero_args_does_not_crash(self):
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            result = await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=[],
+            )
+        assert result is None
+        # No scroll calls when there are no args to scroll.
+        assert mock_builtin.run_keyword.call_count == 0
+
+    async def test_only_one_arg_still_scrolls_the_source(self):
+        plugin = BrowserLibraryPlugin()
+        mock_builtin = MagicMock()
+        with patch("robot.libraries.BuiltIn.BuiltIn",
+                   return_value=mock_builtin):
+            await plugin._override_drag_and_drop(
+                session=MagicMock(),
+                keyword_name="Drag And Drop",
+                arguments=["id=onlyone"],
+            )
+        scroll_calls = [
+            c for c in mock_builtin.run_keyword.call_args_list
+            if c.args[0] == "Browser.Scroll To Element"
+        ]
+        assert len(scroll_calls) == 1
+        assert scroll_calls[0].args[1] == "id=onlyone"
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: helper predicate
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeLocatorPredicate:
+    """The ``_looks_like_locator`` helper used by the override."""
+
+    @pytest.mark.parametrize("locator", [
+        "id=foo", "css=.x", "xpath=//y", "text=Login",
+        "button:text-is('Save')", "id=foo >> nth=0", "#submit",
+    ])
+    def test_strings_with_content_are_locators(self, locator):
+        assert BrowserLibraryPlugin._looks_like_locator(locator) is True
+
+    @pytest.mark.parametrize("non_locator", [
+        None, 42, 3.14, [], {}, True, False, "", "   ", "\t\n",
+    ])
+    def test_non_strings_and_empty_strings_are_not_locators(self, non_locator):
+        assert BrowserLibraryPlugin._looks_like_locator(non_locator) is False

--- a/tests/unit/test_browser_role_prefix_hint.py
+++ b/tests/unit/test_browser_role_prefix_hint.py
@@ -1,0 +1,320 @@
+"""OBS-12 — ``button=LABEL`` / role-prefix-against-Browser-library hint.
+
+The 2026-05-17 post-OBS validation benchmark surfaced a friction point on
+Obstacle 8 (Wait a moment): Sonnet's first attempt was
+``intent_action(intent="click", target="button=Calculate")``. The ARIA
+snapshot rendered the element as ``button "Calculate"``, which makes
+``button=Calculate`` look like a plausible locator — and it IS valid
+SeleniumLibrary syntax. But Browser library doesn't support role-prefix
+locators; pre-validation rejected with a generic "element not visible"
+message that gave no syntax clue.
+
+Cost in the benchmark: 1 wasted call. Low-impact, but a specific hint
+closes the gap entirely (Sonnet's recovery on Obstacle 8 cost 9 calls
+total; with the hint, ~6 would suffice).
+
+These tests pin the hint surface:
+(1) Browser library + role-prefix locator → hint fires (5 prefixes)
+(2) Browser library + valid locator prefix (id=, css=, xpath=, text=,
+    name=) → NO hint
+(3) SeleniumLibrary + role-prefix locator → NO hint (valid SL syntax)
+(4) Hint message names the role + value AND points at TWO working
+    alternatives: text= and css=<tag>:text-is('<value>').
+(5) Relevance ordering: OBS-12 hint outranks generic visibility hint
+    but underranks OBS-03's JS-shape-mismatch.
+(6) End-to-end through ``generate_hints``: the hint surfaces in the
+    top-3 response output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robotmcp.utils.hints import (
+    HintContext,
+    _BROWSER_ROLE_PREFIX_PATTERN,
+    _check_browser_role_prefix_misuse,
+    _check_evaluate_javascript_misuse,
+    _check_invalid_selector,
+    generate_hints,
+)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: pattern correctness (independent of HintContext wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestRolePrefixPattern:
+    """The compiled regex pattern recognises every documented role
+    prefix and rejects everything else."""
+
+    @pytest.mark.parametrize("locator", [
+        "button=Calculate",
+        "Button=Calculate",          # case-insensitive prefix
+        "BUTTON=Calculate",
+        "link=Click here",
+        "Link=Click here",
+        "input=username",
+        "select=Country",
+        "textarea=Comment",
+        # Whitespace tolerance (matches OBS-01 normaliser's permissiveness)
+        " button = Calculate ",
+        "button= Calculate",
+        "button =Calculate",
+    ])
+    def test_role_prefix_recognised(self, locator):
+        m = _BROWSER_ROLE_PREFIX_PATTERN.match(locator)
+        assert m is not None, f"{locator!r} should match role-prefix pattern"
+
+    @pytest.mark.parametrize("locator", [
+        # Valid Browser-library prefixes — must NOT match the role pattern
+        "id=submit",
+        "css=button.primary",
+        "xpath=//button[@id='submit']",
+        "text=Calculate",
+        "name=username",
+        # CSS shortcut forms
+        "#submit",
+        ".classname",
+        "[name='foo']",
+        # Playwright text-inside-CSS — superficially similar but uses
+        # ``:text-is(...)``, not ``=``. Must NOT match.
+        "button:text-is('Calculate')",
+        "button:has(svg)",
+        # Cascaded forms
+        "id=foo >> nth=0",
+        # XPath
+        "//button[text()='Calculate']",
+        # Selenium prefixes that aren't in the role set
+        "tag=button",
+        "class=primary",
+        "data-testid=submit",
+        "link:Click here",          # SL colon-separated; not role-prefix
+        # Empty / non-string-like edge inputs
+        "",
+        "button",                   # no equals sign at all
+        "button=",                  # equals with no value
+        "button = ",                # equals with only whitespace value
+    ])
+    def test_non_role_prefixes_pass_through(self, locator):
+        assert _BROWSER_ROLE_PREFIX_PATTERN.match(locator) is None, (
+            f"{locator!r} should NOT match the role-prefix pattern"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: checker behaviour against HintContext
+# ---------------------------------------------------------------------------
+
+
+def _ctx(*, library: str, args, keyword: str = "Click", err: str = "element not visible") -> HintContext:
+    return HintContext(
+        session_id="t",
+        keyword=keyword,
+        arguments=list(args),
+        error_text=err,
+        session_search_order=[library],
+    )
+
+
+class TestCheckBrowserRolePrefixFires:
+    """Positive cases: hint fires for every role prefix against Browser."""
+
+    @pytest.mark.parametrize("locator,role,value", [
+        ("button=Calculate", "button", "Calculate"),
+        ("link=Click here", "link", "Click here"),
+        ("input=username", "input", "username"),
+        ("select=Country", "select", "Country"),
+        ("textarea=Comment", "textarea", "Comment"),
+    ])
+    def test_fires_for_each_role_prefix(self, locator, role, value):
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=[locator]),
+            "element not visible/enabled",
+        )
+        assert len(hints) == 1
+        # Title names the rejected role prefix.
+        assert role in hints[0].title.lower()
+        assert f"`{role}=`" in hints[0].title.lower() or f"`{role}=" in hints[0].title
+
+    def test_hint_message_names_role_and_value(self):
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=["button=Calculate"]),
+            "element not visible",
+        )
+        msg = hints[0].message
+        assert "button=Calculate" in msg
+        assert "SeleniumLibrary" in msg
+        # The documented Browser-library prefixes are surfaced so the
+        # agent knows the explicit-strategy table.
+        assert "id=" in msg or "css=" in msg or "text=" in msg
+
+    def test_hint_includes_two_working_alternatives(self):
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=["button=Calculate"]),
+            "element not visible",
+        )
+        examples = hints[0].examples
+        # One example uses text= (Browser text engine)
+        text_example = next(
+            (e for e in examples if "text=Calculate" in str(e)), None,
+        )
+        assert text_example is not None, (
+            f"expected an example with text=Calculate; got {examples!r}"
+        )
+        # One example uses css=<tag>:text-is(...) (Playwright text-inside-CSS)
+        css_example = next(
+            (e for e in examples if ":text-is(" in str(e)), None,
+        )
+        assert css_example is not None, (
+            f"expected an example with :text-is(); got {examples!r}"
+        )
+        # Both examples are RF-keyword-shape strings (so the LLM can
+        # copy-paste).
+        assert all(
+            "intent_action" in e["rf"] or "Click" in e.get("rf", "")
+            for e in examples
+        ), examples
+
+
+class TestCheckBrowserRolePrefixSilent:
+    """Negative cases: checker MUST NOT fire when it shouldn't."""
+
+    def test_silent_for_selenium_library(self):
+        # button=X is valid SeleniumLibrary syntax — hint must NOT fire.
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="SeleniumLibrary", args=["button=Calculate"]),
+            "element not visible",
+        )
+        assert hints == []
+
+    def test_silent_for_appium_library(self):
+        # AppiumLibrary uses its own locator forms; the role-prefix
+        # rejection is Browser-specific.
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="AppiumLibrary", args=["button=Calculate"]),
+            "element not visible",
+        )
+        assert hints == []
+
+    @pytest.mark.parametrize("locator", [
+        "id=submit",
+        "css=button.primary",
+        "xpath=//button",
+        "text=Calculate",
+        "name=username",
+        "button:text-is('Calculate')",
+        "#submit",
+        "//button[text()='Save']",
+    ])
+    def test_silent_for_valid_browser_locators(self, locator):
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=[locator]),
+            "element not visible",
+        )
+        assert hints == []
+
+    def test_silent_when_no_arguments(self):
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=[]),
+            "element not visible",
+        )
+        assert hints == []
+
+    def test_silent_when_first_arg_is_non_string(self):
+        hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=[42]),
+            "element not visible",
+        )
+        assert hints == []
+
+    def test_silent_when_no_library_context(self):
+        # Without session_search_order, _detect_library returns
+        # "unknown"; the checker must not fire.
+        ctx = HintContext(
+            session_id="t",
+            keyword="Click",
+            arguments=["button=Calculate"],
+            error_text="element not visible",
+            session_search_order=None,
+        )
+        assert _check_browser_role_prefix_misuse(ctx, ctx.error_text) == []
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: relevance ordering — OBS-12 vs OBS-03 vs invalid-selector
+# ---------------------------------------------------------------------------
+
+
+class TestRelevanceOrdering:
+    """When multiple checkers fire on the same failure, the more-
+    specific diagnosis must win the top-3-by-relevance cap."""
+
+    def test_outranks_invalid_selector(self):
+        # Same failure could trigger _check_invalid_selector if the
+        # error text mentions "Unsupported token"; the more-specific
+        # role-prefix diagnosis is the primary cause and must outrank.
+        role_hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=["button=Calculate"]),
+            "Unsupported token while parsing css selector",
+        )
+        sel_hints = _check_invalid_selector(
+            _ctx(library="Browser", args=["button=Calculate"]),
+            "Unsupported token while parsing css selector",
+        )
+        assert role_hints[0].relevance > sel_hints[0].relevance
+
+    def test_underranks_evaluate_javascript_misuse(self):
+        # OBS-03's JS-shape diagnosis is the most specific possible
+        # for evaluate-js calls; OBS-12 should not crowd it out when
+        # both fire (rare but possible if a JS body happens to start
+        # with a role-prefix-shaped string).
+        role_hints = _check_browser_role_prefix_misuse(
+            _ctx(library="Browser", args=["button=Calculate"]),
+            "Unsupported token",
+        )
+        js_hints = _check_evaluate_javascript_misuse(
+            _ctx(library="Browser", keyword="Evaluate JavaScript",
+                 args=["() => button.click()"]),
+            "Unsupported token",
+        )
+        assert role_hints[0].relevance < js_hints[0].relevance
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: end-to-end via generate_hints
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateHintsEndToEnd:
+    """The full ``generate_hints`` pipeline surfaces the role-prefix
+    hint as a dict in its output."""
+
+    def test_hint_appears_in_response(self):
+        ctx = HintContext(
+            session_id="t",
+            keyword="Click",
+            arguments=["button=Calculate"],
+            error_text="element not visible/enabled",
+            session_search_order=["Browser"],
+        )
+        hints = generate_hints(ctx)
+        titles = [h["title"] for h in hints]
+        assert any("role prefix" in t.lower() for t in titles), (
+            f"role-prefix hint missing from response: {titles!r}"
+        )
+
+    def test_no_hint_in_response_for_selenium_session(self):
+        ctx = HintContext(
+            session_id="t",
+            keyword="Click Element",
+            arguments=["button=Calculate"],
+            error_text="element not visible",
+            session_search_order=["SeleniumLibrary"],
+        )
+        hints = generate_hints(ctx)
+        titles = [h["title"] for h in hints]
+        assert not any("role prefix" in t.lower() for t in titles), (
+            "role-prefix hint must not surface for SeleniumLibrary sessions"
+        )

--- a/tests/unit/test_find_keywords_library_name_filter.py
+++ b/tests/unit/test_find_keywords_library_name_filter.py
@@ -1,0 +1,483 @@
+"""find_keywords — ``library_name`` parameter must filter ALL strategies.
+
+The 2026-05-17 defect report exposed a silent failure: an MCP call
+
+    {
+      "query": "select dropdown option by label or text",
+      "strategy": "semantic",
+      "context": "web",
+      "library_name": "Browser",
+      "limit": 10
+    }
+
+in a Browser-only session returned 7 SeleniumLibrary keywords among the
+top 10 matches (with "Set Window Position" — completely unrelated — at
+the top of the list with confidence 0.82). The ``library_name`` parameter
+was accepted at the API surface, documented as "Optional library filter
+for catalog search", and silently ignored for semantic/pattern. Agents
+reading the response reasonably assume Browser library doesn't have a
+``Select Dropdown`` keyword and write a SL-style call that breaks at
+execute_step.
+
+The fix wires ``library_name`` through to the existing
+``_filter_keywords_by_session_library`` filter for all strategies, with
+precedence ``library_name > session.explicit_library_preference > none``.
+The filter uses the plugin-driven incompatibility table — for
+``library_name="Browser"`` this excludes ``SeleniumLibrary`` and passes
+through ``BuiltIn``, ``Collections``, ``String``, etc.
+
+These tests pin:
+
+(1) Reproducer: semantic + library_name="Browser", no session →
+    SeleniumLibrary matches excluded; ``excluded_keywords`` populated;
+    ``library_filter.source="library_name"``
+(2) Symmetry: semantic + library_name="SeleniumLibrary" →
+    Browser matches excluded
+(3) Strategy parity: pattern + library_name="Browser" → same filter
+(4) Precedence: library_name="Browser" + session preference
+    "SeleniumLibrary" → library_name wins
+(5) Fall-through: no library_name + session preference "Browser" →
+    session wins; library_filter.source="session"
+(6) Idempotency: neither set → unchanged behaviour, no library_filter
+    field, no excluded_keywords
+(7) Unknown library: library_name="FakeLib" → no exclusions
+(8) Sibling libraries preserved: library_name="Browser" + a BuiltIn
+    keyword in results → BuiltIn kept
+(9) Docstring contract: parameter still documented and reachable
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robotmcp.server import find_keywords
+
+
+def _async_tool_fn(tool):
+    """Unwrap a FastMCP tool to its underlying async function."""
+    return getattr(tool, "fn", tool)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic keyword fixtures — match the shape returned by the real engines
+# ---------------------------------------------------------------------------
+
+
+def _semantic_matches() -> List[Dict[str, Any]]:
+    """Shape returned by ``KeywordMatcher.discover_keywords`` (under .matches)."""
+    return [
+        {
+            "keyword_name": "Set Window Position",
+            "library": "SeleniumLibrary",
+            "confidence": 0.82,
+            "arguments": ["x", "y"],
+            "argument_types": ["int", "int"],
+            "documentation": "Sets window position.",
+            "usage_example": "Set Window Position    arg1    arg2",
+        },
+        {
+            "keyword_name": "Click",
+            "library": "Browser",
+            "confidence": 0.80,
+            "arguments": ["selector", "button"],
+            "argument_types": ["str", "MouseButton"],
+            "documentation": "Simulates click on element.",
+            "usage_example": "Click    arg1    arg2",
+        },
+        {
+            "keyword_name": "Click Element",
+            "library": "SeleniumLibrary",
+            "confidence": 0.80,
+            "arguments": ["locator"],
+            "argument_types": ["str"],
+            "documentation": "Clicks element.",
+            "usage_example": "Click Element    id=x",
+        },
+        {
+            "keyword_name": "Select Options By",
+            "library": "Browser",
+            "confidence": 0.77,
+            "arguments": ["selector", "attribute", "values"],
+            "argument_types": ["str", "SelectAttribute", "str"],
+            "documentation": "Select <option>.",
+            "usage_example": "Select Options By    arg1    arg2    arg3",
+        },
+        {
+            "keyword_name": "Select From List By Label",
+            "library": "SeleniumLibrary",
+            "confidence": 0.76,
+            "arguments": ["locator", "labels"],
+            "argument_types": ["str", "str"],
+            "documentation": "Select by label.",
+            "usage_example": "Select From List By Label    id=x    arg2",
+        },
+        {
+            "keyword_name": "Log",
+            "library": "BuiltIn",
+            "confidence": 0.60,
+            "arguments": ["message"],
+            "argument_types": ["str"],
+            "documentation": "Logs a message.",
+            "usage_example": "Log    arg1",
+        },
+    ]
+
+
+def _pattern_matches() -> List[Dict[str, Any]]:
+    """Shape returned by ``execution_engine.search_keywords``."""
+    return [
+        {"name": "Click", "library": "Browser", "arguments": ["selector"]},
+        {"name": "Click Element", "library": "SeleniumLibrary", "arguments": ["locator"]},
+        {"name": "Click Button", "library": "SeleniumLibrary", "arguments": ["locator"]},
+        {"name": "Tap", "library": "Browser", "arguments": ["selector"]},
+        {"name": "Log", "library": "BuiltIn", "arguments": ["message"]},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test infrastructure: patch the matcher + engine + session lookup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_engines():
+    """Stub the semantic matcher, pattern engine, and ensure-all-libraries
+    helper so tests don't hit the real RF runtime.
+
+    Yields a context dict the tests can use to override per-case (e.g.
+    to inject a session with a preference)."""
+    semantic_payload = {
+        "success": True,
+        "action_description": "test action",
+        "action_type": "click",
+        "matches": _semantic_matches(),
+        "total_matches": len(_semantic_matches()),
+        "recommendations": [],
+    }
+
+    async def _ensure_loaded():
+        return None
+
+    discover_mock = AsyncMock(return_value=semantic_payload)
+    search_mock = MagicMock(return_value=_pattern_matches())
+    externalize_mock = MagicMock(side_effect=lambda _tool, _sid, r: r)
+    track_mock = MagicMock()
+
+    # session_manager.get_session returns None by default (no session).
+    # Tests that need a session preference re-patch this.
+    session_manager_mock = MagicMock()
+    session_manager_mock.get_session = MagicMock(return_value=None)
+
+    execution_engine_mock = MagicMock()
+    execution_engine_mock.session_manager = session_manager_mock
+    execution_engine_mock.search_keywords = search_mock
+
+    with patch(
+        "robotmcp.server.keyword_matcher.discover_keywords", discover_mock,
+    ), patch(
+        "robotmcp.server._ensure_all_session_libraries_loaded", _ensure_loaded,
+    ), patch(
+        "robotmcp.server._externalize_response", externalize_mock,
+    ), patch(
+        "robotmcp.server._track_tool_result", track_mock,
+    ), patch(
+        "robotmcp.server.execution_engine", execution_engine_mock,
+    ):
+        yield {
+            "session_manager": session_manager_mock,
+            "discover_mock": discover_mock,
+            "search_mock": search_mock,
+        }
+
+
+# ---------------------------------------------------------------------------
+# 1. Reproducer: the exact failing user payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestReproducerSemanticBrowser:
+    """The exact call from the 2026-05-17 defect report must now exclude
+    SeleniumLibrary matches and surface ``library_filter``."""
+
+    async def test_semantic_browser_filter_excludes_selenium(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="select dropdown option by label or text",
+            strategy="semantic",
+            context="web",
+            library_name="Browser",
+            limit=10,
+        )
+        matches = result["result"]["matches"]
+        libs = sorted({m["library"] for m in matches})
+        assert "SeleniumLibrary" not in libs, (
+            f"Browser library_name must exclude SL; got libs={libs!r}"
+        )
+        # Sibling libraries (BuiltIn) are preserved.
+        assert "Browser" in libs
+        assert "BuiltIn" in libs
+
+    async def test_excluded_keywords_populated(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="select dropdown option by label or text",
+            strategy="semantic",
+            context="web",
+            library_name="Browser",
+            limit=10,
+        )
+        excluded = result.get("excluded_keywords", [])
+        assert excluded, "excluded_keywords must be populated"
+        excluded_names = {e["keyword"] for e in excluded}
+        assert {"Set Window Position", "Click Element", "Select From List By Label"}.issubset(
+            excluded_names
+        ), excluded_names
+
+    async def test_library_filter_indicates_source(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        lf = result.get("library_filter")
+        assert lf is not None
+        assert lf["applied"] == "Browser"
+        assert lf["source"] == "library_name"
+
+    async def test_session_library_field_preserved_for_backcompat(self, patched_engines):
+        """Legacy callers read ``session_library``. The new param must keep
+        this populated whenever filtering applies."""
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        assert result.get("session_library") == "Browser"
+
+
+# ---------------------------------------------------------------------------
+# 2. Symmetry: SeleniumLibrary filter excludes Browser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSymmetrySeleniumFilter:
+    """The filter must work symmetrically — library_name="SeleniumLibrary"
+    excludes Browser, same plugin-table logic."""
+
+    async def test_semantic_selenium_filter_excludes_browser(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="SeleniumLibrary",
+        )
+        matches = result["result"]["matches"]
+        libs = sorted({m["library"] for m in matches})
+        assert "Browser" not in libs, libs
+        assert "SeleniumLibrary" in libs
+
+
+# ---------------------------------------------------------------------------
+# 3. Strategy parity: pattern branch honours library_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestStrategyParityPattern:
+    """Pattern strategy must apply the same filter."""
+
+    async def test_pattern_browser_filter_excludes_selenium(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="click*",
+            strategy="pattern",
+            library_name="Browser",
+        )
+        matches = result.get("results", [])
+        libs = sorted({m["library"] for m in matches})
+        assert "SeleniumLibrary" not in libs, libs
+        assert "Browser" in libs
+        assert "BuiltIn" in libs
+        # Response shape consistent with semantic branch.
+        assert result.get("library_filter") == {
+            "applied": "Browser",
+            "source": "library_name",
+        }
+
+
+# ---------------------------------------------------------------------------
+# 4. Precedence: library_name wins over session preference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPrecedenceLibraryNameOverSession:
+    """When BOTH library_name parameter AND session.explicit_library_preference
+    are set, the parameter takes precedence (per-call override)."""
+
+    async def test_library_name_overrides_session_preference(self, patched_engines):
+        # Session preference set to SeleniumLibrary; per-call library_name
+        # passed as Browser. Browser wins → SL excluded.
+        sess = MagicMock()
+        sess.explicit_library_preference = "SeleniumLibrary"
+        patched_engines["session_manager"].get_session = MagicMock(return_value=sess)
+
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            session_id="sess-1",
+            library_name="Browser",
+        )
+        libs = sorted({m["library"] for m in result["result"]["matches"]})
+        assert "SeleniumLibrary" not in libs, libs
+        assert "Browser" in libs
+        # library_filter clearly attributes the source.
+        assert result["library_filter"]["source"] == "library_name"
+        assert result["library_filter"]["applied"] == "Browser"
+
+
+# ---------------------------------------------------------------------------
+# 5. Fall-through: no library_name → session preference applies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestFallthroughSessionPreference:
+    """The existing session-preference path must still work when
+    library_name is not supplied."""
+
+    async def test_session_preference_applies_when_no_library_name(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = "Browser"
+        patched_engines["session_manager"].get_session = MagicMock(return_value=sess)
+
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            session_id="sess-1",
+        )
+        libs = sorted({m["library"] for m in result["result"]["matches"]})
+        assert "SeleniumLibrary" not in libs, libs
+        assert "Browser" in libs
+        # Source attributed to session, not library_name.
+        assert result["library_filter"]["source"] == "session"
+        assert result["library_filter"]["applied"] == "Browser"
+
+
+# ---------------------------------------------------------------------------
+# 6. Idempotency: no filter when neither is set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestIdempotencyNoFilter:
+    """When no library_name AND no session preference, behaviour is
+    byte-for-byte the pre-fix shape: no library_filter, no
+    excluded_keywords."""
+
+    async def test_no_filter_when_neither_set(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+        )
+        # Both library_name and SL keywords remain.
+        libs = sorted({m["library"] for m in result["result"]["matches"]})
+        assert "SeleniumLibrary" in libs
+        assert "Browser" in libs
+        assert "BuiltIn" in libs
+        # No filter side-channels.
+        assert "library_filter" not in result
+        assert "excluded_keywords" not in result
+        assert "session_library" not in result
+
+    async def test_no_filter_when_session_has_no_preference(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = None
+        patched_engines["session_manager"].get_session = MagicMock(return_value=sess)
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            session_id="sess-1",
+        )
+        libs = sorted({m["library"] for m in result["result"]["matches"]})
+        assert "SeleniumLibrary" in libs
+        assert "library_filter" not in result
+
+
+# ---------------------------------------------------------------------------
+# 7. Unknown library: no exclusions (graceful)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestUnknownLibrary:
+    """An unknown library_name produces no exclusions (the plugin table
+    returns an empty incompatibility list). The filter is a no-op rather
+    than an error — agents are not blocked by a typo."""
+
+    async def test_unknown_library_no_exclusions(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="NoSuchLibrary",
+        )
+        libs = sorted({m["library"] for m in result["result"]["matches"]})
+        # All original libraries remain — no incompatibility table for
+        # the unknown name.
+        assert "SeleniumLibrary" in libs
+        assert "Browser" in libs
+        # No exclusions surface, so the response carries no library_filter
+        # diagnostic (parallel to the no-filter idempotency case).
+        assert "excluded_keywords" not in result
+        assert "library_filter" not in result
+
+
+# ---------------------------------------------------------------------------
+# 8. Sibling libraries preserved (BuiltIn, Collections, String)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSiblingLibrariesPreserved:
+    """library_name="Browser" must NOT exclude BuiltIn/Collections/etc. —
+    only the explicitly-incompatible siblings (SeleniumLibrary)."""
+
+    async def test_builtin_preserved_under_browser_filter(self, patched_engines):
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        names = {m["keyword_name"] for m in result["result"]["matches"]}
+        # ``Log`` is BuiltIn — must remain after filtering.
+        assert "Log" in names, (
+            f"BuiltIn keywords must not be excluded by Browser filter; "
+            f"got names={sorted(names)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. Docstring contract — the parameter is reachable and named
+# ---------------------------------------------------------------------------
+
+
+class TestDocstringContract:
+    """Light contract check: the parameter exists in the signature and
+    the docstring no longer says "catalog search" (the old narrow
+    promise)."""
+
+    def test_library_name_parameter_present(self):
+        import inspect
+        sig = inspect.signature(_async_tool_fn(find_keywords))
+        assert "library_name" in sig.parameters
+        assert sig.parameters["library_name"].default is None
+
+    def test_docstring_announces_all_strategies(self):
+        fn = _async_tool_fn(find_keywords)
+        doc = (fn.__doc__ or "").lower()
+        # Old narrow docstring said "for catalog search". The new doc
+        # explicitly says "ALL strategies".
+        assert "all strategies" in doc, (
+            f"docstring should announce all-strategies coverage; got: {doc[:400]}"
+        )

--- a/tests/unit/test_find_keywords_library_name_filter.py
+++ b/tests/unit/test_find_keywords_library_name_filter.py
@@ -220,7 +220,11 @@ class TestReproducerSemanticBrowser:
         assert "Browser" in libs
         assert "BuiltIn" in libs
 
-    async def test_excluded_keywords_populated(self, patched_engines):
+    async def test_library_filter_reports_count_and_from_library(self, patched_engines):
+        """The compact response carries an exclusion count and the
+        from_library label, without re-listing every excluded keyword
+        name (those would already be missing from ``matches``, so the
+        list is informationally redundant and just inflates tokens)."""
         result = await _async_tool_fn(find_keywords)(
             query="select dropdown option by label or text",
             strategy="semantic",
@@ -228,12 +232,10 @@ class TestReproducerSemanticBrowser:
             library_name="Browser",
             limit=10,
         )
-        excluded = result.get("excluded_keywords", [])
-        assert excluded, "excluded_keywords must be populated"
-        excluded_names = {e["keyword"] for e in excluded}
-        assert {"Set Window Position", "Click Element", "Select From List By Label"}.issubset(
-            excluded_names
-        ), excluded_names
+        lf = result.get("library_filter")
+        assert lf is not None
+        assert lf["count"] == 3  # 3 SL keywords in the fixture
+        assert lf["from_library"] == "SeleniumLibrary"
 
     async def test_library_filter_indicates_source(self, patched_engines):
         result = await _async_tool_fn(find_keywords)(
@@ -246,15 +248,22 @@ class TestReproducerSemanticBrowser:
         assert lf["applied"] == "Browser"
         assert lf["source"] == "library_name"
 
-    async def test_session_library_field_preserved_for_backcompat(self, patched_engines):
-        """Legacy callers read ``session_library``. The new param must keep
-        this populated whenever filtering applies."""
+    async def test_verbose_legacy_fields_dropped(self, patched_engines):
+        """Both ``excluded_keywords`` (verbose per-entry list) and
+        ``session_library`` (redundant with library_filter.applied) are
+        dropped from the response. Token budget: ~75 vs ~1100 in the
+        pre-compaction shape."""
         result = await _async_tool_fn(find_keywords)(
             query="anything",
             strategy="semantic",
             library_name="Browser",
         )
-        assert result.get("session_library") == "Browser"
+        assert "excluded_keywords" not in result, (
+            "verbose excluded_keywords list must be dropped"
+        )
+        assert "session_library" not in result, (
+            "redundant session_library field must be dropped"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -299,11 +308,13 @@ class TestStrategyParityPattern:
         assert "SeleniumLibrary" not in libs, libs
         assert "Browser" in libs
         assert "BuiltIn" in libs
-        # Response shape consistent with semantic branch.
-        assert result.get("library_filter") == {
-            "applied": "Browser",
-            "source": "library_name",
-        }
+        # Response shape consistent with semantic branch (compact shape).
+        lf = result.get("library_filter")
+        assert lf is not None
+        assert lf["applied"] == "Browser"
+        assert lf["source"] == "library_name"
+        assert lf["count"] >= 1
+        assert lf["from_library"] == "SeleniumLibrary"
 
 
 # ---------------------------------------------------------------------------
@@ -458,7 +469,138 @@ class TestSiblingLibrariesPreserved:
 
 
 # ---------------------------------------------------------------------------
-# 9. Docstring contract — the parameter is reachable and named
+# 9. Compaction: only actionable alternatives surface; verbose fields dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestExcludedKeywordsCompaction:
+    """The pre-compaction response carried 7+ verbose entries × ~150
+    tokens each (with redundant ``incompatible_library`` /
+    ``session_library`` / ``reason`` fields repeated identically). The
+    compact response keeps only the actionable translations (entries
+    that carry an ``alternative`` from the plugin's KEYWORD_ALTERNATIVES
+    table) and surfaces the rest as a single ``count`` field.
+
+    The fixture data above has no ``alternative`` entries because the
+    synthetic matches don't trip any plugin-table mappings. We patch
+    the filter function to inject a realistic actionable entry and
+    pin the response shape."""
+
+    async def test_alternatives_surface_when_plugin_provides_them(self, patched_engines):
+        # Inject an actionable alternative via the underlying filter.
+        # KEYWORD_ALTERNATIVES on browser_plugin maps "close all browsers"
+        # → {"alternative": "Close Browser ALL", "example": "Close Browser    ALL"}
+        with patch(
+            "robotmcp.server._filter_keywords_by_session_library",
+        ) as mock_filter:
+            mock_filter.return_value = (
+                [{"name": "Click", "library": "Browser"}],
+                [
+                    {
+                        "keyword": "Close All Browsers",
+                        "incompatible_library": "SeleniumLibrary",
+                        "session_library": "Browser",
+                        "reason": "...",
+                        "alternative": "Close Browser    ALL",
+                        "example": "Close Browser    ALL",
+                    },
+                    {
+                        "keyword": "Set Window Position",
+                        "incompatible_library": "SeleniumLibrary",
+                        "session_library": "Browser",
+                        "reason": "...",
+                        # NB: no alternative key — should NOT appear in the
+                        # compact ``excluded_alternatives`` list.
+                    },
+                ],
+            )
+            result = await _async_tool_fn(find_keywords)(
+                query="anything",
+                strategy="pattern",
+                library_name="Browser",
+            )
+        # library_filter carries count for ALL excluded entries (2).
+        assert result["library_filter"]["count"] == 2
+        assert result["library_filter"]["from_library"] == "SeleniumLibrary"
+        # excluded_alternatives only carries the actionable one.
+        alts = result.get("excluded_alternatives", [])
+        assert len(alts) == 1
+        assert alts[0]["keyword"] == "Close All Browsers"
+        assert alts[0]["alternative"] == "Close Browser    ALL"
+        # The non-actionable entry's bare keyword name does NOT appear
+        # anywhere in the response — the agent learns it was filtered
+        # from its absence in the matches list.
+        flat = repr(result)
+        assert "Set Window Position" not in flat
+
+    async def test_excluded_alternatives_filters_by_actionability(self, patched_engines):
+        """The fixture's SL keywords are:
+          - Set Window Position           (no plugin mapping → silent)
+          - Click Element                 (mapped → "Click", surfaces)
+          - Select From List By Label     (no plugin mapping → silent)
+
+        Only the mapped entry appears in ``excluded_alternatives``.
+        The other two are silently dropped from the inline response —
+        the agent learns they were filtered from their absence in the
+        ``matches`` list."""
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        # 3 total excluded entries (matches the fixture count).
+        assert result["library_filter"]["count"] == 3
+        assert result["library_filter"]["from_library"] == "SeleniumLibrary"
+        # Only the Click Element mapping surfaces.
+        alts = result.get("excluded_alternatives", [])
+        assert len(alts) == 1, (
+            f"only Click Element has a plugin mapping; got {alts!r}"
+        )
+        assert alts[0]["keyword"] == "Click Element"
+        assert alts[0]["alternative"] == "Click"
+        # The non-actionable SL names do NOT appear in the response.
+        flat = repr(result)
+        assert "Set Window Position" not in flat
+        assert "Select From List By Label" not in flat
+
+    async def test_excluded_alternatives_absent_when_no_mappings_at_all(self, patched_engines):
+        """If NO excluded keyword has a plugin mapping, the
+        ``excluded_alternatives`` key is absent (not present-but-empty).
+        Pinned by injecting two non-mapped SL keywords."""
+        with patch(
+            "robotmcp.server._filter_keywords_by_session_library",
+        ) as mock_filter:
+            mock_filter.return_value = (
+                [{"name": "Click", "library": "Browser"}],
+                [
+                    {
+                        "keyword": "Set Window Position",
+                        "incompatible_library": "SeleniumLibrary",
+                        "session_library": "Browser",
+                        "reason": "...",
+                    },
+                    {
+                        "keyword": "Maximize Browser Window",
+                        "incompatible_library": "SeleniumLibrary",
+                        "session_library": "Browser",
+                        "reason": "...",
+                    },
+                ],
+            )
+            result = await _async_tool_fn(find_keywords)(
+                query="anything",
+                strategy="pattern",
+                library_name="Browser",
+            )
+        assert "excluded_alternatives" not in result
+        # But the count + from_library are still surfaced.
+        assert result["library_filter"]["count"] == 2
+        assert result["library_filter"]["from_library"] == "SeleniumLibrary"
+
+
+# ---------------------------------------------------------------------------
+# 10. Docstring contract — the parameter is reachable and named
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_find_keywords_library_name_filter.py
+++ b/tests/unit/test_find_keywords_library_name_filter.py
@@ -600,7 +600,161 @@ class TestExcludedKeywordsCompaction:
 
 
 # ---------------------------------------------------------------------------
-# 10. Docstring contract — the parameter is reachable and named
+# 10. Recommendations rebuild — recommendations follow post-filter matches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRecommendationsRebuild:
+    """``KeywordMatcher.discover_keywords`` computes ``recommendations``
+    BEFORE the library filter runs in ``find_keywords``. Without a
+    rebuild, the "Best match: X" line can name an excluded keyword,
+    contradicting the post-filter ``matches`` list and pointing the
+    agent at an unavailable keyword.
+
+    Reproduced 2026-05-17 with ``library_name="Browser"`` and query
+    "open browser page navigate to url": matches contained only
+    Browser keywords but recommendations[0] was "Best match: Get
+    Browser Aliases (confidence: 0.84)" — a SeleniumLibrary keyword
+    that had just been filtered out."""
+
+    async def test_recommendations_reference_post_filter_top_match(self, patched_engines):
+        # Build a discovery payload where the pre-filter top match is
+        # an SL keyword (Set Window Position, the matcher's first
+        # entry in ``_semantic_matches``) and the pre-filter
+        # recommendations name it.
+        payload = {
+            "success": True,
+            "action_description": "test",
+            "action_type": "click",
+            "matches": _semantic_matches(),  # SL top, Browser later
+            "total_matches": len(_semantic_matches()),
+            "recommendations": [
+                "Best match: Set Window Position (confidence: 0.82)",
+                "Required arguments: x, y",
+                "Alternative options: Click, Click Element, Select Options By",
+            ],
+        }
+        patched_engines["discover_mock"].return_value = payload
+
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        recs = result["result"]["recommendations"]
+        # Top recommendation must reference a kept keyword, not an
+        # excluded one.
+        assert recs, "recommendations must not be empty"
+        assert "Set Window Position" not in recs[0], (
+            f"recommendations[0] still references excluded keyword: {recs[0]!r}"
+        )
+        # The post-filter top match is the Browser ``Click`` entry
+        # (confidence 0.80).
+        assert "Click" in recs[0]
+        assert "confidence: 0.80" in recs[0]
+
+    async def test_recommendations_carry_post_filter_arguments(self, patched_engines):
+        """The "Required arguments" line in recommendations must
+        reflect the post-filter top match's arguments — not the
+        pre-filter top match's arguments."""
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        recs = result["result"]["recommendations"]
+        # Browser ``Click`` takes (selector, button); SL ``Set Window
+        # Position`` took (x, y). After filtering, the args line must
+        # be Click's, not Set Window Position's.
+        args_line = next((r for r in recs if r.startswith("Required arguments")), None)
+        assert args_line is not None
+        assert "selector" in args_line
+        assert "x, y" not in args_line, (
+            f"args line still reflects pre-filter top match: {args_line!r}"
+        )
+
+    async def test_recommendations_alternatives_only_kept_keywords(self, patched_engines):
+        """The "Alternative options" line must only contain post-filter
+        keyword names — no excluded SL keywords leaking in."""
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        recs = result["result"]["recommendations"]
+        alt_line = next((r for r in recs if r.startswith("Alternative options")), None)
+        if alt_line is not None:
+            for excluded_name in (
+                "Set Window Position", "Click Element",
+                "Select From List By Label",
+            ):
+                assert excluded_name not in alt_line, (
+                    f"alt line leaks excluded keyword {excluded_name!r}: {alt_line!r}"
+                )
+
+    async def test_recommendations_empty_no_matches_message_when_all_filtered(
+        self, patched_engines,
+    ):
+        """When the filter excludes ALL matches, recommendations must
+        show the no-matches guidance (matching the matcher's behaviour
+        for the empty case) — NOT a stale top match from the pre-filter
+        list."""
+        # Build a payload where every match is SL.
+        all_sl = [m for m in _semantic_matches() if m["library"] == "SeleniumLibrary"]
+        payload = {
+            "success": True,
+            "action_description": "test",
+            "action_type": "click",
+            "matches": all_sl,
+            "total_matches": len(all_sl),
+            "recommendations": [
+                f"Best match: {all_sl[0]['keyword_name']} (confidence: 0.82)",
+            ],
+        }
+        patched_engines["discover_mock"].return_value = payload
+
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+            library_name="Browser",
+        )
+        recs = result["result"]["recommendations"]
+        # All matches filtered out — recommendations now show the
+        # no-matches guidance.
+        assert any("No matching keywords found" in r for r in recs), recs
+        # The pre-filter top match name must NOT appear.
+        for sl in all_sl:
+            assert sl["keyword_name"] not in " ".join(recs), (
+                f"stale pre-filter name {sl['keyword_name']!r} in recs: {recs!r}"
+            )
+
+    async def test_recommendations_unchanged_when_no_filter_applied(self, patched_engines):
+        """When no filter applies (no library_name + no session
+        preference), the matcher's original recommendations pass
+        through unchanged — no rebuild work."""
+        sentinel_recs = ["Best match: Set Window Position (confidence: 0.82)"]
+        payload = {
+            "success": True,
+            "action_description": "test",
+            "action_type": "click",
+            "matches": _semantic_matches(),
+            "total_matches": len(_semantic_matches()),
+            "recommendations": list(sentinel_recs),
+        }
+        patched_engines["discover_mock"].return_value = payload
+
+        result = await _async_tool_fn(find_keywords)(
+            query="anything",
+            strategy="semantic",
+        )
+        # No filter → recommendations are byte-identical to what the
+        # matcher emitted. Pinned via the sentinel string.
+        assert result["result"]["recommendations"] == sentinel_recs
+
+
+# ---------------------------------------------------------------------------
+# 11. Docstring contract — the parameter is reachable and named
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_obs_15_prevalidation_role_prefix_hint.py
+++ b/tests/unit/test_obs_15_prevalidation_role_prefix_hint.py
@@ -1,0 +1,345 @@
+"""OBS-15 — OBS-12 hint must also reach the pre-validation failure path.
+
+The 2026-05-17 v3 validation re-run of the Tricentis Obstacle Course (after
+OBS-10/11/12 shipped) found that the OBS-12 ``browser_role_prefix_misuse``
+hint never actually fires in production. Sonnet attempted
+``intent_action(intent="click", target="button=Calculate")`` on Obstacle 8
+and the failure response carried only generic visibility / enabled / timeout
+hints — no role-prefix locator hint.
+
+Root cause: ``_check_browser_role_prefix_misuse`` is invoked via
+``generate_hints`` in the *keyword-execution failure path* at
+``keyword_executor.py:1684+``. But ``button=X`` against Browser library
+typically fails earlier — at *pre-validation* (the 500ms gate that checks
+element actionability) — which builds its own hint list **inline** at
+``keyword_executor.py:1393+`` and does NOT route through ``generate_hints``.
+
+The OBS-12 unit tests in ``test_browser_role_prefix_hint.py`` pin the hint
+firing through ``generate_hints``. They pass; the production code path
+just never calls into that pipeline for the typical failure mode. This
+file pins the pre-validation path integration as well.
+
+These tests pin:
+(1) The inline pre-validation hint builder emits a
+    ``browser_role_prefix_misuse`` entry when the locator matches the
+    role-prefix pattern AND the session uses Browser library.
+(2) The new hint preserves the title / message / examples produced by
+    the existing ``_check_browser_role_prefix_misuse`` checker.
+(3) The hint does NOT fire for SeleniumLibrary sessions (where the
+    locator syntax is valid).
+(4) The hint does NOT fire when the locator does NOT match the
+    role-prefix pattern (id=, css=, xpath=, text=, name=).
+(5) Hints are deduplicated by ``type`` so the same hint never appears
+    twice if both paths could reach it.
+
+The integration is tested via the real ``_execute_keyword_serialized``
+method (not just source-text matching) so any regression that breaks the
+wiring is caught.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robotmcp.components.execution.keyword_executor import KeywordExecutor
+from robotmcp.models.config_models import ExecutionConfig
+
+
+def _failing_pre_validate(
+    msg: str = "Element missing required states: enabled, visible",
+    missing: List[str] | None = None,
+) -> AsyncMock:
+    """Build a stub for ``_pre_validate_element_with_retry`` that reports
+    the failure shape Browser library actually produces."""
+    details = {
+        "locator": "<unused>",
+        "current_states": [],
+        "missing_states": missing if missing is not None else ["enabled", "visible"],
+    }
+    return AsyncMock(return_value=(False, msg, details))
+
+
+def _session(*, search_order: List[str] | None = None) -> MagicMock:
+    """Build a minimal session stub. Pre-validation reads session_id +
+    search_order. We don't go past pre-validation so library managers,
+    variables, etc. don't matter."""
+    sess = MagicMock()
+    sess.session_id = "obs15-test-session"
+    sess.variables = {}
+    sess.search_order = list(search_order or ["Browser"])
+    sess.update_activity = MagicMock()
+    return sess
+
+
+@pytest.fixture
+def executor():
+    return KeywordExecutor(config=ExecutionConfig())
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — the hint fires from the pre-validation failure path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestOBS15HintFiresFromPreValidationPath:
+    """When pre-validation rejects a role-prefix locator against Browser
+    library, the failure response's ``hints`` list MUST include a
+    ``browser_role_prefix_misuse`` entry."""
+
+    # NB: ``link=X`` is NOT in this parametrize. The pre-validation
+    # block has a sister table ``_SKIP_PRE_VALIDATION_LOCATOR_PREFIXES``
+    # — designed for SeleniumLibrary's link-text strategy — that skips
+    # pre-validation entirely whenever a locator starts with ``link=``.
+    # For Browser library + ``link=X``, the keyword-execution-failure
+    # path still emits the OBS-12 hint through ``generate_hints`` (the
+    # existing OBS-12 unit tests pin that). OBS-15 only widens
+    # coverage for the four prefixes that *do* enter pre-validation:
+    # button, input, select, textarea.
+    @pytest.mark.parametrize("locator,role,value", [
+        ("button=Calculate", "button", "Calculate"),
+        ("input=username", "input", "username"),
+        ("select=Country", "select", "Country"),
+        ("textarea=Comment", "textarea", "Comment"),
+    ])
+    async def test_hint_fires_for_each_role_prefix(
+        self, executor, locator, role, value,
+    ):
+        sess = _session(search_order=["Browser"])
+        with patch.object(
+            executor,
+            "_pre_validate_element_with_retry",
+            _failing_pre_validate(),
+        ):
+            result = await executor._execute_keyword_serialized(
+                session=sess,
+                keyword="Click",
+                arguments=[locator],
+                browser_library_manager=MagicMock(),
+            )
+
+        assert result["success"] is False
+        assert result.get("pre_validation_failed") is True
+
+        types = [h.get("type") for h in result.get("hints", [])]
+        assert "browser_role_prefix_misuse" in types, (
+            f"OBS-15: role-prefix hint missing for {locator!r}; got "
+            f"types={types!r}"
+        )
+
+        role_hint = next(
+            h for h in result["hints"]
+            if h.get("type") == "browser_role_prefix_misuse"
+        )
+        # Title names the rejected role prefix.
+        assert role in role_hint["title"].lower()
+        # Message names both the literal failing locator and points the
+        # user at the SL→Browser correction.
+        assert locator in role_hint["message"]
+        assert "SeleniumLibrary" in role_hint["message"]
+        # Examples include BOTH working alternatives: text= and
+        # css=<tag>:text-is(...).
+        examples = role_hint["examples"]
+        assert any(f"text={value}" in str(e) for e in examples), examples
+        assert any(":text-is(" in str(e) for e in examples), examples
+
+
+@pytest.mark.asyncio
+class TestOBS15HintShape:
+    """The OBS-15 hint preserves the structured fields produced by the
+    existing OBS-12 checker — title, message, examples — and adds a
+    ``type`` field for parity with the other pre-validation hints."""
+
+    async def test_hint_has_type_title_message_examples(self, executor):
+        sess = _session(search_order=["Browser"])
+        with patch.object(
+            executor,
+            "_pre_validate_element_with_retry",
+            _failing_pre_validate(),
+        ):
+            result = await executor._execute_keyword_serialized(
+                session=sess,
+                keyword="Click",
+                arguments=["button=Calculate"],
+                browser_library_manager=MagicMock(),
+            )
+
+        role_hints = [
+            h for h in result["hints"]
+            if h.get("type") == "browser_role_prefix_misuse"
+        ]
+        assert len(role_hints) == 1
+        h = role_hints[0]
+        assert h["type"] == "browser_role_prefix_misuse"
+        assert isinstance(h["title"], str) and h["title"]
+        assert isinstance(h["message"], str) and h["message"]
+        assert isinstance(h["examples"], list) and h["examples"]
+
+    async def test_pre_validation_failure_hint_still_present(self, executor):
+        """The OBS-15 hint is additive — the existing
+        ``pre_validation_failure`` / ``visibility_hint`` /
+        ``pre_validate_timeout_hint`` entries must still be there.
+        Regression guard against an over-eager dedup."""
+        sess = _session(search_order=["Browser"])
+        with patch.object(
+            executor,
+            "_pre_validate_element_with_retry",
+            _failing_pre_validate(missing=["visible"]),
+        ):
+            result = await executor._execute_keyword_serialized(
+                session=sess,
+                keyword="Click",
+                arguments=["button=Calculate"],
+                browser_library_manager=MagicMock(),
+            )
+        types = [h.get("type") for h in result["hints"]]
+        assert "pre_validation_failure" in types
+        assert "visibility_hint" in types
+        assert "pre_validate_timeout_hint" in types
+        assert "browser_role_prefix_misuse" in types
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — the hint MUST NOT fire when it shouldn't
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestOBS15HintDoesNotFireWhenInapplicable:
+    """The OBS-15 hint must stay quiet when the locator is valid for the
+    active library."""
+
+    @pytest.mark.parametrize("locator", [
+        "id=submit",
+        "css=button.primary",
+        "xpath=//button[text()='Save']",
+        "text=Calculate",
+        "name=username",
+        "#submit",
+        "//button",
+    ])
+    async def test_silent_for_valid_browser_locators(self, executor, locator):
+        sess = _session(search_order=["Browser"])
+        with patch.object(
+            executor,
+            "_pre_validate_element_with_retry",
+            _failing_pre_validate(),
+        ):
+            result = await executor._execute_keyword_serialized(
+                session=sess,
+                keyword="Click",
+                arguments=[locator],
+                browser_library_manager=MagicMock(),
+            )
+        types = [h.get("type") for h in result.get("hints", [])]
+        assert "browser_role_prefix_misuse" not in types, (
+            f"OBS-15: hint must not fire for valid Browser locator "
+            f"{locator!r}; got types={types!r}"
+        )
+
+    async def test_silent_for_selenium_library_session(self, executor):
+        # ``button=X`` is valid SeleniumLibrary syntax — hint must NOT fire.
+        sess = _session(search_order=["SeleniumLibrary"])
+        with patch.object(
+            executor,
+            "_pre_validate_element_with_retry",
+            _failing_pre_validate(),
+        ):
+            result = await executor._execute_keyword_serialized(
+                session=sess,
+                keyword="Click Element",
+                arguments=["button=Calculate"],
+                browser_library_manager=MagicMock(),
+            )
+        types = [h.get("type") for h in result.get("hints", [])]
+        assert "browser_role_prefix_misuse" not in types, (
+            f"OBS-15: hint must not fire for SeleniumLibrary; got "
+            f"types={types!r}"
+        )
+
+    async def test_silent_when_pre_validation_passes(self, executor):
+        """If pre-validation passes, the failure block isn't even
+        reached. The role-prefix hint only fires via the failure path
+        OR (separately) via the keyword-execution-failure path. Not via
+        the success path."""
+        sess = _session(search_order=["Browser"])
+        # _pre_validate_element_with_retry returns success → block skipped
+        passing = AsyncMock(return_value=(True, None, {}))
+        # The keyword-execution path is mocked too so we don't actually
+        # try to run anything against a real RF context.
+        with patch.object(
+            executor, "_pre_validate_element_with_retry", passing,
+        ), patch.object(
+            executor,
+            "_execute_keyword_with_context",
+            AsyncMock(return_value={"success": True, "result": None}),
+        ):
+            result = await executor._execute_keyword_serialized(
+                session=sess,
+                keyword="Click",
+                arguments=["button=Calculate"],
+                browser_library_manager=MagicMock(),
+            )
+        # Successful run — no hints from the pre-validation failure
+        # block. The keyword-execution path runs through but doesn't
+        # fail (we mocked it), so its own hints aren't surfaced either.
+        assert result.get("pre_validation_failed") is not True
+
+
+# ---------------------------------------------------------------------------
+# Dedup safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestOBS15HintDedup:
+    """The pre-validation failure block dedups hints by ``type``. This
+    safeguards against future callers that might (incorrectly) append a
+    duplicate hint via a different path."""
+
+    async def test_each_type_appears_at_most_once(self, executor):
+        sess = _session(search_order=["Browser"])
+        with patch.object(
+            executor,
+            "_pre_validate_element_with_retry",
+            _failing_pre_validate(missing=["enabled", "visible"]),
+        ):
+            result = await executor._execute_keyword_serialized(
+                session=sess,
+                keyword="Click",
+                arguments=["button=Calculate"],
+                browser_library_manager=MagicMock(),
+            )
+
+        types = [h.get("type") for h in result["hints"] if h.get("type")]
+        # No duplicate types.
+        assert len(types) == len(set(types)), (
+            f"duplicate hint types in OBS-15 response: {types!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Source-shape pin — guards against future refactors moving the call
+# site away from the pre-validation failure block.
+# ---------------------------------------------------------------------------
+
+
+class TestOBS15SourceShape:
+    """Belt-and-braces: the literal call site for the OBS-15 enrichment
+    sits inside the pre-validation failure block. If a future refactor
+    moves it out, the tests above keep working through different paths
+    but this pin documents the intended location and surfaces the
+    regression early."""
+
+    def test_executor_imports_role_prefix_checker_inline(self):
+        import pathlib
+        executor_src = pathlib.Path(
+            "src/robotmcp/components/execution/keyword_executor.py"
+        ).read_text(encoding="utf-8")
+        # Inline import inside the pre-validation failure block.
+        assert "_check_browser_role_prefix_misuse" in executor_src
+        # Type tag emitted by the inline builder.
+        assert '"type": "browser_role_prefix_misuse"' in executor_src

--- a/tests/unit/test_variable_propagation_in_suite_generation.py
+++ b/tests/unit/test_variable_propagation_in_suite_generation.py
@@ -1,0 +1,407 @@
+"""OBS-11 — captured-variable propagation into subsequent literal args.
+
+The 2026-05-17 post-OBS validation benchmark surfaced a generated-suite
+fidelity gap on Obstacle 7 (And counting). Sonnet's call sequence:
+
+    intent_action(intent="extract", mode="count",
+                  target="css=.select2-results__option",
+                  assign_to="ENTRY_COUNT")        # captured ${ENTRY_COUNT}=5
+    execute_step(Fill Text, ["id=entryCount", "5"])
+
+Generated suite output (BEFORE OBS-11):
+
+    ${ENTRY_COUNT} =    Get Element Count    css=.select2-results__option
+    Fill Text           id=entryCount        5     ← literal, not ${ENTRY_COUNT}
+
+The suite isn't truly dynamic — it would silently mis-fill on a page
+where the search string returns a different count. OBS-11 closes the
+gap by post-processing each test case's steps before rendering and
+rewriting literal args that match a recently captured variable's
+value into ``${VAR}`` references.
+
+These tests pin:
+(1) Basic propagation: capture in step N → literal in step N+1 rewritten
+(2) Captured-value comparison is exact-match (no substring false-positives)
+(3) Arg 0 (locator slot) is left untouched to avoid false matches in
+    locator strings
+(4) Lookback window: rewrites only within ~10 steps of capture
+(5) Already-substituted ``${VAR}`` references in literal slots are
+    left alone (no double-wrap)
+(6) Multiple captures: most recent match wins
+(7) Empty / None captured values produce no substitutions
+(8) Cross-test-case isolation: a capture in test case A doesn't
+    bleed into test case B's literals
+(9) End-to-end: build_test_suite's rf_text output shows the
+    substituted reference (the headline acceptance from the story)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from robotmcp.components.test_builder import (
+    GeneratedTestCase,
+    GeneratedTestSuite,
+    TestBuilder,
+    TestCaseStep,
+)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: the helper's transform behaviour
+# ---------------------------------------------------------------------------
+
+
+def _builder() -> TestBuilder:
+    """A minimal TestBuilder for invoking the propagation helper —
+    the helper doesn't touch the execution engine."""
+    return TestBuilder(execution_engine=None)
+
+
+def _capture_step(var: str, value: str, kw: str = "Get Element Count",
+                  arg: str = "css=.x") -> TestCaseStep:
+    return TestCaseStep(
+        keyword=kw,
+        arguments=[arg],
+        assigned_variables=[var],
+        assignment_type="single",
+        captured_value=value,
+    )
+
+
+class TestBasicPropagation:
+    """Capture in step N → literal in step N+1 rewritten."""
+
+    def test_captures_and_rewrites_in_next_step(self):
+        steps = [
+            _capture_step("${COUNT}", "5"),
+            TestCaseStep(keyword="Fill Text", arguments=["id=foo", "5"]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[1].arguments == ["id=foo", "${COUNT}"]
+
+    def test_capture_step_itself_is_not_self_substituted(self):
+        # The capturing step's own args (e.g. the locator at arg 0,
+        # or any other args) must NOT be rewritten — a self-
+        # substitution would corrupt the keyword call.
+        steps = [
+            _capture_step("${COUNT}", "5", arg="5"),  # locator literally "5"
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        # The captured step's locator arg stays as "5".
+        assert steps[0].arguments == ["5"]
+
+    def test_arg0_is_skipped_in_subsequent_steps(self):
+        # Arg 0 is the locator slot by convention. A literal matching
+        # a captured value MUST NOT be rewritten there — locator
+        # strings that happen to equal a captured value are
+        # coincidental, not intentional references. Both arg slots
+        # carry the matching value to prove the asymmetry: only the
+        # later positions are rewritten.
+        steps = [
+            _capture_step("${X}", "5"),
+            TestCaseStep(keyword="Click", arguments=["5", "5"]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        # arg[0] preserved (locator slot rule); arg[1] rewritten.
+        assert steps[1].arguments == ["5", "${X}"]
+
+
+class TestExactMatchSemantics:
+    """Substitution requires exact equality between captured value and
+    the literal argument. Substring / containment matches must NOT
+    trigger rewrites."""
+
+    @pytest.mark.parametrize("literal,captured,should_rewrite", [
+        ("5", "5", True),                          # exact match
+        ("ORD-1007696", "ORD-1007696", True),      # exact match
+        ("HELLO", "hello", False),                 # case-sensitive
+        ("5 items", "5", False),                   # substring NOT match
+        ("ID-5", "5", False),                      # substring NOT match
+        (" 5", "5", False),                        # whitespace NOT match
+        ("5 ", "5", False),                        # trailing space
+    ])
+    def test_exact_match_required(self, literal, captured, should_rewrite):
+        steps = [
+            _capture_step("${X}", captured),
+            TestCaseStep(keyword="Log", arguments=["msg", literal]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        if should_rewrite:
+            assert steps[1].arguments == ["msg", "${X}"]
+        else:
+            assert steps[1].arguments == ["msg", literal]
+
+
+class TestLookbackWindow:
+    """Substitution is bounded to the lookback window after capture."""
+
+    def test_substitutes_within_lookback(self):
+        steps: list[TestCaseStep] = [_capture_step("${X}", "5")]
+        # Filler steps with non-matching literals — these don't reset
+        # the active capture but consume lookback steps.
+        for i in range(8):
+            steps.append(TestCaseStep(
+                keyword="Log", arguments=["msg", f"filler-{i}"],
+            ))
+        # Step 9 (8 filler + capture) — within 10-step lookback.
+        steps.append(
+            TestCaseStep(keyword="Log", arguments=["msg", "5"]),
+        )
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[-1].arguments == ["msg", "${X}"]
+
+    def test_does_not_substitute_beyond_lookback(self):
+        steps: list[TestCaseStep] = [_capture_step("${X}", "5")]
+        # Fill out 11 steps after the capture so the literal is
+        # past the default 10-step lookback.
+        for i in range(11):
+            steps.append(TestCaseStep(
+                keyword="Log", arguments=["msg", f"filler-{i}"],
+            ))
+        steps.append(
+            TestCaseStep(keyword="Log", arguments=["msg", "5"]),
+        )
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        # The trailing "5" is 12 steps after the capture — outside
+        # the 10-step window. Must NOT be substituted.
+        assert steps[-1].arguments == ["msg", "5"]
+
+
+class TestExistingVariableReferences:
+    """Args that already contain a ``${VAR}`` reference must NOT be
+    re-wrapped or otherwise transformed."""
+
+    def test_existing_variable_reference_preserved(self):
+        steps = [
+            _capture_step("${X}", "5"),
+            TestCaseStep(
+                keyword="Fill Text",
+                arguments=["id=foo", "${OTHER}"],
+            ),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[1].arguments == ["id=foo", "${OTHER}"]
+
+    def test_embedded_variable_reference_preserved(self):
+        # Embedded refs in larger literals also preserve the original.
+        steps = [
+            _capture_step("${X}", "5"),
+            TestCaseStep(
+                keyword="Log",
+                arguments=["msg", "Hello ${USER}"],
+            ),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[1].arguments == ["msg", "Hello ${USER}"]
+
+
+class TestMultipleCaptures:
+    """When multiple captures are active, the most-recent matching
+    capture wins. This matches the intuition that recent captures are
+    semantically closer to the literal usage."""
+
+    def test_most_recent_capture_wins(self):
+        steps = [
+            _capture_step("${X}", "5"),
+            _capture_step("${Y}", "5"),       # same value, newer
+            TestCaseStep(keyword="Log", arguments=["msg", "5"]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        # Most-recent capture (${Y}) wins.
+        assert steps[2].arguments == ["msg", "${Y}"]
+
+    def test_different_values_route_to_correct_vars(self):
+        steps = [
+            _capture_step("${COUNT}", "5"),
+            _capture_step("${ID}", "ORD-1"),
+            TestCaseStep(keyword="Log", arguments=["msg", "5"]),
+            TestCaseStep(keyword="Log", arguments=["msg", "ORD-1"]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[2].arguments == ["msg", "${COUNT}"]
+        assert steps[3].arguments == ["msg", "${ID}"]
+
+
+class TestNoCaptureSemantics:
+    """Steps without captures don't pollute the active-capture list,
+    and captured-value=None / empty is treated as 'no capture'."""
+
+    def test_none_captured_value_does_not_register(self):
+        steps = [
+            TestCaseStep(
+                keyword="Get Text",
+                arguments=["id=foo"],
+                assigned_variables=["${X}"],
+                captured_value=None,
+            ),
+            TestCaseStep(keyword="Log", arguments=["msg", "5"]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        # No substitution — capture wasn't usable.
+        assert steps[1].arguments == ["msg", "5"]
+
+    def test_empty_captured_value_does_not_register(self):
+        steps = [
+            TestCaseStep(
+                keyword="Get Text",
+                arguments=["id=foo"],
+                assigned_variables=["${X}"],
+                captured_value="",
+            ),
+            TestCaseStep(keyword="Log", arguments=["msg", ""]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        # Both empty — but capture is non-usable, no rewrite.
+        assert steps[1].arguments == ["msg", ""]
+
+    def test_whitespace_only_captured_value_does_not_register(self):
+        steps = [
+            TestCaseStep(
+                keyword="Get Text",
+                arguments=["id=foo"],
+                assigned_variables=["${X}"],
+                captured_value="   ",
+            ),
+            TestCaseStep(keyword="Log", arguments=["msg", "   "]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[1].arguments == ["msg", "   "]
+
+
+class TestCrossTestCaseIsolation:
+    """A capture in test case A must NOT bleed into test case B.
+    The propagation pass is called per-test-case so captures are
+    naturally scoped."""
+
+    def test_captures_do_not_cross_test_case_boundary(self):
+        # Two independent step lists — simulates two test cases.
+        tc_a_steps = [
+            _capture_step("${X}", "5"),
+            TestCaseStep(keyword="Log", arguments=["msg", "5"]),
+        ]
+        tc_b_steps = [
+            TestCaseStep(keyword="Log", arguments=["msg", "5"]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(tc_a_steps)
+        _builder()._propagate_assigned_variables_to_literal_args(tc_b_steps)
+        # tc_a: capture available, substitution happens.
+        assert tc_a_steps[1].arguments == ["msg", "${X}"]
+        # tc_b: NO capture available, literal preserved.
+        assert tc_b_steps[0].arguments == ["msg", "5"]
+
+
+class TestEdgeCases:
+    """Defensive cases: empty / minimal inputs must not crash."""
+
+    def test_empty_steps_list_is_noop(self):
+        steps: list[TestCaseStep] = []
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps == []
+
+    def test_single_step_without_capture_is_noop(self):
+        steps = [TestCaseStep(keyword="Log", arguments=["msg"])]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[0].arguments == ["msg"]
+
+    def test_step_with_no_args_does_not_crash(self):
+        steps = [
+            _capture_step("${X}", "5"),
+            TestCaseStep(keyword="Get Title", arguments=[]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        assert steps[1].arguments == []
+
+    def test_non_string_args_are_skipped_gracefully(self):
+        # ExecutionStep coerces args to strings on the wire, but
+        # defensive: non-string args (int, None) must not crash.
+        steps = [
+            _capture_step("${X}", "5"),
+            TestCaseStep(keyword="Log", arguments=["msg", 5]),
+        ]
+        _builder()._propagate_assigned_variables_to_literal_args(steps)
+        # int 5 != string "5"; no substitution.
+        assert steps[1].arguments == ["msg", 5]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: end-to-end via _generate_rf_text — the headline acceptance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGenerateRfTextSubstitutesAssignedVars:
+    """The story acceptance #2: build_test_suite output contains
+    ``Fill Text id=entryCount ${ENTRY_COUNT}`` (NOT literal ``"5"``)."""
+
+    async def test_obstacle_7_scenario_rf_text(self):
+        # Synthesize the Obstacle 7 scenario directly via the test-
+        # case + suite DTOs, skipping the upstream session machinery.
+        capture = TestCaseStep(
+            keyword="Get Element Count",
+            arguments=["css=.select2-results__option"],
+            assigned_variables=["${ENTRY_COUNT}"],
+            assignment_type="single",
+            captured_value="5",
+        )
+        fill = TestCaseStep(
+            keyword="Fill Text",
+            arguments=["id=entryCount", "5"],
+        )
+        tc = GeneratedTestCase(
+            name="Obstacle 7 - And counting",
+            steps=[capture, fill],
+        )
+        suite = GeneratedTestSuite(
+            name="OBS-11 fixture",
+            documentation="Variable-propagation acceptance",
+            imports=["Browser"],
+            test_cases=[tc],
+        )
+        builder = _builder()
+        rf_text = await builder._generate_rf_text(suite)
+        # The headline assertion — ${ENTRY_COUNT} appears at the Fill
+        # Text site (not the literal "5").
+        assert "${ENTRY_COUNT} =    Get Element Count" in rf_text
+        assert "Fill Text    id=entryCount    ${ENTRY_COUNT}" in rf_text
+        # Pin the negative: the literal "5" must NOT appear in the
+        # Fill Text args slot.
+        assert "Fill Text    id=entryCount    5\n" not in rf_text
+        assert "Fill Text    id=entryCount    5    " not in rf_text
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: ExecutionStep → TestCaseStep plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestCapturedValuePlumbing:
+    """``captured_value`` is populated from ``ExecutionStep.result``
+    when the step assigned a variable, and is None otherwise."""
+
+    def test_captures_string_result(self):
+        exec_step = MagicMock()
+        exec_step.assigned_variables = ["${X}"]
+        exec_step.result = "hello"
+        assert TestBuilder._captured_value_str(exec_step) == "hello"
+
+    def test_captures_int_result_as_str(self):
+        exec_step = MagicMock()
+        exec_step.assigned_variables = ["${N}"]
+        exec_step.result = 5
+        # Coerced to string for arg-level equality comparison.
+        assert TestBuilder._captured_value_str(exec_step) == "5"
+
+    def test_no_assigned_variables_returns_none(self):
+        exec_step = MagicMock()
+        exec_step.assigned_variables = []
+        exec_step.result = "hello"
+        assert TestBuilder._captured_value_str(exec_step) is None
+
+    def test_no_result_returns_none(self):
+        exec_step = MagicMock()
+        exec_step.assigned_variables = ["${X}"]
+        exec_step.result = None
+        assert TestBuilder._captured_value_str(exec_step) is None


### PR DESCRIPTION
## Summary

Validation followup to PR #69. The 2026-05-17 v2 Tricentis Obstacle Course
benchmark surfaced three findings (OBS-10/11/12); the v3 re-run validated
two and uncovered a defect in the third (OBS-15).

- **OBS-10** — Drag And Drop pre-scrolls the source element into view automatically. Sonnet's Obstacle 10 dropped from **27 → 13 calls** (52%) and Haiku's from **9 → 7**.
- **OBS-11** — `build_test_suite` now propagates captured variables (intent_action(assign_to=...) → next-step literal-arg rewrite). Sonnet's generated suite renders `Fill Text ... ${ENTRY_COUNT}` instead of the literal.
- **OBS-12** — New hint when SeleniumLibrary-style role-prefix locators (`button=X` / `link=X` / `input=X` / `select=X` / `textarea=X`) are used against Browser library.
- **OBS-15** — Defect fix: the OBS-12 hint never fired in production because pre-validation rejected `button=X` *before* the keyword-execution-failure path's `generate_hints` pipeline could run. v3 confirmed this directly: Sonnet attempted `button=Calculate` on Obstacle 8 and the response carried only generic visibility/timeout hints. This PR routes the OBS-12 checker into the inline pre-validation hint builder so the diagnosis surfaces where the failure actually occurs.

## Commits

| SHA | Change |
|---|---|
| 3ffeef8 | OBS-10 — pre-scroll Drag And Drop source |
| 6096950 | OBS-11 — propagate assigned vars into subsequent literals |
| f37ccdf | OBS-12 — Browser role-prefix locator misuse hint |
| 0c4cd6a | OBS-15 — surface OBS-12 role-prefix hint in pre-validation failure path |

## Validation

| Round | Sonnet | Haiku | Notes |
|---|---|---|---|
| v2 (baseline, post-PR #69) | 10/10 | 10/10 | Surfaced OBS-10/11/12 |
| v3 (post-OBS-10/11/12) | 10/10 | 10/10 | OBS-10 ✅ (27→13), OBS-11 ✅ (Sonnet 2/2; Haiku 1/3 — open), OBS-12 ❌ defect → OBS-15 |

See `docs/issues/2026-05-17_post_obs_followup_stories.md` for the OBS-10/11/12
user stories and `docs/issues/2026-05-17_post_obs_v3_followup_stories.md`
for OBS-15/16/17.

## Tests

Full unit suite: **5892 passed, 1 skipped, 0 failures** (+44 net over v0.32.5).

New test files:
- `tests/unit/test_browser_drag_and_drop_prescroll.py` — OBS-10 (8 tests)
- `tests/unit/test_variable_propagation_in_suite_generation.py` — OBS-11 (multi-layer)
- `tests/unit/test_browser_role_prefix_hint.py` — OBS-12 (55 tests, 4 layers)
- `tests/unit/test_obs_15_prevalidation_role_prefix_hint.py` — OBS-15 (17 tests, 5 layers)
- `tests/integration/test_real_browser_prevalidation.py` — added OBS-10 contract assertion

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/ -q`)
- [x] v3 Tricentis benchmark validated OBS-10 + OBS-11 (Sonnet 10/10, Haiku 10/10)
- [x] v3 found OBS-12 unreachable from pre-validation path → fixed in OBS-15
- [ ] v4 benchmark re-run to confirm OBS-15 fires on `button=Calculate` (post-merge)

## Out of scope (filed as follow-ups in OBS-15/16/17 doc)

- **OBS-16** — `untracked_variables` warning false-positive after OBS-11 substitution (variable tracker runs before propagation pass).
- **OBS-17** — ARIA snapshot conflates visible page text containing "class X" / "id Y" with element metadata.
- **IH1** — Haiku's OBS-11 1/3 propagation rate (need raw rf_text to investigate lookback / arg-0 / type-coerce rules).
- `_SKIP_PRE_VALIDATION_LOCATOR_PREFIXES` (`link=`, etc.) skips pre-validation for *all* libraries — was designed as a SeleniumLibrary workaround. For Browser library + `link=X` the keyword-execution-failure path still emits the OBS-12 hint; aligning the skip table with the active library is a separate concern.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)