### PR TITLE
feat(discovery): Wave 3 — OBS-18B reranker + OBS-23A/B/20/33 (cross-LLM reviewed)

### DIFF
--- a/src/robotmcp/components/execution/rf_native_context_manager.py
+++ b/src/robotmcp/components/execution/rf_native_context_manager.py
@@ -1638,8 +1638,22 @@ class RobotFrameworkNativeContextManager:
                 "args": args or []
             }
 
-    def list_available_keywords(self, session_id: str) -> Dict[str, Any]:
-        """List available keyword names from imported libraries and resources in this session."""
+    def list_available_keywords(
+        self,
+        session_id: str,
+        name_filter: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """List available keyword names from imported libraries and resources in this session.
+
+        OBS-23A — accepts optional ``name_filter`` (case-insensitive
+        substring match on keyword name) and ``limit`` (max entries
+        across library+resource union). When both omitted, behaviour
+        is identical to the pre-OBS-23A implementation.
+
+        ``total_before_trim`` and ``total_after_filter`` are surfaced
+        in the response so callers can detect when truncation occurred.
+        """
         try:
             if session_id not in self._session_contexts:
                 return {"success": False, "error": "No RF context for session", "session_id": session_id}
@@ -1675,12 +1689,46 @@ class RobotFrameworkNativeContextManager:
             except Exception:
                 pass
 
+            # OBS-23A — capture pre-trim totals before any filtering.
+            total_before_trim = len(library_keywords) + len(resource_keywords)
+
+            # Apply name_filter (case-insensitive substring on `name`)
+            if name_filter:
+                needle = name_filter.lower().strip()
+                if needle:
+                    library_keywords = [
+                        kw for kw in library_keywords
+                        if needle in kw["name"].lower()
+                    ]
+                    resource_keywords = [
+                        kw for kw in resource_keywords
+                        if needle in kw["name"].lower()
+                    ]
+
+            total_after_filter = len(library_keywords) + len(resource_keywords)
+
+            # Apply limit across the union (library first, then resource).
+            # NB: limit is applied AFTER filtering — agents that ask for
+            # `query="click", limit=5` get up to 5 hits whose name
+            # contains "click", not 5 random keywords from the session.
+            if isinstance(limit, int) and limit > 0:
+                remaining = limit
+                if len(library_keywords) > remaining:
+                    library_keywords = library_keywords[:remaining]
+                    resource_keywords = []
+                else:
+                    remaining -= len(library_keywords)
+                    resource_keywords = resource_keywords[:remaining]
+
             return {
                 "success": True,
                 "session_id": session_id,
                 "libraries_count": len(list(namespace.libraries)),
                 "library_keywords": library_keywords,
                 "resource_keywords": resource_keywords,
+                # OBS-23A diagnostics so callers see the filter/limit effect.
+                "total_before_trim": total_before_trim,
+                "total_after_filter": total_after_filter,
             }
         except Exception as e:
             return {"success": False, "error": str(e), "session_id": session_id}

--- a/src/robotmcp/components/keyword_matcher.py
+++ b/src/robotmcp/components/keyword_matcher.py
@@ -1,9 +1,11 @@
 """Keyword Matcher component for semantic matching of Robot Framework keywords."""
 
+import os
 import re
 import logging
 from typing import Any, Dict, List, Optional, Tuple
-from dataclasses import dataclass
+import dataclasses
+from dataclasses import dataclass, field
 import asyncio
 from difflib import SequenceMatcher
 
@@ -44,6 +46,279 @@ class KeywordMatch:
     argument_types: List[str]
     documentation: str
     usage_example: Optional[str] = None
+    # OBS-18B — RF tags carried through the matcher pipeline so the
+    # action-class reranker can classify keywords (per OBS-18A v2
+    # design). Default empty list to keep existing call-sites
+    # backward-compatible.
+    tags: List[str] = field(default_factory=list)
+
+
+# ----------------------------------------------------------------------------
+# OBS-18B — Action-class reranker (per OBS-18A v2 design)
+# ----------------------------------------------------------------------------
+#
+# The matcher's pre-rerank confidence reflects per-strategy local optima
+# (SequenceMatcher overlap + tag-boost + pattern similarity). High
+# confidence doesn't always mean the keyword performs the queried action
+# — e.g., S02 ("select dropdown option by visible label") ranks
+# `Element Should Be Visible` at 0.87 because "visible" matches both
+# query and keyword name.
+#
+# The reranker classifies BOTH the query and each keyword into one of
+# 9 action classes, then down-weights mismatches. A separate confidence
+# cap fires when (A) top-3 spans ≥3 distinct classes (uncertain
+# matcher) OR (B) query is `unknown` and the top match has an
+# opinionated class above the cap threshold.
+#
+# Feature flag: ROBOTMCP_MATCHER_RERANK (off → no-op; on → reranker
+# active). Defaults to on in v0.34+ per OBS-18A v2 rollback plan.
+
+
+_QUERY_TRIGGERS: Dict[str, Tuple[str, ...]] = {
+    # Order matters when triggers overlap; first match wins.
+    "wait":     ("wait until", "wait for", "wait ", "sleep", "pause",
+                 "delay", "timeout"),
+    "navigate": ("go to", "navigate", "visit", "open page", "open url",
+                 "load url", "new page"),
+    "select":   ("select dropdown", "select option", "select from list",
+                 "choose dropdown", "pick from", "dropdown option"),
+    "fill":     ("fill ", "type ", "enter ", "input ", "set value",
+                 "set text", "write "),
+    "assert":   ("should ", "verify ", "must be", "ensure ", "expect ",
+                 "page contains", "page should"),
+    "query":    ("get ", "read ", "fetch ", "retrieve ", "current ",
+                 "value of", "count of"),
+    "control":  ("iterate", "loop ", "repeat ", "for each",
+                 "conditionally", "run keyword"),
+    "click":    ("click", "press", "tap", "push button", "hit"),
+}
+
+
+def _classify_query_action_class(query: str) -> str:
+    """Return action class for a natural-language query.
+
+    Determines intent from trigger phrases. Order matters — more
+    specific intents (wait, navigate) checked before broad ones
+    (click). Returns 'unknown' when no trigger matches.
+    """
+    q = (query or "").lower().strip()
+    if not q:
+        return "unknown"
+    for cls, triggers in _QUERY_TRIGGERS.items():
+        for trig in triggers:
+            if trig in q:
+                return cls
+    return "unknown"
+
+
+def classify_keyword_action(name: str, tags: List[str]) -> str:
+    """Return action class for a keyword. Deterministic; same inputs
+    always produce same output.
+
+    Precedence (per OBS-18A v2 design):
+      Wait → BrowserControl → Getter → Assertion → Setter+name → name-pattern
+
+    Tag values are case-normalised + space-stripped, so both
+    ``PageContent`` and ``Page Content`` map to the same set entry.
+    None entries in tags are filtered defensively.
+    """
+    name_lower = (name or "").lower()
+    tag_set = {
+        (t or "").lower().replace(" ", "")
+        for t in (tags or [])
+        if t
+    }
+
+    # Priority 1: Wait wins (most specific intent)
+    if "wait" in tag_set:
+        return "wait"
+    # Priority 2: BrowserControl wins over Setter (Go To, New Page tagged BOTH)
+    if "browsercontrol" in tag_set:
+        return "navigate"
+    # Priority 3: Getter wins over Assertion when co-tagged
+    if "getter" in tag_set:
+        return "query"
+    # Priority 4: Pure Assertion (no Getter) — Should*, Page Should*
+    if "assertion" in tag_set:
+        return "assert"
+    # Priority 5: Setter — context-dependent via name pattern
+    if "setter" in tag_set:
+        if name_lower.startswith((
+            "select options", "select option", "select from",
+            "select checkbox", "deselect options", "deselect checkbox",
+        )):
+            return "select"
+        if name_lower.startswith((
+            "fill text", "fill secret", "type text", "type secret",
+            "input text", "input password", "input secret",
+            "set text", "press keys",
+        )):
+            return "fill"
+        return "click"  # default Setter
+
+    # Priority 6: name-pattern fallback (SL, BuiltIn, resource kws)
+    if name_lower.startswith("wait") or name_lower == "sleep":
+        return "wait"
+    if name_lower.startswith((
+        "go to", "navigate", "new page", "new browser",
+        "new context", "new persistent context",
+        "open browser", "open page",
+    )):
+        return "navigate"
+    if name_lower.startswith(("select from", "select options",
+                              "deselect", "select checkbox")):
+        return "select"
+    if name_lower.startswith(("click", "tap", "press", "double click")):
+        return "click"
+    if name_lower.startswith(("fill", "type", "input text", "type text",
+                              "input password", "set text", "press keys",
+                              "send keys")):
+        return "fill"
+    # Pure-assertion check before pure-query so ``Element Should Be
+    # Visible`` etc. don't get mis-classified as control.
+    if (name_lower.startswith(("should ", "page should",
+                               "element should"))
+            or " should be " in f" {name_lower} "):
+        return "assert"
+    if name_lower.startswith(("get ", "fetch ", "read ")):
+        return "query"
+    if name_lower.startswith(("run keyword", "repeat keyword",
+                              "for each", "evaluate")):
+        return "control"
+
+    return "unknown"
+
+
+def _reranker_enabled() -> bool:
+    """Feature flag — ROBOTMCP_MATCHER_RERANK env var. Defaults to
+    ON (1) per OBS-18A v2 rollback plan. Set to '0' / 'false' / 'off'
+    to disable.
+    """
+    val = os.getenv("ROBOTMCP_MATCHER_RERANK", "1").strip().lower()
+    return val not in ("0", "false", "off", "no", "")
+
+
+def apply_action_class_reranker(
+    matches: List[KeywordMatch],
+    query_action_class: str,
+) -> List[KeywordMatch]:
+    """Down-weight matches whose action class doesn't match the
+    query's class. Caller-supplied confidence cap is applied
+    separately by ``apply_confidence_cap``.
+
+    Uses ``dataclasses.replace`` for the down-weight rebuild (per
+    Codex/Claude round-1 perf review — ~5x faster than rebuilding
+    7 explicit kwargs).
+    """
+    if query_action_class == "unknown" or not matches:
+        # Abstain — preserve matcher's original ranking.
+        return matches
+    downweight = float(os.getenv("ROBOTMCP_RERANK_DOWNWEIGHT", "0.6"))
+    reranked: List[KeywordMatch] = []
+    for m in matches:
+        kw_class = classify_keyword_action(m.keyword_name, m.tags)
+        if kw_class == query_action_class:
+            reranked.append(m)  # confidence unchanged
+        else:
+            reranked.append(dataclasses.replace(
+                m, confidence=m.confidence * downweight,
+            ))
+    # Re-sort by the new confidence
+    return sorted(reranked, key=lambda x: x.confidence, reverse=True)
+
+
+def apply_confidence_cap_dict(
+    matches: List[Dict[str, Any]],
+    query_action_class: str,
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Variant of ``apply_confidence_cap`` operating on the dict shape
+    used post-library-filter in ``server.find_keywords``. Used by
+    OBS-18B to re-apply the cap to the actual user-visible top match
+    after library filtering may have shuffled the matcher's top entry.
+
+    Returns (matches, low_confidence_top_match_flag).
+    """
+    if not matches:
+        return matches, False
+    cap = float(os.getenv("ROBOTMCP_RERANK_CAP", "0.5"))
+    top = matches[0]
+    top_name = top.get("keyword_name") or top.get("name") or ""
+    top_tags = top.get("tags") or []
+    top_conf = float(top.get("confidence", 0.0))
+    top_class = classify_keyword_action(top_name, top_tags)
+
+    trigger_b = (
+        query_action_class == "unknown"
+        and top_class != "unknown"
+    )
+
+    trigger_a = False
+    if len(matches) >= 3:
+        top3_classes = set()
+        for m in matches[:3]:
+            nm = m.get("keyword_name") or m.get("name") or ""
+            tg = m.get("tags") or []
+            top3_classes.add(classify_keyword_action(nm, tg))
+        trigger_a = len(top3_classes) >= 3
+
+    if not (trigger_a or trigger_b):
+        return matches, False
+
+    if top_conf > cap:
+        capped = dict(top)
+        capped["confidence"] = cap
+        return [capped] + list(matches[1:]), True
+    return matches, True
+
+
+def apply_confidence_cap(
+    matches: List[KeywordMatch],
+    query_action_class: str,
+) -> Tuple[List[KeywordMatch], bool]:
+    """Cap top-match confidence under two trigger conditions:
+
+    - Trigger A: top-3 spans ≥3 distinct action classes (divergent
+      ranking — matcher is uncertain).
+    - Trigger B (OBS-18A v2 — closes the S10 gap): query class is
+      ``unknown`` AND top match has an opinionated class AND its
+      confidence > cap threshold.
+
+    Returns (matches, low_confidence_top_match_flag).
+    """
+    if not matches:
+        return matches, False
+    cap = float(os.getenv("ROBOTMCP_RERANK_CAP", "0.5"))
+    top = matches[0]
+    top_class = classify_keyword_action(top.keyword_name, top.tags)
+
+    # Trigger B — unknown query + opinionated top → matcher reaches
+    # for a class the query doesn't ask for. Flag fires regardless of
+    # whether confidence happens to be above the cap (the agent
+    # benefits from knowing the matcher is uncertain). The actual
+    # confidence cap only applies when conf > cap.
+    trigger_b = (
+        query_action_class == "unknown"
+        and top_class != "unknown"
+    )
+
+    # Trigger A — divergent top-3
+    trigger_a = False
+    if len(matches) >= 3:
+        top3_classes = {
+            classify_keyword_action(m.keyword_name, m.tags)
+            for m in matches[:3]
+        }
+        trigger_a = len(top3_classes) >= 3
+
+    if not (trigger_a or trigger_b):
+        return matches, False
+
+    if top.confidence > cap:
+        capped_top = dataclasses.replace(top, confidence=cap)
+        return [capped_top] + list(matches[1:]), True
+    # Top is already at/below cap; still surface the flag so agents
+    # know the matcher is uncertain.
+    return matches, True
 
 @dataclass
 class KeywordInfo:
@@ -328,11 +603,28 @@ class KeywordMatcher:
             unique_matches = self._deduplicate_matches(matches)
             ranked_matches = self._rank_matches(unique_matches, normalized_action, context)
 
+            # OBS-18B — Action-class reranker + confidence cap.
+            # Gated by ROBOTMCP_MATCHER_RERANK env var (default ON).
+            # Pipeline order:
+            #   5. _rank_matches (sort by raw confidence) — existing
+            #   6. apply_action_class_reranker (NEW) — penalise mismatch
+            #   7. apply_confidence_cap (NEW) — surface uncertainty
+            #   8. limit slice (OBS-22) — caller-supplied trim
+            low_confidence_top_match = False
+            if _reranker_enabled() and ranked_matches:
+                query_class = _classify_query_action_class(action_description)
+                ranked_matches = apply_action_class_reranker(
+                    ranked_matches, query_class,
+                )
+                ranked_matches, low_confidence_top_match = apply_confidence_cap(
+                    ranked_matches, query_class,
+                )
+
             # OBS-22 — honour caller-supplied limit (default 10).
             effective_limit = limit if (isinstance(limit, int) and limit > 0) else 10
             top_matches = ranked_matches[:effective_limit]
-            
-            return {
+
+            response = {
                 "success": True,
                 "action_description": action_description,
                 "action_type": action_type,
@@ -344,13 +636,24 @@ class KeywordMatcher:
                         "arguments": match.arguments,
                         "argument_types": match.argument_types,
                         "documentation": match.documentation[:200] + "..." if len(match.documentation) > 200 else match.documentation,
-                        "usage_example": match.usage_example
+                        "usage_example": match.usage_example,
+                        # OBS-18B — propagate tags so the find_keywords
+                        # post-library-filter cap can re-classify the
+                        # actual surviving top match.
+                        "tags": list(match.tags or []),
                     } for match in top_matches
                 ],
                 "total_matches": len(unique_matches),
                 "recommendations": self._generate_usage_recommendations(top_matches, normalized_action)
             }
-            
+            # OBS-18B — surface the cap flag at the matcher-response
+            # level. find_keywords wraps under `result` so agents see
+            # ``result.low_confidence_top_match: true`` when the cap
+            # fires.
+            if low_confidence_top_match:
+                response["low_confidence_top_match"] = True
+            return response
+
         except Exception as e:
             logger.error(f"Error discovering keywords: {e}")
             return {
@@ -425,7 +728,8 @@ class KeywordMatcher:
                                     arguments=keyword_info.arguments,
                                     argument_types=keyword_info.argument_types,
                                     documentation=keyword_info.documentation,
-                                    usage_example=self._generate_usage_example(keyword_info, action)
+                                    usage_example=self._generate_usage_example(keyword_info, action),
+                                    tags=list(keyword_info.tags or []),
                                 ))
         
         return matches
@@ -464,7 +768,8 @@ class KeywordMatcher:
                             arguments=keyword_info.arguments,
                             argument_types=keyword_info.argument_types,
                             documentation=keyword_info.documentation,
-                            usage_example=self._generate_usage_example(keyword_info, action)
+                            usage_example=self._generate_usage_example(keyword_info, action),
+                            tags=list(keyword_info.tags or []),
                         ))
         
         except Exception as e:
@@ -533,7 +838,8 @@ class KeywordMatcher:
                         arguments=keyword_info.arguments,
                         argument_types=keyword_info.argument_types,
                         documentation=keyword_info.documentation,
-                        usage_example=self._generate_usage_example(keyword_info, action)
+                        usage_example=self._generate_usage_example(keyword_info, action),
+                        tags=list(keyword_info.tags or []),
                     ))
         
         return matches

--- a/src/robotmcp/components/keyword_matcher.py
+++ b/src/robotmcp/components/keyword_matcher.py
@@ -97,18 +97,33 @@ _QUERY_TRIGGERS: Dict[str, Tuple[str, ...]] = {
 def _classify_query_action_class(query: str) -> str:
     """Return action class for a natural-language query.
 
-    Determines intent from trigger phrases. Order matters — more
-    specific intents (wait, navigate) checked before broad ones
-    (click). Returns 'unknown' when no trigger matches.
+    Determines intent from trigger phrases. Compound queries that
+    match multiple opinionated classes (e.g., "wait for X and then
+    click Y") classify as ``ambiguous`` — the reranker abstains
+    instead of arbitrarily picking the first-trigger class which
+    would penalise the keywords matching the OTHER class.
+
+    Per Wave-3 review (Copilot + Claude subagent caught the S12
+    regression where "wait for ... and click ..." was classified
+    as ``wait`` because of trigger ordering, demoting click-class
+    keywords below their pre-Wave-3 baselines).
+
+    Returns ``unknown`` when no trigger matches.
     """
     q = (query or "").lower().strip()
     if not q:
         return "unknown"
+    matched: set[str] = set()
     for cls, triggers in _QUERY_TRIGGERS.items():
         for trig in triggers:
             if trig in q:
-                return cls
-    return "unknown"
+                matched.add(cls)
+                break
+    if not matched:
+        return "unknown"
+    if len(matched) > 1:
+        return "ambiguous"
+    return next(iter(matched))
 
 
 def classify_keyword_action(name: str, tags: List[str]) -> str:
@@ -210,8 +225,10 @@ def apply_action_class_reranker(
     Codex/Claude round-1 perf review — ~5x faster than rebuilding
     7 explicit kwargs).
     """
-    if query_action_class == "unknown" or not matches:
-        # Abstain — preserve matcher's original ranking.
+    if query_action_class in ("unknown", "ambiguous") or not matches:
+        # Abstain — preserve matcher's original ranking. ``ambiguous``
+        # covers compound queries like "wait for X and click Y" where
+        # picking either class would penalise the other.
         return matches
     downweight = float(os.getenv("ROBOTMCP_RERANK_DOWNWEIGHT", "0.6"))
     reranked: List[KeywordMatch] = []

--- a/src/robotmcp/domains/artifact_output/services.py
+++ b/src/robotmcp/domains/artifact_output/services.py
@@ -77,6 +77,14 @@ DEFAULT_RULES: List[ExternalizationRule] = [
     # the typical 2-entry ambiguous case) stays inline because
     # ``should_externalize`` checks total serialised size first.
     ExternalizationRule(tool_name="get_keyword_info", field_path="matches"),
+    # OBS-23B-impl Phase 1 — session strategy dual-emits legacy
+    # ``library_keywords`` / ``resource_keywords`` at top level.
+    # The existing ``find_keywords.result`` rule covers the new
+    # unified shape (result.matches); these rules cover the legacy
+    # mirror fields so they don't leak inline during the deprecation
+    # window. Target removal: OBS-35 (v0.36).
+    ExternalizationRule(tool_name="find_keywords", field_path="library_keywords"),
+    ExternalizationRule(tool_name="find_keywords", field_path="resource_keywords"),
     # execute_step
     ExternalizationRule(
         tool_name="execute_step", field_path="session_variables"

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2175,6 +2175,53 @@ def _rebuild_post_filter_recommendations(
     return recs
 
 
+def _build_session_recommendations(
+    matches: List[Dict[str, Any]], query: str,
+) -> List[str]:
+    """OBS-23B-impl — build honest recommendations prose for the
+    session strategy.
+
+    Session strategy is a literal name-substring lookup. There's no
+    ranking, so the prose names the kind of match found (exact name
+    vs substring) WITHOUT a fake confidence number (round-1 review
+    flagged ``confidence: 1.00`` as dishonest).
+    """
+    if not matches:
+        return [
+            "No keywords match the query in this session.",
+            "- Verify the query string",
+            "- Check the session's imported libraries",
+        ]
+    q_lower = (query or "").lower().strip()
+    exact = None
+    if q_lower:
+        for m in matches:
+            if m.get("keyword_name", "").lower() == q_lower:
+                exact = m
+                break
+    top = exact or matches[0]
+    top_name = top.get("keyword_name", "")
+    top_lib = top.get("library") or top.get("source") or "session"
+    if exact:
+        recs = [f"Exact match: {top_name} ({top_lib})"]
+    else:
+        if q_lower:
+            recs = [
+                f"Substring match: {top_name} ({top_lib}); "
+                f"no exact name match for '{query}'"
+            ]
+        else:
+            recs = [f"First in session: {top_name} ({top_lib})"]
+    # Required-arguments line intentionally OMITTED — session strategy
+    # doesn't have per-keyword arg info from list_available_keywords.
+    # Agents fetch full info via get_keyword_info(mode="keyword",
+    # keyword_name=..., session_id=...) if needed.
+    if len(matches) > 1:
+        alt_names = [m.get("keyword_name", "") for m in matches[1:4]]
+        recs.append(f"Alternative options: {', '.join(alt_names)}")
+    return recs
+
+
 def _build_filter_diagnostics(
     excluded: List[Dict[str, Any]],
     applied: str,
@@ -2689,14 +2736,81 @@ async def find_keywords(
             name_filter=query if query else None,
             limit=limit_value,
         )
-        payload.update({"strategy": "session", "query": query})
+
+        # OBS-23B-impl Phase 1 — dual-emit:
+        # 1. Build the unified ``result.matches`` shape that matches
+        #    semantic/pattern/catalog strategies.
+        # 2. Preserve the legacy top-level ``library_keywords`` /
+        #    ``resource_keywords`` / ``libraries_count`` fields for
+        #    backwards-compat through Phase 2 (target v0.34) →
+        #    Phase 3 removal (target v0.36).
+        # Per round-1 review fixes: match_type replaces dishonest
+        # confidence=1.00; match_count dropped (redundant with
+        # len(matches)).
+        unified_matches: List[Dict[str, Any]] = []
+        for kw in (payload.get("library_keywords") or []):
+            unified_matches.append({
+                "keyword_name": kw.get("name", ""),
+                "library": kw.get("library"),
+                "full_name": kw.get("full_name", kw.get("name", "")),
+                "match_type": "exact_substring",
+                "source_type": "library",
+                "source": None,
+            })
+        for kw in (payload.get("resource_keywords") or []):
+            unified_matches.append({
+                "keyword_name": kw.get("name", ""),
+                "library": None,
+                "full_name": kw.get("full_name", kw.get("name", "")),
+                "match_type": "exact_substring",
+                "source_type": "resource",
+                "source": kw.get("resource"),
+            })
+
+        # OBS-23B recommendations (no fake confidence — honest prose
+        # about how the match was found).
+        recommendations = _build_session_recommendations(
+            unified_matches, query,
+        )
+
+        # Build the response with BOTH the unified shape under `result`
+        # AND the legacy top-level fields (Phase 1 dual-emit).
+        response: Dict[str, Any] = {
+            "success": payload.get("success", True),
+            "strategy": "session",
+            "query": query,
+            "result": {
+                "matches": unified_matches,
+                "library_count": len({
+                    m["library"] for m in unified_matches if m["library"]
+                }),
+                "resource_count": len({
+                    m["source"] for m in unified_matches if m["source"]
+                }),
+                "recommendations": recommendations,
+            },
+            # OBS-23B Phase 1 legacy fields (target removal: OBS-35 / v0.36)
+            "library_keywords": payload.get("library_keywords") or [],
+            "resource_keywords": payload.get("resource_keywords") or [],
+            "libraries_count": payload.get("libraries_count", 0),
+        }
+        # OBS-23A diagnostic fields surface at top level too
+        # (pre-trim vs post-filter visibility for the agent).
+        if "total_before_trim" in payload:
+            response["result"]["total_before_trim"] = payload["total_before_trim"]
+        if "total_after_filter" in payload:
+            response["result"]["total_after_filter"] = payload["total_after_filter"]
+        # Propagate session error path if applicable
+        if not payload.get("success") and payload.get("error"):
+            response["error"] = payload["error"]
+
         # ADR-015: Externalize large fields to artifacts
-        payload = _externalize_response("find_keywords", session_id, payload)
+        response = _externalize_response("find_keywords", session_id, response)
         # Track for instruction learning
         _track_tool_result(
-            session_id, "find_keywords", {"query": query, "strategy": strategy}, payload
+            session_id, "find_keywords", {"query": query, "strategy": strategy}, response
         )
-        return payload
+        return response
 
     return {"success": False, "error": f"Unsupported strategy '{strategy}'"}
 

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2621,7 +2621,14 @@ async def find_keywords(
                 "error": "session_id is required when strategy='session'",
             }
         mgr = get_rf_native_context_manager()
-        payload = mgr.list_available_keywords(session_id)
+        # OBS-23A — pass the caller's ``query`` as a name_filter and
+        # ``limit_value`` as the trim cap. Pre-OBS-23A behaviour
+        # (no filter, no limit) is preserved when both are absent.
+        payload = mgr.list_available_keywords(
+            session_id,
+            name_filter=query if query else None,
+            limit=limit_value,
+        )
         payload.update({"strategy": "session", "query": query})
         # ADR-015: Externalize large fields to artifacts
         payload = _externalize_response("find_keywords", session_id, payload)

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2504,6 +2504,28 @@ async def find_keywords(
                     )
                 )
 
+            # OBS-18B — re-apply the action-class confidence cap to
+            # the post-filter top match. The matcher's pre-filter cap
+            # may have targeted a match the filter then removed,
+            # leaving the actual user-visible top match uncapped.
+            try:
+                from robotmcp.components.keyword_matcher import (
+                    _classify_query_action_class,
+                    _reranker_enabled,
+                    apply_confidence_cap_dict,
+                )
+                if _reranker_enabled() and discovery.get("matches"):
+                    qclass = _classify_query_action_class(query)
+                    capped_matches, low_conf = apply_confidence_cap_dict(
+                        discovery["matches"], qclass,
+                    )
+                    discovery["matches"] = capped_matches
+                    if low_conf:
+                        discovery["low_confidence_top_match"] = True
+            except Exception:
+                # Reranker enrichment is best-effort.
+                pass
+
         result = {
             "success": bool(discovery.get("success", True)),
             "strategy": "semantic",

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2395,6 +2395,24 @@ async def find_keywords(
             if session_pref:
                 effective_library_preference = session_pref
                 library_filter_source = "session"
+            else:
+                # OBS-20 — discovery/execution filter symmetry. The
+                # Browser plugin's execute-time validation at
+                # ``browser_plugin.py:312-321`` rejects SeleniumLibrary
+                # keywords whenever Browser is imported (regardless of
+                # explicit preference). The SeleniumLibrary plugin is
+                # ASYMMETRIC — it only acts on explicit
+                # ``selenium*``-prefixed preference. Mirror those exact
+                # rules here so discovery surfaces match what
+                # execute_step will accept.
+                imported = set(
+                    getattr(session, "imported_libraries", []) or []
+                )
+                # Browser is the only plugin with imported-fallback.
+                # SL plugin does NOT mirror this — keep the asymmetry.
+                if "Browser" in imported:
+                    effective_library_preference = "Browser"
+                    library_filter_source = "session_imported"
 
     if strategy_norm in {"semantic", "intent"}:
         # OBS-22 — thread ``limit`` into the matcher so the matcher's

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2490,24 +2490,16 @@ async def find_keywords(
                 for m in filtered_matches
             ]
             discovery["filtered_count"] = len(excluded)
-            # Regenerate recommendations against the post-filter
-            # matches — the matcher emits its recommendations BEFORE
-            # we apply the library filter, so without this fix the
-            # ``Best match: X`` line can name an excluded keyword.
-            # Only rebuild when the filter actually trimmed entries —
-            # if ``excluded`` is empty, the matcher's recommendations
-            # are still accurate and we avoid the no-op work.
-            if excluded:
-                discovery["recommendations"] = (
-                    _rebuild_post_filter_recommendations(
-                        discovery["matches"]
-                    )
-                )
 
-            # OBS-18B — re-apply the action-class confidence cap to
-            # the post-filter top match. The matcher's pre-filter cap
-            # may have targeted a match the filter then removed,
-            # leaving the actual user-visible top match uncapped.
+            # OBS-18B post-filter cap MUST run BEFORE the
+            # recommendation rebuild so the rebuild can read the
+            # capped confidence value (round-3 review caught: pre-fix
+            # ordering produced contradictory output where
+            # ``matches[0].confidence`` was 0.50 but
+            # ``recommendations[0]`` still said "confidence: 0.72").
+            # The matcher's pre-filter cap may have targeted a match
+            # the filter then removed, leaving the actual user-
+            # visible top match uncapped.
             try:
                 from robotmcp.components.keyword_matcher import (
                     _classify_query_action_class,
@@ -2520,11 +2512,30 @@ async def find_keywords(
                         discovery["matches"], qclass,
                     )
                     discovery["matches"] = capped_matches
+                    # CLEAR the flag if no trigger fired post-filter
+                    # (otherwise a matcher-set flag would persist as a
+                    # false positive once the filter shuffled the top
+                    # match into a non-divergent set).
                     if low_conf:
                         discovery["low_confidence_top_match"] = True
+                    else:
+                        discovery.pop("low_confidence_top_match", None)
             except Exception:
                 # Reranker enrichment is best-effort.
                 pass
+
+            # Regenerate recommendations against the post-filter,
+            # post-cap matches — the matcher emits its
+            # recommendations BEFORE we apply the library filter +
+            # post-filter cap. Only rebuild when the filter actually
+            # trimmed entries — if ``excluded`` is empty, the
+            # matcher's recommendations are still accurate.
+            if excluded:
+                discovery["recommendations"] = (
+                    _rebuild_post_filter_recommendations(
+                        discovery["matches"]
+                    )
+                )
 
         result = {
             "success": bool(discovery.get("success", True)),
@@ -2789,6 +2800,31 @@ async def find_keywords(
                 "source": kw.get("resource"),
             })
 
+        # OBS-33 (Wave-3 round-1 review fix) — apply library filter +
+        # strict_library to the unified matches in session strategy.
+        # Pre-fix: the session branch entirely bypassed
+        # ``_filter_keywords_by_session_library``, so OBS-33 had no
+        # effect on this strategy. Now we apply the SAME resolved
+        # preference (effective_library_preference) + strict_library
+        # flag that semantic/pattern/catalog use. Wraps each match
+        # into the filter's expected ``{name, library, ...}`` shape,
+        # then converts back. Resource entries (library=None) are
+        # exempt — filter operates on library names only.
+        session_excluded: List[Dict[str, Any]] = []
+        if effective_library_preference and unified_matches:
+            lib_matches = [
+                {"name": m["keyword_name"], "library": m["library"], **m}
+                for m in unified_matches if m.get("library")
+            ]
+            resource_matches = [m for m in unified_matches if not m.get("library")]
+            kept, session_excluded = _filter_keywords_by_session_library(
+                lib_matches, session_id, effective_library_preference,
+                strict_library=strict_library,
+            )
+            unified_matches = [
+                {k: v for k, v in m.items() if k != "name"} for m in kept
+            ] + resource_matches
+
         # OBS-23B recommendations (no fake confidence — honest prose
         # about how the match was found).
         recommendations = _build_session_recommendations(
@@ -2801,6 +2837,10 @@ async def find_keywords(
             "success": payload.get("success", True),
             "strategy": "session",
             "query": query,
+            # OBS-23B-impl backwards-compat fix (Wave-3 round-1):
+            # propagate ``session_id`` from the legacy backend payload
+            # so callers reading it at top level continue to work.
+            "session_id": payload.get("session_id", session_id),
             "result": {
                 "matches": unified_matches,
                 "library_count": len({
@@ -2816,12 +2856,22 @@ async def find_keywords(
             "resource_keywords": payload.get("resource_keywords") or [],
             "libraries_count": payload.get("libraries_count", 0),
         }
-        # OBS-23A diagnostic fields surface at top level too
+        # OBS-23A diagnostic fields surface under ``result``
         # (pre-trim vs post-filter visibility for the agent).
         if "total_before_trim" in payload:
             response["result"]["total_before_trim"] = payload["total_before_trim"]
         if "total_after_filter" in payload:
             response["result"]["total_after_filter"] = payload["total_after_filter"]
+        # OBS-33 — surface filter diagnostics when filtering applied
+        if session_excluded:
+            response.update(
+                _build_filter_diagnostics(
+                    session_excluded,
+                    effective_library_preference,
+                    library_filter_source,
+                    strict_library=strict_library,
+                )
+            )
         # Propagate session error path if applicable
         if not payload.get("success") and payload.get("error"):
             response["error"] = payload["error"]

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -2038,6 +2038,7 @@ def _filter_keywords_by_session_library(
     keywords: List[Dict[str, Any]],
     session_id: str | None,
     session_library_preference: str | None,
+    strict_library: bool = False,
 ) -> tuple[List[Dict[str, Any]], List[Dict[str, str]]]:
     """Filter keywords to only include those compatible with session library preference.
 
@@ -2047,6 +2048,12 @@ def _filter_keywords_by_session_library(
         keywords: List of keyword dicts with 'name' and 'library' fields
         session_id: Session ID for logging
         session_library_preference: Explicit library preference (e.g., "Browser", "SeleniumLibrary")
+        strict_library: OBS-33 — when True AND a preference is set,
+            exclude EVERY library that isn't the named one (not just
+            the plugin's incompatible siblings). Compatible "neutral"
+            libraries like BuiltIn/Collections/etc. are dropped too.
+            Default False preserves the existing "incompatible-only"
+            behaviour.
 
     Returns:
         Tuple of (filtered_keywords, excluded_keywords_with_alternatives)
@@ -2059,6 +2066,15 @@ def _filter_keywords_by_session_library(
     excluded_libraries = set(
         plugin_manager.get_incompatible_libraries(session_library_preference)
     )
+
+    if strict_library:
+        # OBS-33 — extend excluded_libraries to cover ALL non-preferred
+        # libraries. Compute from the actual keywords list so we don't
+        # have to enumerate every possible library globally.
+        all_libs_in_input = {kw.get("library", "") for kw in keywords if kw.get("library")}
+        excluded_libraries = excluded_libraries | (
+            all_libs_in_input - {session_library_preference}
+        )
 
     if not excluded_libraries:
         return keywords, []
@@ -2098,7 +2114,8 @@ def _filter_keywords_by_session_library(
     if excluded_with_alternatives:
         logger.info(
             f"Session {session_id}: Filtered out {len(excluded_with_alternatives)} "
-            f"keywords from incompatible libraries: {list(excluded_libraries)}"
+            f"keywords from incompatible libraries: {list(excluded_libraries)} "
+            f"(strict_library={strict_library})"
         )
 
     return filtered_keywords, excluded_with_alternatives
@@ -2162,6 +2179,7 @@ def _build_filter_diagnostics(
     excluded: List[Dict[str, Any]],
     applied: str,
     source: str,
+    strict_library: bool = False,
 ) -> Dict[str, Any]:
     """Build compact response diagnostics for a library filter pass.
 
@@ -2199,6 +2217,11 @@ def _build_filter_diagnostics(
             "applied": applied,
             "source": source,
             "count": len(excluded),
+            # OBS-33 — agent visibility into which filter rule fired.
+            # "strict" = ALL non-preferred libraries excluded.
+            # "compatible" = only plugin-table-incompatible siblings
+            # excluded (BuiltIn, Collections, etc. stay visible).
+            "mode": "strict" if strict_library else "compatible",
         }
     }
     if from_library:
@@ -2227,6 +2250,7 @@ async def find_keywords(
     library_name: str | None = None,
     current_state: Dict[str, Any] | None = None,
     limit: int | None = None,
+    strict_library: bool = False,
 ) -> Dict[str, Any]:
     """Discover Robot Framework keywords using multiple strategies.
 
@@ -2263,6 +2287,18 @@ async def find_keywords(
                       lookup to this library.
         current_state: Optional state payload to improve semantic matching.
         limit: Optional maximum number of results to return.
+        strict_library: OBS-33 — when True AND a library preference is
+                        set (via ``library_name`` or session
+                        ``explicit_library_preference``), exclude EVERY
+                        library that isn't the preferred one. Default
+                        behaviour (False) preserves "compatible siblings"
+                        — BuiltIn / Collections / String / DateTime etc.
+                        remain visible alongside the preferred library.
+                        Use strict mode to scope discovery tightly to
+                        a single library (e.g., pattern ``"Get*"`` +
+                        ``library_name="Browser"`` +
+                        ``strict_library=True`` → Browser keywords only,
+                        no BuiltIn helpers).
 
     Returns:
         Dict[str, Any]: Discovery result:
@@ -2380,7 +2416,8 @@ async def find_keywords(
                 for m in discovery.get("matches", [])
             ]
             filtered_matches, excluded = _filter_keywords_by_session_library(
-                matches_for_filter, session_id, effective_library_preference
+                matches_for_filter, session_id, effective_library_preference,
+                strict_library=strict_library,
             )
             # Convert back to original format
             discovery["matches"] = [
@@ -2414,6 +2451,7 @@ async def find_keywords(
                     excluded,
                     effective_library_preference,
                     library_filter_source,
+                    strict_library=strict_library,
                 )
             )
         # ADR-015: Externalize large fields to artifacts
@@ -2437,7 +2475,8 @@ async def find_keywords(
         excluded = []
         if effective_library_preference:
             matches, excluded = _filter_keywords_by_session_library(
-                matches, session_id, effective_library_preference
+                matches, session_id, effective_library_preference,
+                strict_library=strict_library,
             )
 
         if limit_value is not None:
@@ -2469,6 +2508,7 @@ async def find_keywords(
                     excluded,
                     effective_library_preference,
                     library_filter_source,
+                    strict_library=strict_library,
                 )
             )
         # ADR-015: Externalize large fields to artifacts
@@ -2506,7 +2546,8 @@ async def find_keywords(
         excluded = []
         if effective_library_preference:
             catalog, excluded = _filter_keywords_by_session_library(
-                catalog, session_id, effective_library_preference
+                catalog, session_id, effective_library_preference,
+                strict_library=strict_library,
             )
 
         # OBS-25 — Hard-cap unscoped catalog dumps to prevent the 97k
@@ -2582,6 +2623,7 @@ async def find_keywords(
                     excluded,
                     effective_library_preference,
                     library_filter_source,
+                    strict_library=strict_library,
                 )
             )
 

--- a/tests/unit/test_find_keywords_library_name_filter.py
+++ b/tests/unit/test_find_keywords_library_name_filter.py
@@ -649,10 +649,14 @@ class TestRecommendationsRebuild:
         assert "Set Window Position" not in recs[0], (
             f"recommendations[0] still references excluded keyword: {recs[0]!r}"
         )
-        # The post-filter top match is the Browser ``Click`` entry
-        # (confidence 0.80).
+        # The post-filter top match is the Browser ``Click`` entry.
+        # OBS-18B (Wave 3 round-1 fix): query="anything" classifies as
+        # "unknown"; ``Click`` is an opinionated class → Trigger B
+        # fires → confidence capped at 0.50. Recommendation
+        # correctly reports the CAPPED value (cap runs BEFORE rebuild
+        # per Wave-3 round-1 ordering fix).
         assert "Click" in recs[0]
-        assert "confidence: 0.80" in recs[0]
+        assert "confidence: 0.50" in recs[0]
 
     async def test_recommendations_carry_post_filter_arguments(self, patched_engines):
         """The "Required arguments" line in recommendations must

--- a/tests/unit/test_obs_18b_matcher_reranker.py
+++ b/tests/unit/test_obs_18b_matcher_reranker.py
@@ -1,0 +1,412 @@
+"""OBS-18B — Action-class reranker for the semantic matcher.
+
+Implements the OBS-18A v2 design: classify query + each keyword into
+9 action classes; down-weight mismatches; cap top-match confidence
+under Triggers A (top-3 divergent) or B (unknown query + opinionated
+top match above cap).
+
+These tests pin:
+1. ``classify_keyword_action`` deterministic + v2 precedence-correct
+   for real Browser tags (verified against ``LibraryDocumentation('Browser')``
+   sample outputs from OBS-18A v2 worked-examples table).
+2. ``_classify_query_action_class`` recognises all 9 query intents.
+3. ``apply_action_class_reranker`` down-weights mismatches; abstains
+   on ``unknown`` query.
+4. ``apply_confidence_cap`` fires under Trigger A (divergent top-3)
+   and Trigger B (unknown query + opinionated high-confidence top).
+5. End-to-end: S02 outcome — top match becomes ``Select From List By
+   Label`` (the AC #4a fix).
+6. End-to-end: S10 outcome — ``low_confidence_top_match: true``
+   surfaces in the response (the AC #4b fix via Trigger B).
+7. Feature flag ``ROBOTMCP_MATCHER_RERANK=0`` disables the reranker
+   (rollback path).
+8. ``KeywordMatch.tags`` field carries tags through.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robotmcp.components.keyword_matcher import (
+    KeywordMatch,
+    _classify_query_action_class,
+    apply_action_class_reranker,
+    apply_confidence_cap,
+    classify_keyword_action,
+)
+
+
+def _mk_match(name, library, confidence, tags=None):
+    return KeywordMatch(
+        keyword_name=name, library=library, confidence=confidence,
+        arguments=[], argument_types=[], documentation="",
+        usage_example=None, tags=list(tags or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Classifier — verified against actual Browser library tag distribution
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordClassifier:
+    """v2 precedence-correct classifier for real Browser tags."""
+
+    @pytest.mark.parametrize("name,tags,expected", [
+        # Browser keywords — verified actual tags
+        ("Click",                  ["PageContent", "Setter"], "click"),
+        ("Fill Text",              ["PageContent", "Setter"], "fill"),
+        ("Type Text",              ["PageContent", "Setter"], "fill"),
+        ("Press Keys",             ["PageContent", "Setter"], "fill"),
+        ("Go To",                  ["BrowserControl", "Setter"], "navigate"),
+        ("New Page",               ["BrowserControl", "Setter"], "navigate"),
+        ("Select Options By",      ["PageContent", "Setter"], "select"),
+        ("Wait For Elements State",["PageContent", "Wait"], "wait"),
+        # Browser getter-asserts — getter wins over assertion (v1 had bug here)
+        ("Get Text",               ["Assertion", "Getter", "PageContent"], "query"),
+        ("Get Element Count",      ["Assertion", "Getter", "PageContent"], "query"),
+        # SL keywords — no tags, name-pattern fallback
+        ("Click Element",          [], "click"),
+        ("Click Button",           [], "click"),
+        ("Click Link",             [], "click"),
+        ("Input Text",             [], "fill"),
+        ("Input Password",         [], "fill"),
+        ("Open Browser",           [], "navigate"),
+        ("Go To",                  [], "navigate"),
+        ("Select From List By Label",   [], "select"),
+        ("Select From List By Value",   [], "select"),
+        ("Deselect All From List",      [], "select"),
+        ("Get Text",               [], "query"),
+        ("Get Element Attribute",  [], "query"),
+        ("Wait Until Element Is Visible", [], "wait"),
+        ("Page Should Contain",    [], "assert"),
+        ("Element Should Be Visible", [], "assert"),
+        # BuiltIn keywords
+        ("Should Be Equal",        [], "assert"),
+        ("Should Contain",         [], "assert"),
+        ("Run Keyword If",         [], "control"),
+        ("Repeat Keyword",         [], "control"),
+        ("Sleep",                  [], "wait"),
+        ("Get Length",             [], "query"),
+        # Unknown / unclassifiable
+        ("Set Window Position",    [], "unknown"),  # SL — not in patterns
+        ("My Custom Keyword",      [], "unknown"),
+        ("",                       [], "unknown"),
+    ])
+    def test_classifier(self, name, tags, expected):
+        assert classify_keyword_action(name, tags) == expected, (
+            f"{name} {tags!r} → expected {expected}, "
+            f"got {classify_keyword_action(name, tags)}"
+        )
+
+    def test_none_tags_handled(self):
+        # Robustness: None entry in tags must not crash
+        assert classify_keyword_action("Click", [None, "Setter"]) == "click"
+
+    def test_case_insensitive_tag_matching(self):
+        # Lower or upper case tags both match (e.g., "wait" vs "Wait")
+        assert classify_keyword_action("X", ["WAIT"]) == "wait"
+        assert classify_keyword_action("X", ["wait"]) == "wait"
+
+    def test_space_normalised_tag_matching(self):
+        # Browser has one outlier "Page Content" with space; treat as same tag
+        assert classify_keyword_action(
+            "Get Element States", ["Page Content", "Getter", "Assertion"],
+        ) == "query"
+
+
+class TestQueryClassifier:
+    @pytest.mark.parametrize("query,expected", [
+        ("click button", "click"),
+        ("press the submit button", "click"),
+        ("tap the link", "click"),
+        ("fill the form field", "fill"),
+        ("type into the input", "fill"),
+        ("enter username", "fill"),
+        ("input text value", "fill"),
+        ("set value to 10", "fill"),
+        ("go to url", "navigate"),
+        ("navigate to page", "navigate"),
+        ("visit website", "navigate"),
+        ("open page", "navigate"),
+        ("select dropdown option by label", "select"),
+        ("choose dropdown value", "select"),
+        ("verify text is shown", "assert"),
+        ("should contain message", "assert"),
+        ("expect element visible", "assert"),
+        ("wait until loaded", "wait"),
+        ("wait for element", "wait"),
+        ("sleep 2 seconds", "wait"),
+        ("get element text", "query"),
+        ("read the value", "query"),
+        ("fetch attribute", "query"),
+        ("iterate over rows", "control"),
+        ("for each item", "control"),
+        # Unknown — API queries, ambiguous prose
+        ("send http post request with json body", "unknown"),
+        ("banana telephone", "unknown"),
+        ("", "unknown"),
+    ])
+    def test_query_classification(self, query, expected):
+        assert _classify_query_action_class(query) == expected
+
+
+# ---------------------------------------------------------------------------
+# Reranker
+# ---------------------------------------------------------------------------
+
+
+class TestReranker:
+    """apply_action_class_reranker down-weights mismatches; abstains
+    on unknown."""
+
+    def test_match_class_keeps_confidence(self):
+        matches = [
+            _mk_match("Click", "Browser", 0.85,
+                      tags=["PageContent", "Setter"]),
+        ]
+        out = apply_action_class_reranker(matches, "click")
+        assert out[0].confidence == 0.85
+
+    def test_mismatch_class_downweighted(self):
+        matches = [
+            _mk_match("Element Should Be Visible", "SeleniumLibrary", 0.87),
+        ]
+        # query is "select" — keyword class is "assert" → mismatch
+        out = apply_action_class_reranker(matches, "select")
+        # Default downweight 0.6
+        assert abs(out[0].confidence - 0.87 * 0.6) < 1e-6
+
+    def test_unknown_query_abstains(self):
+        matches = [
+            _mk_match("Click", "Browser", 0.85,
+                      tags=["PageContent", "Setter"]),
+            _mk_match("Get Text", "Browser", 0.7,
+                      tags=["Assertion", "Getter", "PageContent"]),
+        ]
+        out = apply_action_class_reranker(matches, "unknown")
+        # No change — reranker abstains
+        confs = [m.confidence for m in out]
+        assert confs == [0.85, 0.7]
+
+    def test_s02_outcome(self):
+        """S02 — query: 'select dropdown option by visible label'
+        (class: select). The pre-rerank winner ``Element Should Be
+        Visible`` (assert class) should be down-weighted below the
+        ``Select From List By Label`` (select class) at 0.82.
+        """
+        matches = [
+            _mk_match("Element Should Be Visible", "SeleniumLibrary", 0.87),
+            _mk_match("Select From List By Label", "SeleniumLibrary", 0.82),
+            _mk_match("Set Window Position", "SeleniumLibrary", 0.82),
+            _mk_match("Unselect From List By Label", "SeleniumLibrary", 0.80),
+        ]
+        # Force the reranker (env var defaults ON in newer state but
+        # tests run with whatever the environment provides; pass class
+        # directly to bypass).
+        out = apply_action_class_reranker(matches, "select")
+        # Top match becomes Select From List By Label
+        assert out[0].keyword_name == "Select From List By Label", (
+            f"S02 outcome — expected Select From List By Label as top, "
+            f"got {out[0].keyword_name}"
+        )
+
+    def test_downweight_env_var_tunable(self, monkeypatch):
+        monkeypatch.setenv("ROBOTMCP_RERANK_DOWNWEIGHT", "0.3")
+        matches = [
+            _mk_match("Element Should Be Visible", "SeleniumLibrary", 1.0),
+        ]
+        out = apply_action_class_reranker(matches, "select")
+        # 1.0 * 0.3 = 0.3
+        assert abs(out[0].confidence - 0.3) < 1e-6
+
+
+class TestConfidenceCap:
+    """apply_confidence_cap fires under Trigger A or Trigger B."""
+
+    def test_trigger_a_top3_divergent(self):
+        """Top-3 spans ≥ 3 distinct classes → cap fires."""
+        matches = [
+            _mk_match("Click", "Browser", 0.8,
+                      tags=["PageContent", "Setter"]),  # click
+            _mk_match("Get Text", "Browser", 0.75,
+                      tags=["Assertion", "Getter", "PageContent"]),  # query
+            _mk_match("Wait For Elements State", "Browser", 0.7,
+                      tags=["PageContent", "Wait"]),  # wait
+        ]
+        out, flag = apply_confidence_cap(matches, "click")
+        assert flag is True
+        assert out[0].confidence == 0.5  # capped
+
+    def test_trigger_b_unknown_query_opinionated_top(self):
+        """Query class unknown + top has opinionated class + conf > cap
+        → cap fires (the S10 fix)."""
+        matches = [
+            _mk_match("New Persistent Context", "Browser", 0.72,
+                      tags=["BrowserControl", "Setter"]),  # navigate
+        ]
+        out, flag = apply_confidence_cap(matches, "unknown")
+        assert flag is True
+        assert out[0].confidence == 0.5
+
+    def test_no_trigger_no_cap(self):
+        """Top-3 all same class + query matches → no cap."""
+        matches = [
+            _mk_match("Click", "Browser", 0.85,
+                      tags=["PageContent", "Setter"]),
+            _mk_match("Click Element", "SeleniumLibrary", 0.80),
+            _mk_match("Click Button", "SeleniumLibrary", 0.75),
+        ]
+        out, flag = apply_confidence_cap(matches, "click")
+        assert flag is False
+        assert out[0].confidence == 0.85  # unchanged
+
+    def test_top_already_at_cap_still_flags(self):
+        """Trigger B fires even if top is at cap — agent learns
+        about the uncertainty either way."""
+        matches = [
+            _mk_match("X", "Browser", 0.5, tags=["PageContent", "Setter"]),
+        ]
+        out, flag = apply_confidence_cap(matches, "unknown")
+        assert flag is True  # flag still set
+        assert out[0].confidence == 0.5  # but no actual change
+
+    def test_cap_env_var_tunable(self, monkeypatch):
+        monkeypatch.setenv("ROBOTMCP_RERANK_CAP", "0.3")
+        matches = [
+            _mk_match("X", "Browser", 0.5, tags=["PageContent", "Setter"]),
+        ]
+        out, flag = apply_confidence_cap(matches, "unknown")
+        assert flag is True
+        assert out[0].confidence == 0.3
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through discover_keywords
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDiscoverKeywordsIntegration:
+    """The reranker is wired into the matcher pipeline. End-to-end
+    behaviour pinned via mocked _pattern_based_matching etc."""
+
+    async def _matcher_with_synthetic_matches(self, fake_ranked):
+        from robotmcp.components.keyword_matcher import KeywordMatcher
+        m = KeywordMatcher()
+        m._initialized = True
+
+        async def _ensure():
+            return None
+        m._ensure_initialized = _ensure
+        m._pattern_based_matching = AsyncMock(return_value=[])
+        m._context_aware_matching = AsyncMock(return_value=[])
+        m._deduplicate_matches = MagicMock(return_value=fake_ranked)
+        m._rank_matches = MagicMock(return_value=fake_ranked)
+        m._normalize_action = MagicMock(side_effect=lambda x: x.lower())
+        m._classify_action = MagicMock(return_value="click")
+        m._generate_usage_recommendations = MagicMock(return_value=[])
+        return m
+
+    async def test_s02_top_match_changes_to_select(self, monkeypatch):
+        monkeypatch.setenv("ROBOTMCP_MATCHER_RERANK", "1")
+        fake = [
+            _mk_match("Element Should Be Visible", "SeleniumLibrary", 0.87),
+            _mk_match("Select From List By Label", "SeleniumLibrary", 0.82),
+            _mk_match("Set Window Position", "SeleniumLibrary", 0.82),
+        ]
+        m = await self._matcher_with_synthetic_matches(fake)
+        result = await m.discover_keywords(
+            "select dropdown option by visible label", limit=5,
+        )
+        assert result["matches"][0]["keyword_name"] == "Select From List By Label"
+
+    async def test_s10_low_confidence_top_match_flag(self, monkeypatch):
+        monkeypatch.setenv("ROBOTMCP_MATCHER_RERANK", "1")
+        fake = [
+            _mk_match("New Persistent Context", "Browser", 0.72,
+                      tags=["BrowserControl", "Setter"]),
+        ]
+        m = await self._matcher_with_synthetic_matches(fake)
+        result = await m.discover_keywords(
+            "send http post request with json body", limit=5,
+        )
+        # Trigger B fires (unknown query + opinionated top + conf > cap)
+        assert result.get("low_confidence_top_match") is True
+        assert result["matches"][0]["confidence"] == 0.5
+
+    async def test_feature_flag_off_no_reranker(self, monkeypatch):
+        """ROBOTMCP_MATCHER_RERANK=0 disables the reranker entirely
+        (rollback path). Top match stays as pre-reranker ranking."""
+        monkeypatch.setenv("ROBOTMCP_MATCHER_RERANK", "0")
+        fake = [
+            _mk_match("Element Should Be Visible", "SeleniumLibrary", 0.87),
+            _mk_match("Select From List By Label", "SeleniumLibrary", 0.82),
+        ]
+        m = await self._matcher_with_synthetic_matches(fake)
+        result = await m.discover_keywords(
+            "select dropdown option by visible label",
+        )
+        # Reranker disabled — pre-rerank top remains
+        assert result["matches"][0]["keyword_name"] == "Element Should Be Visible"
+        # Cap also disabled
+        assert "low_confidence_top_match" not in result
+
+    async def test_feature_flag_default_on(self, monkeypatch):
+        """Default (env unset) → reranker active."""
+        monkeypatch.delenv("ROBOTMCP_MATCHER_RERANK", raising=False)
+        fake = [
+            _mk_match("Element Should Be Visible", "SeleniumLibrary", 0.87),
+            _mk_match("Select From List By Label", "SeleniumLibrary", 0.82),
+        ]
+        m = await self._matcher_with_synthetic_matches(fake)
+        result = await m.discover_keywords(
+            "select dropdown option by visible label",
+        )
+        assert result["matches"][0]["keyword_name"] == "Select From List By Label"
+
+
+class TestKeywordMatchTagsField:
+    """KeywordMatch.tags is the OBS-18B plumbing — verify it's
+    populated and propagates."""
+
+    def test_tags_field_default_empty(self):
+        m = _mk_match("X", "Browser", 0.5)
+        assert m.tags == []
+
+    def test_tags_field_carries_through(self):
+        m = _mk_match("Click", "Browser", 0.85,
+                      tags=["PageContent", "Setter"])
+        assert m.tags == ["PageContent", "Setter"]
+
+    def test_dataclasses_replace_preserves_tags(self):
+        import dataclasses
+        m = _mk_match("Click", "Browser", 0.85,
+                      tags=["PageContent", "Setter"])
+        m2 = dataclasses.replace(m, confidence=0.5)
+        assert m2.tags == ["PageContent", "Setter"]
+        assert m2.confidence == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Regression — pin existing-correct scenarios stay correct
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionBaselines:
+    """Per OBS-18A v2 "Pinned regression baselines": the reranker
+    must NOT regress existing-correct scenarios."""
+
+    @pytest.mark.parametrize("query,expected_top_class", [
+        # Each query's class corresponds to a correct top-match's class
+        ("click button", "click"),
+        ("fill form input field", "fill"),
+        ("navigate to url page", "navigate"),
+        ("wait for element visible", "wait"),
+        ("get element text", "query"),
+    ])
+    def test_query_class_matches_expected(self, query, expected_top_class):
+        assert _classify_query_action_class(query) == expected_top_class

--- a/tests/unit/test_obs_18b_matcher_reranker.py
+++ b/tests/unit/test_obs_18b_matcher_reranker.py
@@ -410,3 +410,141 @@ class TestRegressionBaselines:
     ])
     def test_query_class_matches_expected(self, query, expected_top_class):
         assert _classify_query_action_class(query) == expected_top_class
+
+
+# ---------------------------------------------------------------------------
+# Real end-to-end regression baseline tests (post-Wave-3 review fix)
+#
+# Codex + Claude subagent flagged the parametrised classifier tests
+# above as tautological — they only verify the query classifier, not
+# that the actual ``discover_keywords`` pipeline produces the right
+# top match. This class pins top-match name+library against the REAL
+# matcher with the REAL Browser/SeleniumLibrary keyword data. If
+# anyone changes the reranker, classifier, or matcher pipeline in a
+# way that breaks the OBS-18A v2 pinned baselines, these tests fail.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPinnedTopMatchEndToEnd:
+    """Real end-to-end pinning of top-match name+library for the OBS-18A
+    v2 pinned baselines. Uses the real matcher (no mocks of internals)
+    so the test exercises the actual production code path."""
+
+    async def _run(self, query, library_name=None, monkeypatch=None):
+        if monkeypatch is not None:
+            monkeypatch.setenv("ROBOTMCP_MATCHER_RERANK", "1")
+        from robotmcp.server import find_keywords as fk
+        fn = getattr(fk, "fn", fk)
+        kwargs = {"query": query, "strategy": "semantic", "limit": 5}
+        if library_name:
+            kwargs["library_name"] = library_name
+        return await fn(**kwargs)
+
+    async def test_S01_click_button_browser_top_is_click(self, monkeypatch):
+        """S01-style: 'click button' + Browser → top match in click class.
+        Note benchmark S01 actually uses 'select dropdown' query; this
+        test uses the design's pinned 'click button' query directly."""
+        r = await self._run("click button", "Browser", monkeypatch)
+        matches = r["result"]["matches"]
+        assert matches, "expected at least one match"
+        top = matches[0]
+        # Top match must be from Browser, click-class
+        assert top["library"] == "Browser"
+        assert classify_keyword_action(top["keyword_name"], top.get("tags", [])) == "click", (
+            f"Expected click-class top match for 'click button' query; "
+            f"got {top['keyword_name']} ({classify_keyword_action(top['keyword_name'], top.get('tags', []))})"
+        )
+
+    async def test_S02_select_dropdown_sl_top_is_select_from_list(self, monkeypatch):
+        """S02 (the OBS-18B fix target): query
+        'select dropdown option by visible label' + SeleniumLibrary →
+        top match MUST be ``Select From List By Label``."""
+        r = await self._run(
+            "select dropdown option by visible label",
+            "SeleniumLibrary", monkeypatch,
+        )
+        matches = r["result"]["matches"]
+        assert matches
+        assert matches[0]["keyword_name"] == "Select From List By Label", (
+            f"S02 regression: top match must be Select From List By Label; "
+            f"got {matches[0]['keyword_name']}"
+        )
+
+    async def test_S06_click_browser_top_is_click(self, monkeypatch):
+        """S06: single-word 'click' + Browser → top match Browser.Click."""
+        r = await self._run("click", "Browser", monkeypatch)
+        matches = r["result"]["matches"]
+        assert matches
+        assert matches[0]["library"] == "Browser"
+        assert matches[0]["keyword_name"] == "Click", (
+            f"S06 regression: 'click' + Browser top must be Click; "
+            f"got {matches[0]['keyword_name']}"
+        )
+
+    async def test_S07_navigate_browser_top_is_go_to(self, monkeypatch):
+        """S07: 'navigate' + Browser → top match Browser.Go To."""
+        r = await self._run("navigate", "Browser", monkeypatch)
+        matches = r["result"]["matches"]
+        assert matches
+        assert matches[0]["library"] == "Browser"
+        assert matches[0]["keyword_name"] == "Go To", (
+            f"S07 regression: 'navigate' + Browser top must be Go To; "
+            f"got {matches[0]['keyword_name']}"
+        )
+
+    async def test_S10_api_query_browser_caps_with_flag(self, monkeypatch):
+        """S10 (OBS-18B AC #4b): cross-domain 'send http post request' +
+        Browser must produce ``low_confidence_top_match: true`` AND a
+        matches[0].confidence ≤ 0.5 (capped by Trigger B)."""
+        r = await self._run(
+            "send http post request with json body",
+            "Browser", monkeypatch,
+        )
+        res = r["result"]
+        assert res.get("low_confidence_top_match") is True, (
+            "S10 must set low_confidence_top_match=True"
+        )
+        assert res["matches"][0]["confidence"] <= 0.5, (
+            f"S10 top-match confidence must be ≤ 0.5; "
+            f"got {res['matches'][0]['confidence']}"
+        )
+
+    async def test_S12_compound_wait_click_top_stays_click_class(self, monkeypatch):
+        """S12 (Wave-3 round-1 review FIX): compound query with both
+        'wait' and 'click' triggers must NOT regress click-class top
+        match. Pre-fix this query returned ``Wait For Condition``
+        because of trigger ordering. Post-fix it returns Click (the
+        reranker abstains on ambiguous compound queries)."""
+        r = await self._run(
+            "wait for the modal dialog to appear and then click the "
+            "confirm button at the bottom of the form",
+            "Browser", monkeypatch,
+        )
+        matches = r["result"]["matches"]
+        assert matches
+        top_class = classify_keyword_action(
+            matches[0]["keyword_name"], matches[0].get("tags", []),
+        )
+        # Top match must be click-class (NOT wait-class) — compound
+        # queries are ambiguous; the reranker abstains; the pre-rerank
+        # matcher's top is click-class.
+        assert top_class == "click", (
+            f"S12 regression: compound 'wait... click...' top must stay "
+            f"click-class; got {matches[0]['keyword_name']} ({top_class})"
+        )
+
+    async def test_S13_bdd_click_top_is_click(self, monkeypatch):
+        """S13: BDD-prefixed 'When I click submit button' + Browser →
+        top match in click class (BDD prefix stripped before
+        classification)."""
+        r = await self._run("When I click submit button", "Browser", monkeypatch)
+        matches = r["result"]["matches"]
+        assert matches
+        top_class = classify_keyword_action(
+            matches[0]["keyword_name"], matches[0].get("tags", []),
+        )
+        assert top_class == "click", (
+            f"S13 regression: BDD 'When I click...' must produce click-class top; "
+            f"got {matches[0]['keyword_name']} ({top_class})"
+        )

--- a/tests/unit/test_obs_20_discovery_execution_symmetry.py
+++ b/tests/unit/test_obs_20_discovery_execution_symmetry.py
@@ -1,0 +1,335 @@
+"""OBS-20 — discovery filter mirrors Browser plugin's imported-libraries fallback.
+
+Pre-fix: ``_filter_keywords_by_session_library`` only ran when
+``session.explicit_library_preference`` was non-None. Meanwhile, the
+Browser plugin's execute-time validation
+(``browser_plugin.py:312-321``) ALSO falls back to imported libraries
+when no explicit preference exists:
+
+  if not pref:
+      imported = getattr(session, "imported_libraries", []) or []
+      if "Browser" not in imported:
+          return None  # Browser not loaded — skip validation
+
+Result: an agent in a session created with ``libraries=["Browser"]``
+but no explicit preference set saw SL keywords in ``find_keywords``
+results, picked one, and had it rejected at ``execute_step``. Same
+tools, asymmetric filtering rules.
+
+The SeleniumLibrary plugin at ``selenium_plugin.py:203-205`` is
+explicitly asymmetric — it ONLY acts when
+``explicit_library_preference.startswith("selenium")``. Does NOT use
+imported-libraries fallback. OBS-20 mirrors this exact asymmetry —
+it does NOT invent a clean XOR rule that would contradict production.
+
+These tests pin the actual asymmetric rule:
+
+1. Browser imported, no explicit preference → SL excluded from
+   discovery (mirrors Browser plugin's execute rule).
+2. SL imported, no explicit preference → Browser KEPT in discovery
+   (mirrors SL plugin's lack of imported-fallback).
+3. BOTH Browser + SL imported → SL still excluded (Browser plugin's
+   rule fires when Browser is imported, regardless of SL also being
+   imported).
+4. Explicit preference set → unchanged behaviour (no regression on
+   the existing path).
+5. Neither Browser nor SL imported → no filter (existing behaviour).
+6. ``library_name`` parameter takes precedence over session
+   imported-fallback (existing precedence preserved).
+7. Neutral libraries (BuiltIn, Collections, etc.) never excluded by
+   this filter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robotmcp.server import find_keywords
+
+
+def _fn(tool):
+    return getattr(tool, "fn", tool)
+
+
+@pytest.fixture
+def patched_engines():
+    """Stub matcher/engine/externalisation so tests don't hit RF runtime."""
+    discover_mock = AsyncMock()
+    async def _ensure_loaded():
+        return None
+    sess_mgr = MagicMock()
+    sess_mgr.get_session = MagicMock(return_value=None)
+    engine = MagicMock()
+    engine.session_manager = sess_mgr
+    engine.search_keywords = MagicMock(return_value=[])
+    engine.get_available_keywords = MagicMock(return_value=[])
+    with patch(
+        "robotmcp.server.keyword_matcher.discover_keywords", discover_mock,
+    ), patch(
+        "robotmcp.server._ensure_all_session_libraries_loaded", _ensure_loaded,
+    ), patch(
+        "robotmcp.server._externalize_response", side_effect=lambda *a: a[-1],
+    ), patch(
+        "robotmcp.server._track_tool_result", MagicMock(),
+    ), patch(
+        "robotmcp.server.execution_engine", engine,
+    ):
+        yield {"discover": discover_mock, "engine": engine, "sess_mgr": sess_mgr}
+
+
+def _stub_semantic(matches):
+    return {
+        "success": True,
+        "action_description": "test",
+        "action_type": "click",
+        "matches": matches,
+        "total_matches": len(matches),
+        "recommendations": [],
+    }
+
+
+@pytest.mark.asyncio
+class TestImportedFallbackForBrowser:
+    """OBS-20 core: when a session imports Browser but doesn't set
+    explicit_library_preference, discovery still excludes SL."""
+
+    async def test_browser_imported_no_preference_excludes_sl(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = None
+        sess.imported_libraries = ["Browser", "BuiltIn"]
+        patched_engines["sess_mgr"].get_session = MagicMock(return_value=sess)
+
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click", "library": "Browser",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.80, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic", session_id="s",
+        )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # SL excluded by imported-fallback rule
+        assert "SeleniumLibrary" not in libs, (
+            f"OBS-20: Browser imported + no preference must exclude SL; "
+            f"got libs={libs!r}"
+        )
+        assert "Browser" in libs
+        # library_filter.source signals the imported-fallback path
+        lf = result.get("library_filter")
+        assert lf is not None
+        assert lf["source"] == "session_imported"
+        assert lf["applied"] == "Browser"
+
+
+@pytest.mark.asyncio
+class TestSlAsymmetricRule:
+    """OBS-20 honours SL plugin's lack of imported-fallback: SL
+    imported + no preference does NOT exclude Browser."""
+
+    async def test_sl_imported_no_preference_keeps_browser(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = None
+        # SL imported, Browser NOT imported
+        sess.imported_libraries = ["SeleniumLibrary", "BuiltIn"]
+        patched_engines["sess_mgr"].get_session = MagicMock(return_value=sess)
+
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click", "library": "Browser",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.80, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic", session_id="s",
+        )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # Both libraries' keywords remain — SL plugin has no
+        # imported-fallback; mirror exactly.
+        assert "Browser" in libs, (
+            "OBS-20 asymmetry: SL imported without preference must NOT "
+            "trigger an imported-fallback filter (SL plugin doesn't have "
+            "one at selenium_plugin.py:203-205)"
+        )
+        # No library_filter applied
+        assert "library_filter" not in result
+
+
+@pytest.mark.asyncio
+class TestMixedImports:
+    """When BOTH Browser AND SL are imported (no explicit preference),
+    Browser plugin's rule still fires — SL is excluded."""
+
+    async def test_both_imported_no_preference_sl_still_excluded(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = None
+        sess.imported_libraries = ["Browser", "SeleniumLibrary", "BuiltIn"]
+        patched_engines["sess_mgr"].get_session = MagicMock(return_value=sess)
+
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click", "library": "Browser",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.80, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic", session_id="s",
+        )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # SL excluded because Browser is imported (browser_plugin.py:312-321
+        # rule). This is the production rule, regardless of SL also being
+        # imported.
+        assert "SeleniumLibrary" not in libs, (
+            "Browser plugin's execute-time rule fires whenever Browser is "
+            "imported; discovery must mirror"
+        )
+        assert "Browser" in libs
+
+
+@pytest.mark.asyncio
+class TestExplicitPreferenceUnchanged:
+    """When explicit_library_preference IS set, OBS-20 changes nothing —
+    existing session-preference path applies."""
+
+    async def test_explicit_preference_overrides_imported_fallback(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = "SeleniumLibrary"  # explicit
+        sess.imported_libraries = ["Browser", "SeleniumLibrary"]
+        patched_engines["sess_mgr"].get_session = MagicMock(return_value=sess)
+
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click", "library": "Browser",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.80, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic", session_id="s",
+        )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # Browser excluded because explicit preference is SL
+        assert "Browser" not in libs
+        assert "SeleniumLibrary" in libs
+        # Source is "session" (the explicit preference path), not
+        # the imported-fallback path
+        assert result["library_filter"]["source"] == "session"
+
+
+@pytest.mark.asyncio
+class TestNeutralLibrariesUnaffected:
+    """BuiltIn / Collections / etc. always pass through, regardless
+    of which filter rule fires."""
+
+    async def test_imported_fallback_keeps_builtin(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = None
+        sess.imported_libraries = ["Browser", "BuiltIn"]
+        patched_engines["sess_mgr"].get_session = MagicMock(return_value=sess)
+
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click", "library": "Browser",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Log", "library": "BuiltIn",
+             "confidence": 0.80, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic", session_id="s",
+        )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # Compatible neutral library (BuiltIn) stays visible
+        assert "BuiltIn" in libs
+        assert "Browser" in libs
+        assert "SeleniumLibrary" not in libs
+
+
+@pytest.mark.asyncio
+class TestNoImportFallback:
+    """Sessions that import neither Browser nor SL → no filter."""
+
+    async def test_no_browser_no_sl_no_filter(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = None
+        sess.imported_libraries = ["BuiltIn", "Collections"]
+        patched_engines["sess_mgr"].get_session = MagicMock(return_value=sess)
+
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic", session_id="s",
+        )
+        # No filter applied
+        assert "library_filter" not in result
+
+
+@pytest.mark.asyncio
+class TestLibraryNamePrecedence:
+    """library_name parameter takes precedence over the imported-
+    fallback (existing precedence preserved)."""
+
+    async def test_library_name_overrides_imported_fallback(self, patched_engines):
+        sess = MagicMock()
+        sess.explicit_library_preference = None
+        sess.imported_libraries = ["Browser", "BuiltIn"]
+        patched_engines["sess_mgr"].get_session = MagicMock(return_value=sess)
+
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click", "library": "Browser",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.80, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        # library_name=SeleniumLibrary overrides session imported-fallback
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic",
+            library_name="SeleniumLibrary", session_id="s",
+        )
+        # Browser excluded (library_name=SL filter); SL kept
+        libs = {m["library"] for m in result["result"]["matches"]}
+        assert "Browser" not in libs
+        assert "SeleniumLibrary" in libs
+        assert result["library_filter"]["source"] == "library_name"
+
+
+@pytest.mark.asyncio
+class TestNoSessionUnchanged:
+    """When no session_id is provided, the imported-fallback path
+    can't fire — behaviour is unchanged from pre-OBS-20."""
+
+    async def test_no_session_id_no_imported_fallback(self, patched_engines):
+        patched_engines["discover"].return_value = _stub_semantic([
+            {"keyword_name": "Click", "library": "Browser",
+             "confidence": 0.85, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary",
+             "confidence": 0.80, "arguments": [], "argument_types": [],
+             "documentation": "", "usage_example": ""},
+        ])
+        # No session_id, no library_name → no filter
+        result = await _fn(find_keywords)(
+            query="click", strategy="semantic",
+        )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # Both libraries' matches remain
+        assert "Browser" in libs
+        assert "SeleniumLibrary" in libs
+        assert "library_filter" not in result

--- a/tests/unit/test_obs_23a_session_query_limit.py
+++ b/tests/unit/test_obs_23a_session_query_limit.py
@@ -231,9 +231,11 @@ class TestSessionStrategyEndToEnd:
         assert result["success"] is True
         assert result["strategy"] == "session"
         assert result["query"] == "click"
-        # Diagnostic fields surface
-        assert result["total_before_trim"] == 50
-        assert result["total_after_filter"] == 1
+        # Diagnostic fields surface under result.* (OBS-23B-impl
+        # moved these under the unified ``result`` envelope per
+        # ``docs/proposals/session_strategy_schema.md`` v2).
+        assert result["result"]["total_before_trim"] == 50
+        assert result["result"]["total_after_filter"] == 1
 
     async def test_session_strategy_empty_query_no_filter(self):
         """Empty query → no name_filter passed to backend."""

--- a/tests/unit/test_obs_23a_session_query_limit.py
+++ b/tests/unit/test_obs_23a_session_query_limit.py
@@ -1,0 +1,275 @@
+"""OBS-23A — find_keywords(strategy="session") honours query + limit.
+
+Pre-fix: ``find_keywords(strategy="session", query="click", limit=5)``
+silently dumped the entire session namespace because the lower-level
+``list_available_keywords`` didn't accept query / limit. Verified
+end-to-end Codex round-2: query was decorative, echoed in response
+but never consulted.
+
+The fix: ``list_available_keywords`` gains ``name_filter`` and
+``limit`` parameters. ``find_keywords`` session branch passes the
+caller's ``query`` and ``limit_value`` through.
+
+These tests pin:
+1. ``name_filter`` substring-matches keyword names case-insensitively.
+2. ``limit`` trims the union (library + resource) to N entries.
+3. No filter + no limit → identical pre-fix behaviour (backwards
+   compat).
+4. ``total_before_trim`` / ``total_after_filter`` diagnostic fields
+   surface so callers can detect truncation.
+5. find_keywords session branch passes query → name_filter through.
+6. Limit application order: filter first, then limit (so ``query="click",
+   limit=5`` returns up to 5 click-matching keywords, not 5 arbitrary
+   keywords).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robotmcp.server import find_keywords
+
+
+def _fn(tool):
+    return getattr(tool, "fn", tool)
+
+
+def _stub_namespace(library_keywords, resource_keywords=None):
+    """Build a synthetic namespace returning library/resource keywords."""
+    kw_objs = []
+    for spec in library_keywords:
+        kw_obj = MagicMock()
+        kw_obj.name = spec["name"]
+        kw_obj.full_name = spec.get("full_name", spec["name"])
+        kw_objs.append((kw_obj, spec.get("library", "Browser")))
+    return kw_objs
+
+
+class TestListAvailableKeywordsFilter:
+    """Unit tests against ``RobotFrameworkNativeContextManager.list_available_keywords``
+    directly (the backend method) — independent of the MCP wrapper."""
+
+    def _build_mgr_with_session(self, library_keywords, resource_keywords=None):
+        from robotmcp.components.execution.rf_native_context_manager import (
+            RobotFrameworkNativeContextManager,
+        )
+        mgr = RobotFrameworkNativeContextManager()
+
+        # Build mock namespace.libraries — each library has .keywords + .name
+        libs = []
+        # Group keywords by library
+        by_library = {}
+        for kw_spec in library_keywords:
+            lib_name = kw_spec.get("library", "Browser")
+            by_library.setdefault(lib_name, []).append(kw_spec)
+        for lib_name, specs in by_library.items():
+            lib = MagicMock()
+            lib.name = lib_name
+            lib.keywords = []
+            for spec in specs:
+                kw = MagicMock()
+                kw.name = spec["name"]
+                kw.full_name = spec.get("full_name", spec["name"])
+                lib.keywords.append(kw)
+            libs.append(lib)
+
+        namespace = MagicMock()
+        namespace.libraries = libs
+        mgr._session_contexts["test-sess"] = {
+            "namespace": namespace,
+            "resources": resource_keywords or [],
+        }
+        return mgr
+
+    def test_no_filter_no_limit_returns_all(self):
+        mgr = self._build_mgr_with_session([
+            {"name": "Click", "library": "Browser"},
+            {"name": "Fill Text", "library": "Browser"},
+            {"name": "Go To", "library": "Browser"},
+            {"name": "Log", "library": "BuiltIn"},
+        ])
+        result = mgr.list_available_keywords("test-sess")
+        assert result["success"] is True
+        assert len(result["library_keywords"]) == 4
+        assert result["total_before_trim"] == 4
+        assert result["total_after_filter"] == 4
+
+    def test_name_filter_substring_match(self):
+        mgr = self._build_mgr_with_session([
+            {"name": "Click", "library": "Browser"},
+            {"name": "Click Element", "library": "SeleniumLibrary"},
+            {"name": "Fill Text", "library": "Browser"},
+            {"name": "Go To", "library": "Browser"},
+        ])
+        result = mgr.list_available_keywords("test-sess", name_filter="click")
+        names = [kw["name"] for kw in result["library_keywords"]]
+        assert sorted(names) == ["Click", "Click Element"]
+        # Pre-trim diagnostic still shows the full count.
+        assert result["total_before_trim"] == 4
+        # Post-filter shows the filtered count (before any limit applied).
+        assert result["total_after_filter"] == 2
+
+    def test_name_filter_case_insensitive(self):
+        mgr = self._build_mgr_with_session([
+            {"name": "Click", "library": "Browser"},
+            {"name": "Fill Text", "library": "Browser"},
+        ])
+        # Mixed-case filter must still match
+        result = mgr.list_available_keywords("test-sess", name_filter="CLICK")
+        assert len(result["library_keywords"]) == 1
+        assert result["library_keywords"][0]["name"] == "Click"
+
+    def test_name_filter_whitespace_only_treated_as_no_filter(self):
+        mgr = self._build_mgr_with_session([
+            {"name": "Click", "library": "Browser"},
+            {"name": "Fill Text", "library": "Browser"},
+        ])
+        result = mgr.list_available_keywords("test-sess", name_filter="   ")
+        # Whitespace-only filter → no filtering applied
+        assert len(result["library_keywords"]) == 2
+
+    def test_limit_trims_to_n(self):
+        mgr = self._build_mgr_with_session([
+            {"name": f"Keyword{i}", "library": "Browser"} for i in range(20)
+        ])
+        result = mgr.list_available_keywords("test-sess", limit=5)
+        assert len(result["library_keywords"]) == 5
+        # Pre-trim diagnostic
+        assert result["total_before_trim"] == 20
+        # After-filter equals pre-trim when no name_filter
+        assert result["total_after_filter"] == 20
+
+    def test_filter_then_limit_order(self):
+        """When both filter + limit are present, filter applies FIRST,
+        then limit. So ``query="click", limit=3`` returns up to 3 click
+        matches (not 3 arbitrary keywords)."""
+        mgr = self._build_mgr_with_session(
+            [{"name": "Click", "library": "Browser"}]
+            + [{"name": f"Click{i}", "library": "Browser"} for i in range(10)]
+            + [{"name": f"Other{i}", "library": "Browser"} for i in range(5)]
+        )
+        result = mgr.list_available_keywords(
+            "test-sess", name_filter="click", limit=3,
+        )
+        assert len(result["library_keywords"]) == 3
+        # Every returned entry contains "click"
+        for kw in result["library_keywords"]:
+            assert "click" in kw["name"].lower()
+        # Diagnostics show the picture: 16 total, 11 click-matches,
+        # trimmed to 3
+        assert result["total_before_trim"] == 16
+        assert result["total_after_filter"] == 11
+
+    def test_invalid_limit_zero_no_trim(self):
+        mgr = self._build_mgr_with_session([
+            {"name": "Click", "library": "Browser"},
+            {"name": "Fill Text", "library": "Browser"},
+        ])
+        # limit=0 is invalid; behaves as no limit
+        result = mgr.list_available_keywords("test-sess", limit=0)
+        assert len(result["library_keywords"]) == 2
+
+    def test_invalid_limit_negative_no_trim(self):
+        mgr = self._build_mgr_with_session([
+            {"name": "Click", "library": "Browser"},
+            {"name": "Fill Text", "library": "Browser"},
+        ])
+        result = mgr.list_available_keywords("test-sess", limit=-5)
+        assert len(result["library_keywords"]) == 2
+
+    def test_missing_session_returns_error(self):
+        from robotmcp.components.execution.rf_native_context_manager import (
+            RobotFrameworkNativeContextManager,
+        )
+        mgr = RobotFrameworkNativeContextManager()
+        result = mgr.list_available_keywords("nonexistent")
+        assert result["success"] is False
+        assert "No RF context" in result["error"]
+
+
+@pytest.mark.asyncio
+class TestSessionStrategyEndToEnd:
+    """End-to-end: find_keywords(strategy="session", query=..., limit=...)
+    passes query → name_filter and limit → list_available_keywords."""
+
+    async def test_session_strategy_passes_query_as_name_filter(self):
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(
+            return_value={
+                "success": True,
+                "library_keywords": [
+                    {"name": "Click", "library": "Browser"},
+                ],
+                "resource_keywords": [],
+                "total_before_trim": 50,
+                "total_after_filter": 1,
+                "libraries_count": 2,
+            },
+        )
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *args: args[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            result = await _fn(find_keywords)(
+                query="click",
+                strategy="session",
+                session_id="sess-x",
+                limit=5,
+            )
+        # Verify the backend was called with the filter+limit
+        _, kwargs = mock_mgr.list_available_keywords.call_args
+        assert kwargs.get("name_filter") == "click"
+        assert kwargs.get("limit") == 5
+        # Response carries the data + strategy + query echo
+        assert result["success"] is True
+        assert result["strategy"] == "session"
+        assert result["query"] == "click"
+        # Diagnostic fields surface
+        assert result["total_before_trim"] == 50
+        assert result["total_after_filter"] == 1
+
+    async def test_session_strategy_empty_query_no_filter(self):
+        """Empty query → no name_filter passed to backend."""
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(
+            return_value={
+                "success": True,
+                "library_keywords": [],
+                "resource_keywords": [],
+                "total_before_trim": 0,
+                "total_after_filter": 0,
+                "libraries_count": 0,
+            },
+        )
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *args: args[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            await _fn(find_keywords)(
+                query="",
+                strategy="session",
+                session_id="sess-x",
+            )
+        _, kwargs = mock_mgr.list_available_keywords.call_args
+        # Empty query → name_filter is None
+        assert kwargs.get("name_filter") is None
+
+    async def test_session_strategy_no_session_id_errors(self):
+        result = await _fn(find_keywords)(
+            query="click",
+            strategy="session",
+        )
+        assert result["success"] is False
+        assert "session_id is required" in result["error"]

--- a/tests/unit/test_obs_23b_session_unified_shape.py
+++ b/tests/unit/test_obs_23b_session_unified_shape.py
@@ -1,0 +1,345 @@
+"""OBS-23B-impl Phase 1 — session strategy unified shape + legacy dual-emit.
+
+The session strategy's previous response shape diverged from
+semantic/pattern/catalog strategies:
+- Top-level ``library_keywords`` + ``resource_keywords`` siblings
+- No unified ``result.matches[]``
+- No ``recommendations`` prose
+- Legacy fields uncovered by existing externalisation rules
+
+Phase 1 dual-emit (this story):
+- ADDS the unified ``result`` envelope with ``matches``, ``library_count``,
+  ``resource_count``, ``recommendations``, ``total_before_trim``,
+  ``total_after_filter``.
+- PRESERVES the legacy top-level fields for backwards-compat during
+  Phase 2 (deprecation warning, OBS-34, v0.34) → Phase 3 (removal,
+  OBS-35, v0.36).
+- ADDS externalisation rules for ``library_keywords`` /
+  ``resource_keywords`` so the legacy mirror also externalises.
+
+Match shape uses ``match_type: "exact_substring"`` instead of v1's
+fake ``confidence=1.00``.
+
+These tests pin:
+1. Unified ``result.matches`` is populated from library+resource
+   keywords, with correct ``source_type`` per entry.
+2. Legacy top-level fields still present.
+3. ``library_count``/``resource_count`` count distinct values.
+4. ``recommendations`` prose uses honest match-type language.
+5. Recommendations exact-match path when query matches a keyword
+   name; substring path otherwise.
+6. ``total_before_trim`` + ``total_after_filter`` surface under
+   ``result``.
+7. Externalisation rules added to ``DEFAULT_RULES``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robotmcp.server import (
+    _build_session_recommendations,
+    find_keywords,
+)
+
+
+def _fn(tool):
+    return getattr(tool, "fn", tool)
+
+
+class TestExternalizationRules:
+    def test_library_keywords_rule_added(self):
+        from robotmcp.domains.artifact_output.services import DEFAULT_RULES
+        pairs = {(r.tool_name, r.field_path) for r in DEFAULT_RULES}
+        assert ("find_keywords", "library_keywords") in pairs
+
+    def test_resource_keywords_rule_added(self):
+        from robotmcp.domains.artifact_output.services import DEFAULT_RULES
+        pairs = {(r.tool_name, r.field_path) for r in DEFAULT_RULES}
+        assert ("find_keywords", "resource_keywords") in pairs
+
+
+class TestSessionRecommendations:
+    """The recommendations helper produces honest prose without
+    fake confidence numbers."""
+
+    def test_empty_matches_returns_no_match_prose(self):
+        recs = _build_session_recommendations([], "click")
+        assert any("No keywords match" in r for r in recs)
+
+    def test_exact_match_naming(self):
+        matches = [
+            {"keyword_name": "Click", "library": "Browser"},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary"},
+        ]
+        recs = _build_session_recommendations(matches, "click")
+        # Exact match wins (case-insensitive)
+        assert recs[0].startswith("Exact match: Click")
+        assert "(Browser)" in recs[0]
+        # No fake confidence number
+        assert "confidence" not in recs[0].lower()
+
+    def test_substring_match_naming(self):
+        matches = [
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary"},
+            {"keyword_name": "Click Button", "library": "SeleniumLibrary"},
+        ]
+        recs = _build_session_recommendations(matches, "click")
+        # No exact match; falls back to substring
+        assert "Substring match" in recs[0]
+        assert "Click Element" in recs[0]
+        # Mentions the failed-exact-match query
+        assert "click" in recs[0]
+
+    def test_empty_query_uses_first_in_session(self):
+        matches = [
+            {"keyword_name": "Log", "library": "BuiltIn"},
+            {"keyword_name": "Click", "library": "Browser"},
+        ]
+        recs = _build_session_recommendations(matches, "")
+        assert "First in session" in recs[0]
+        assert "Log" in recs[0]
+
+    def test_alternatives_section_when_multiple_matches(self):
+        matches = [
+            {"keyword_name": "Click", "library": "Browser"},
+            {"keyword_name": "Click Element", "library": "SeleniumLibrary"},
+            {"keyword_name": "Click Button", "library": "SeleniumLibrary"},
+            {"keyword_name": "Tap", "library": "Browser"},
+        ]
+        recs = _build_session_recommendations(matches, "click")
+        # Alternative options appears
+        alt_line = next((r for r in recs if r.startswith("Alternative")), None)
+        assert alt_line is not None
+        # Names matches[1:4]
+        assert "Click Element" in alt_line
+        assert "Click Button" in alt_line
+        assert "Tap" in alt_line
+
+    def test_required_arguments_NOT_present(self):
+        """Per design v2 — session strategy doesn't have per-keyword
+        arg info, so 'Required arguments' line is intentionally
+        omitted (was a v1 design bug)."""
+        matches = [
+            {"keyword_name": "Click", "library": "Browser"},
+        ]
+        recs = _build_session_recommendations(matches, "click")
+        assert not any(
+            "Required arguments" in r or "Required Arguments" in r
+            for r in recs
+        )
+
+
+@pytest.mark.asyncio
+class TestUnifiedShape:
+    """find_keywords(strategy='session') response gains the unified
+    ``result.matches`` envelope on top of the existing legacy fields."""
+
+    async def _call(self, library_keywords=None, resource_keywords=None,
+                    query="", limit=None, total_before=None, total_after=None):
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(return_value={
+            "success": True,
+            "library_keywords": library_keywords or [],
+            "resource_keywords": resource_keywords or [],
+            "libraries_count": len({kw.get("library") for kw in (library_keywords or [])}),
+            "total_before_trim": total_before if total_before is not None
+                                 else len(library_keywords or []) + len(resource_keywords or []),
+            "total_after_filter": total_after if total_after is not None
+                                  else len(library_keywords or []) + len(resource_keywords or []),
+        })
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            return await _fn(find_keywords)(
+                query=query, strategy="session",
+                session_id="sess-x", limit=limit,
+            )
+
+    async def test_unified_result_matches_populated(self):
+        result = await self._call(
+            library_keywords=[
+                {"name": "Click", "library": "Browser", "full_name": "Browser.Click"},
+                {"name": "Log", "library": "BuiltIn", "full_name": "BuiltIn.Log"},
+            ],
+            resource_keywords=[
+                {"name": "Login User", "resource": "/path/to/keywords.resource",
+                 "full_name": "Login User"},
+            ],
+            query="click",
+        )
+        # Unified result envelope
+        assert "result" in result
+        assert "matches" in result["result"]
+        # 3 entries total (2 library + 1 resource)
+        assert len(result["result"]["matches"]) == 3
+
+    async def test_match_shape_uses_match_type_not_confidence(self):
+        result = await self._call(
+            library_keywords=[
+                {"name": "Click", "library": "Browser"},
+            ],
+        )
+        matches = result["result"]["matches"]
+        # match_type field present, NO confidence field (honest shape)
+        assert matches[0]["match_type"] == "exact_substring"
+        assert "confidence" not in matches[0]
+
+    async def test_source_type_distinguishes_library_from_resource(self):
+        result = await self._call(
+            library_keywords=[
+                {"name": "Click", "library": "Browser"},
+            ],
+            resource_keywords=[
+                {"name": "Login", "resource": "/foo.resource"},
+            ],
+        )
+        matches = result["result"]["matches"]
+        library_matches = [m for m in matches if m["source_type"] == "library"]
+        resource_matches = [m for m in matches if m["source_type"] == "resource"]
+        assert len(library_matches) == 1
+        assert library_matches[0]["library"] == "Browser"
+        assert library_matches[0]["source"] is None
+        assert len(resource_matches) == 1
+        assert resource_matches[0]["library"] is None
+        assert resource_matches[0]["source"] == "/foo.resource"
+
+    async def test_counts_reflect_distinct_libraries_and_resources(self):
+        result = await self._call(
+            library_keywords=[
+                {"name": "Click", "library": "Browser"},
+                {"name": "Tap", "library": "Browser"},  # same lib
+                {"name": "Log", "library": "BuiltIn"},  # different lib
+            ],
+            resource_keywords=[
+                {"name": "Login", "resource": "/a.resource"},
+                {"name": "Logout", "resource": "/a.resource"},  # same res
+                {"name": "Greet", "resource": "/b.resource"},  # different res
+            ],
+        )
+        assert result["result"]["library_count"] == 2  # Browser + BuiltIn
+        assert result["result"]["resource_count"] == 2  # /a.resource + /b.resource
+
+    async def test_recommendations_present_in_result(self):
+        result = await self._call(
+            library_keywords=[
+                {"name": "Click", "library": "Browser"},
+            ],
+            query="click",
+        )
+        assert "recommendations" in result["result"]
+        recs = result["result"]["recommendations"]
+        assert recs[0].startswith("Exact match: Click")
+
+    async def test_total_before_trim_surfaces(self):
+        result = await self._call(
+            library_keywords=[
+                {"name": "Click", "library": "Browser"},
+            ],
+            query="click",
+            total_before=50,
+            total_after=1,
+        )
+        # Diagnostic fields under result for agent visibility
+        assert result["result"]["total_before_trim"] == 50
+        assert result["result"]["total_after_filter"] == 1
+
+
+@pytest.mark.asyncio
+class TestBackwardsCompat:
+    """Phase 1 dual-emit MUST preserve legacy top-level fields so
+    existing readers (tests/e2e/test_openai_fastmcp.py:294,
+    tests/benchmarks/test_robustness_token_overhead.py:124) keep
+    working."""
+
+    async def test_legacy_library_keywords_still_top_level(self):
+        result = await self._call_helper([
+            {"name": "Click", "library": "Browser"},
+        ])
+        # Legacy field at top level (NOT under result)
+        assert "library_keywords" in result
+        assert len(result["library_keywords"]) == 1
+        assert result["library_keywords"][0]["name"] == "Click"
+
+    async def test_legacy_resource_keywords_still_top_level(self):
+        result = await self._call_helper(
+            library_keywords=[],
+            resource_keywords=[
+                {"name": "Login", "resource": "/foo.resource"},
+            ],
+        )
+        assert "resource_keywords" in result
+        assert len(result["resource_keywords"]) == 1
+
+    async def test_legacy_libraries_count_still_present(self):
+        result = await self._call_helper([
+            {"name": "Click", "library": "Browser"},
+            {"name": "Log", "library": "BuiltIn"},
+        ])
+        # Legacy alias for library_count
+        assert "libraries_count" in result
+
+    async def test_strategy_and_query_echoed(self):
+        result = await self._call_helper(query="click")
+        assert result["strategy"] == "session"
+        assert result["query"] == "click"
+
+    async def _call_helper(self, library_keywords=None, resource_keywords=None, query=""):
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(return_value={
+            "success": True,
+            "library_keywords": library_keywords or [],
+            "resource_keywords": resource_keywords or [],
+            "libraries_count": 1,
+            "total_before_trim": len(library_keywords or []) + len(resource_keywords or []),
+            "total_after_filter": len(library_keywords or []) + len(resource_keywords or []),
+        })
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            return await _fn(find_keywords)(
+                query=query, strategy="session",
+                session_id="sess-x",
+            )
+
+
+@pytest.mark.asyncio
+class TestRfNativeFailurePropagation:
+    """When the backend returns success=False (e.g., 'No RF context'),
+    the wrapper carries the error through."""
+
+    async def test_no_rf_context_error_propagated(self):
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(return_value={
+            "success": False,
+            "error": "No RF context for session",
+            "session_id": "sess-x",
+        })
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            result = await _fn(find_keywords)(
+                query="", strategy="session", session_id="sess-x",
+            )
+        assert result["success"] is False
+        assert "No RF context" in result["error"]

--- a/tests/unit/test_obs_33_strict_library_mode.py
+++ b/tests/unit/test_obs_33_strict_library_mode.py
@@ -1,0 +1,308 @@
+"""OBS-33 — strict_library=True filter mode.
+
+Pre-fix: ``find_keywords(strategy="pattern", query="Get*",
+library_name="Browser")`` returned 85 results across 10 libraries
+because the library_name filter only excluded plugin-table-
+incompatible siblings (SeleniumLibrary). Compatible/neutral
+libraries (BuiltIn, Collections, etc.) passed through.
+
+The fix: add ``strict_library: bool = False`` parameter to
+``find_keywords``. When True AND a preference is set, exclude EVERY
+library that isn't the preferred one. Compatible "neutral" libraries
+like BuiltIn / Collections / String / DateTime are dropped too.
+
+These tests pin:
+1. Default (strict_library=False) preserves the existing behaviour
+   — compatible siblings remain visible. BACKWARDS-COMPAT.
+2. strict_library=True + library_name="Browser" → ONLY Browser
+   keywords. Neutral helpers excluded.
+3. strict_library=True + no library_name → ignored (no library to be
+   strict about).
+4. Response carries ``library_filter.mode`` field
+   ("strict" | "compatible") so agents see which rule fired.
+5. Works across all three strategies that use the filter (semantic,
+   pattern, catalog).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robotmcp.server import (
+    _filter_keywords_by_session_library,
+    find_keywords,
+)
+
+
+def _fn(tool):
+    return getattr(tool, "fn", tool)
+
+
+def _stub_catalog(library_distribution):
+    """Build a synthetic catalog where ``library_distribution`` is
+    a list of (library, count) tuples."""
+    catalog = []
+    counter = 0
+    for lib, count in library_distribution:
+        for i in range(count):
+            catalog.append({
+                "name": f"{lib}_kw_{counter}",
+                "library": lib,
+                "args": [],
+                "short_doc": f"kw {counter}",
+            })
+            counter += 1
+    return catalog
+
+
+class TestFilterBackwardCompat:
+    """Default strict_library=False MUST preserve existing behaviour:
+    only plugin-incompatible libraries excluded; neutral libraries
+    pass through."""
+
+    def test_default_compatible_mode_keeps_neutral_libraries(self):
+        catalog = _stub_catalog([
+            ("Browser", 5),
+            ("BuiltIn", 3),
+            ("SeleniumLibrary", 2),  # incompatible with Browser
+            ("Collections", 1),
+        ])
+        filtered, excluded = _filter_keywords_by_session_library(
+            catalog, session_id="t", session_library_preference="Browser",
+        )
+        # SL excluded; Browser + BuiltIn + Collections kept
+        kept_libs = {kw["library"] for kw in filtered}
+        assert kept_libs == {"Browser", "BuiltIn", "Collections"}
+        assert len(excluded) == 2  # 2 SL keywords
+
+
+class TestStrictLibraryMode:
+    """strict_library=True excludes ALL non-preferred libraries."""
+
+    def test_strict_browser_excludes_everything_else(self):
+        catalog = _stub_catalog([
+            ("Browser", 5),
+            ("BuiltIn", 3),
+            ("SeleniumLibrary", 2),
+            ("Collections", 1),
+            ("String", 1),
+        ])
+        filtered, excluded = _filter_keywords_by_session_library(
+            catalog, session_id="t", session_library_preference="Browser",
+            strict_library=True,
+        )
+        # ONLY Browser keywords kept
+        kept_libs = {kw["library"] for kw in filtered}
+        assert kept_libs == {"Browser"}
+        assert len(filtered) == 5
+        # All non-Browser keywords excluded (7 total: 3+2+1+1)
+        assert len(excluded) == 7
+
+    def test_strict_selenium_excludes_browser_and_neutrals(self):
+        """Symmetric test: strict_library=True works for any preference."""
+        catalog = _stub_catalog([
+            ("Browser", 5),
+            ("BuiltIn", 3),
+            ("SeleniumLibrary", 4),
+        ])
+        filtered, excluded = _filter_keywords_by_session_library(
+            catalog, session_id="t",
+            session_library_preference="SeleniumLibrary",
+            strict_library=True,
+        )
+        kept_libs = {kw["library"] for kw in filtered}
+        assert kept_libs == {"SeleniumLibrary"}
+        assert len(filtered) == 4
+
+    def test_strict_mode_no_preference_no_op(self):
+        """strict_library=True with no preference is a no-op (no library
+        to be strict about)."""
+        catalog = _stub_catalog([("Browser", 5), ("BuiltIn", 3)])
+        filtered, excluded = _filter_keywords_by_session_library(
+            catalog, session_id="t", session_library_preference=None,
+            strict_library=True,
+        )
+        # No filter applied — all keywords kept
+        assert len(filtered) == 8
+        assert len(excluded) == 0
+
+    def test_strict_mode_preserves_keyword_count_diagnostic(self):
+        """Excluded count includes all dropped keywords, not just
+        plugin-incompatible ones."""
+        catalog = _stub_catalog([
+            ("Browser", 3),
+            ("BuiltIn", 10),  # would normally pass; now excluded
+        ])
+        _, excluded = _filter_keywords_by_session_library(
+            catalog, session_id="t", session_library_preference="Browser",
+            strict_library=True,
+        )
+        assert len(excluded) == 10
+
+
+@pytest.mark.asyncio
+class TestFindKeywordsStrictParameter:
+    """find_keywords accepts strict_library and passes it through."""
+
+    async def test_pattern_strategy_strict_library_filters(self):
+        """S16-style scenario: Get* + Browser + strict → only Browser
+        Get* keywords."""
+        async def _ensure_loaded():
+            return None
+
+        # Synthetic engine output: 5 Browser Get*, 8 BuiltIn Get*, 2 SL Get*
+        results = [
+            {"name": f"Get Browser{i}", "library": "Browser",
+             "args": [], "short_doc": ""}
+            for i in range(5)
+        ] + [
+            {"name": f"Get BuiltIn{i}", "library": "BuiltIn",
+             "args": [], "short_doc": ""}
+            for i in range(8)
+        ] + [
+            {"name": f"Get SL{i}", "library": "SeleniumLibrary",
+             "args": [], "short_doc": ""}
+            for i in range(2)
+        ]
+        sess_mgr = MagicMock()
+        sess_mgr.get_session = MagicMock(return_value=None)
+        engine = MagicMock()
+        engine.search_keywords = MagicMock(return_value=results)
+        engine.session_manager = sess_mgr
+
+        with patch(
+            "robotmcp.server._ensure_all_session_libraries_loaded", _ensure_loaded,
+        ), patch(
+            "robotmcp.server.execution_engine", engine,
+        ), patch(
+            "robotmcp.server._externalize_response", side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            # Without strict mode — Browser + BuiltIn kept, SL excluded
+            result_compat = await _fn(find_keywords)(
+                query="Get*", strategy="pattern", library_name="Browser",
+            )
+            kept_libs_compat = {kw["library"] for kw in result_compat["results"]}
+            assert "BuiltIn" in kept_libs_compat  # neutral kept
+
+            # With strict mode — ONLY Browser
+            result_strict = await _fn(find_keywords)(
+                query="Get*", strategy="pattern", library_name="Browser",
+                strict_library=True,
+            )
+            kept_libs_strict = {kw["library"] for kw in result_strict["results"]}
+            assert kept_libs_strict == {"Browser"}
+            assert len(result_strict["results"]) == 5
+
+    async def test_library_filter_mode_field_surfaces(self):
+        """The library_filter.mode field tells the agent which rule
+        fired ("strict" or "compatible")."""
+        async def _ensure_loaded():
+            return None
+        results = [
+            {"name": "Click", "library": "Browser", "args": [], "short_doc": ""},
+            {"name": "Log", "library": "BuiltIn", "args": [], "short_doc": ""},
+            {"name": "Click Element", "library": "SeleniumLibrary",
+             "args": [], "short_doc": ""},
+        ]
+        sess_mgr = MagicMock()
+        sess_mgr.get_session = MagicMock(return_value=None)
+        engine = MagicMock()
+        engine.search_keywords = MagicMock(return_value=results)
+        engine.session_manager = sess_mgr
+
+        with patch(
+            "robotmcp.server._ensure_all_session_libraries_loaded", _ensure_loaded,
+        ), patch(
+            "robotmcp.server.execution_engine", engine,
+        ), patch(
+            "robotmcp.server._externalize_response", side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            # Compatible mode
+            r1 = await _fn(find_keywords)(
+                query="Click*", strategy="pattern", library_name="Browser",
+            )
+            assert r1["library_filter"]["mode"] == "compatible"
+
+            # Strict mode
+            r2 = await _fn(find_keywords)(
+                query="Click*", strategy="pattern", library_name="Browser",
+                strict_library=True,
+            )
+            assert r2["library_filter"]["mode"] == "strict"
+
+    async def test_strict_library_no_library_name_no_op(self):
+        """strict_library=True without library_name (and no session
+        preference) is a no-op — no preference to be strict about."""
+        async def _ensure_loaded():
+            return None
+        results = [
+            {"name": "Click", "library": "Browser",
+             "args": [], "short_doc": ""},
+            {"name": "Log", "library": "BuiltIn",
+             "args": [], "short_doc": ""},
+        ]
+        sess_mgr = MagicMock()
+        sess_mgr.get_session = MagicMock(return_value=None)
+        engine = MagicMock()
+        engine.search_keywords = MagicMock(return_value=results)
+        engine.session_manager = sess_mgr
+
+        with patch(
+            "robotmcp.server._ensure_all_session_libraries_loaded", _ensure_loaded,
+        ), patch(
+            "robotmcp.server.execution_engine", engine,
+        ), patch(
+            "robotmcp.server._externalize_response", side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            result = await _fn(find_keywords)(
+                query="*", strategy="pattern", strict_library=True,
+            )
+        # No filter applied — both libraries' keywords remain
+        kept_libs = {kw["library"] for kw in result["results"]}
+        assert "Browser" in kept_libs
+        assert "BuiltIn" in kept_libs
+
+    async def test_default_strict_library_false_unchanged(self):
+        """When strict_library is omitted from the call, behaviour is
+        identical to pre-OBS-33 (compatible-only filter)."""
+        async def _ensure_loaded():
+            return None
+        results = [
+            {"name": "Click", "library": "Browser",
+             "args": [], "short_doc": ""},
+            {"name": "Log", "library": "BuiltIn",
+             "args": [], "short_doc": ""},
+            {"name": "Click Element", "library": "SeleniumLibrary",
+             "args": [], "short_doc": ""},
+        ]
+        sess_mgr = MagicMock()
+        sess_mgr.get_session = MagicMock(return_value=None)
+        engine = MagicMock()
+        engine.search_keywords = MagicMock(return_value=results)
+        engine.session_manager = sess_mgr
+
+        with patch(
+            "robotmcp.server._ensure_all_session_libraries_loaded", _ensure_loaded,
+        ), patch(
+            "robotmcp.server.execution_engine", engine,
+        ), patch(
+            "robotmcp.server._externalize_response", side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            result = await _fn(find_keywords)(
+                query="*", strategy="pattern", library_name="Browser",
+            )
+        # SL excluded; Browser + BuiltIn kept (existing compat behaviour)
+        kept_libs = {kw["library"] for kw in result["results"]}
+        assert "Browser" in kept_libs
+        assert "BuiltIn" in kept_libs
+        assert "SeleniumLibrary" not in kept_libs

--- a/tests/unit/test_output_noise_reduction.py
+++ b/tests/unit/test_output_noise_reduction.py
@@ -749,9 +749,10 @@ class TestExternalizationRulesExpanded:
     def test_total_rule_count(self):
         from robotmcp.domains.artifact_output.services import DEFAULT_RULES
 
-        # 14 pre-OBS-21 + 5 OBS-21 (get_keyword_info rules:
-        # library.doc, library.keywords, keyword.doc, doc, matches) = 19
-        assert len(DEFAULT_RULES) == 19
+        # 14 pre-OBS-21 + 5 OBS-21 (get_keyword_info rules) +
+        # 2 OBS-23B-impl (find_keywords.library_keywords +
+        # find_keywords.resource_keywords legacy mirrors) = 21
+        assert len(DEFAULT_RULES) == 21
 
     def test_get_session_state_rules_present(self):
         from robotmcp.domains.artifact_output.services import DEFAULT_RULES

--- a/tests/unit/test_wave3_review_fixes.py
+++ b/tests/unit/test_wave3_review_fixes.py
@@ -1,0 +1,448 @@
+"""Wave-3 round-1 review fixes.
+
+Four cross-LLM reviewers (Codex CLI, Copilot CLI sonnet-4.6, Kilo CLI
+MiniMax-M2.7, Claude sub-agent) converged on these blockers in the
+initial Wave-3 implementation:
+
+1. **S12 regression**: compound query "wait for X and click Y" was
+   classified as ``wait`` (first trigger match wins), causing the
+   reranker to penalise the click-class top match. Pre-Wave-3 top
+   was ``Browser.Click @ 0.80``, post-Wave-3 became
+   ``Browser.Wait For Condition @ 0.54``. Violated design AC #4
+   ("no regression on S12") AND the user's hard requirement
+   ("rf-mcp does not decrease in keyword finding/search").
+
+2. **Cap-then-rebuild ordering**: ``_rebuild_post_filter_recommendations``
+   ran BEFORE the post-filter cap. Result: ``matches[0].confidence``
+   was 0.5 but ``recommendations[0]`` read "confidence: 0.72" —
+   contradictory output the agent had to reconcile.
+
+3. **OBS-33 session-strategy bypass**: ``strict_library=True`` had no
+   effect on ``strategy="session"`` because the session branch never
+   invoked the filter helper. Violated OBS-33 AC #3 ("works across
+   all strategies").
+
+4. **OBS-23B-impl session_id dropped**: the legacy backend payload
+   carries top-level ``session_id``. The unified-shape wrapper
+   dropped it. Backwards-compat break.
+
+5. **Stale low_confidence_top_match**: pre-filter cap on the matcher
+   could set the flag, then filtering shuffled the top match into a
+   non-divergent set, but the flag persisted as a false positive.
+
+These tests pin all five fixes.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from robotmcp.components.keyword_matcher import (
+    KeywordMatch,
+    _classify_query_action_class,
+    apply_action_class_reranker,
+    apply_confidence_cap,
+    apply_confidence_cap_dict,
+    classify_keyword_action,
+)
+from robotmcp.config import library_registry
+from robotmcp.server import find_keywords
+
+
+@pytest.fixture(autouse=True)
+def _ensure_plugin_state():
+    """Tests in this file call ``find_keywords`` end-to-end, which
+    hits ``_filter_keywords_by_session_library`` → the global plugin
+    manager. ``test_plugin_keyword_validation.py`` has an autouse
+    fixture that resets the plugin manager state; running it before
+    this file leaves the manager empty for our tests. Re-initialize
+    explicitly so the Browser/SeleniumLibrary incompatibility table
+    is populated."""
+    library_registry._ensure_plugins_registered()
+    yield
+
+
+def _fn(tool):
+    return getattr(tool, "fn", tool)
+
+
+def _mk_match(name, library, confidence, tags=None):
+    return KeywordMatch(
+        keyword_name=name, library=library, confidence=confidence,
+        arguments=[], argument_types=[], documentation="",
+        usage_example=None, tags=list(tags or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — S12 regression: ambiguous compound queries
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguousQueryClassification:
+    """Compound queries matching multiple opinionated classes
+    classify as ``ambiguous`` (not first-match-wins). The reranker
+    abstains on ambiguous classes."""
+
+    @pytest.mark.parametrize("query,expected_class", [
+        # S12-style: wait + click compound
+        ("wait for the modal dialog to appear and then click the "
+         "confirm button at the bottom of the form", "ambiguous"),
+        # Simpler ambiguous combinations
+        ("wait for element and click it", "ambiguous"),
+        ("click button and verify result", "ambiguous"),
+        ("navigate to page and fill form", "ambiguous"),
+        ("go to url and wait for load", "ambiguous"),
+        # Single-class queries remain unambiguous
+        ("click submit button", "click"),
+        ("wait for element visible", "wait"),
+        ("fill form input field", "fill"),
+        ("navigate to url", "navigate"),
+        ("select dropdown option", "select"),
+        ("verify text is shown", "assert"),
+        ("get element text", "query"),
+        # No-trigger queries
+        ("banana telephone", "unknown"),
+        ("send http post request", "unknown"),
+        ("", "unknown"),
+    ])
+    def test_compound_queries_classify_as_ambiguous(self, query, expected_class):
+        assert _classify_query_action_class(query) == expected_class
+
+    def test_reranker_abstains_on_ambiguous(self):
+        """When query class is ``ambiguous``, the reranker must NOT
+        down-weight any class — both wait-class AND click-class
+        candidates must keep their pre-rerank confidence."""
+        matches = [
+            _mk_match("Click", "Browser", 0.85,
+                      tags=["PageContent", "Setter"]),
+            _mk_match("Wait For Elements State", "Browser", 0.80,
+                      tags=["PageContent", "Wait"]),
+            _mk_match("Get Text", "Browser", 0.75,
+                      tags=["Assertion", "Getter", "PageContent"]),
+        ]
+        out = apply_action_class_reranker(matches, "ambiguous")
+        # Confidences unchanged
+        confs = [m.confidence for m in out]
+        assert confs == [0.85, 0.80, 0.75]
+
+    def test_cap_trigger_b_does_not_fire_on_ambiguous(self):
+        """Trigger B fires only on ``unknown``. ``ambiguous`` queries
+        have meaning — no cap."""
+        matches = [
+            _mk_match("New Persistent Context", "Browser", 0.72,
+                      tags=["BrowserControl", "Setter"]),
+        ]
+        # unknown query → Trigger B fires (existing behaviour pinned)
+        _, flag_unknown = apply_confidence_cap(matches, "unknown")
+        assert flag_unknown is True
+        # ambiguous query → Trigger B does NOT fire
+        _, flag_ambig = apply_confidence_cap(matches, "ambiguous")
+        assert flag_ambig is False
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — Cap-then-rebuild ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCapBeforeRebuild:
+    """The post-filter confidence cap MUST apply BEFORE recommendations
+    are rebuilt. Pre-fix ordering produced contradictory output:
+    ``matches[0].confidence`` showed the capped value but
+    ``recommendations[0]`` showed the uncapped value."""
+
+    async def test_recommendations_show_capped_confidence(self):
+        """Inject 3 matches (1 Browser + 2 SL). Browser filter excludes
+        SL → rebuild fires. Query is ``unknown`` + opinionated top
+        Browser match at 0.72 → Trigger B → cap to 0.5. Recommendation
+        must show the CAPPED 0.5, not the uncapped 0.72."""
+        async def _ensure_loaded():
+            return None
+        discover_mock = AsyncMock(return_value={
+            "success": True,
+            "matches": [
+                {
+                    "keyword_name": "New Persistent Context",
+                    "library": "Browser",
+                    "confidence": 0.72,
+                    "arguments": ["userDataDir"],
+                    "argument_types": ["str"],
+                    "documentation": "",
+                    "usage_example": "",
+                    "tags": ["BrowserControl", "Setter"],
+                },
+                {
+                    "keyword_name": "Click Element",
+                    "library": "SeleniumLibrary",
+                    "confidence": 0.80,
+                    "arguments": ["locator"],
+                    "argument_types": ["str"],
+                    "documentation": "",
+                    "usage_example": "",
+                    "tags": [],
+                },
+                {
+                    "keyword_name": "Set Window Position",
+                    "library": "SeleniumLibrary",
+                    "confidence": 0.75,
+                    "arguments": ["x", "y"],
+                    "argument_types": ["int", "int"],
+                    "documentation": "",
+                    "usage_example": "",
+                    "tags": [],
+                },
+            ],
+            "total_matches": 3,
+            "recommendations": [
+                "Best match: Click Element (confidence: 0.80)",  # pre-filter
+            ],
+        })
+        sess_mgr = MagicMock()
+        sess_mgr.get_session = MagicMock(return_value=None)
+        engine = MagicMock()
+        engine.session_manager = sess_mgr
+        engine.search_keywords = MagicMock(return_value=[])
+        with patch.dict(os.environ, {"ROBOTMCP_MATCHER_RERANK": "1"}), patch(
+            "robotmcp.server.keyword_matcher.discover_keywords", discover_mock,
+        ), patch(
+            "robotmcp.server._ensure_all_session_libraries_loaded",
+            _ensure_loaded,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ), patch(
+            "robotmcp.server.execution_engine", engine,
+        ):
+            result = await _fn(find_keywords)(
+                query="send http post request",  # unknown class
+                strategy="semantic",
+                library_name="Browser",
+            )
+        res = result["result"]
+        # Top match capped at 0.5 (Trigger B fires on unknown query +
+        # opinionated Browser top match above cap).
+        assert res["matches"][0]["keyword_name"] == "New Persistent Context"
+        assert res["matches"][0]["confidence"] == 0.5
+        # Flag fires.
+        assert res.get("low_confidence_top_match") is True
+        # Recommendations rebuilt POST-CAP — must show 0.50, NOT 0.72.
+        assert "0.50" in res["recommendations"][0]
+        assert "0.72" not in res["recommendations"][0]
+
+    async def test_flag_cleared_when_filter_changes_top_match(self):
+        """Pre-filter cap may set ``low_confidence_top_match: True``,
+        but if the library filter shuffles top to a non-divergent set,
+        the flag must be CLEARED post-filter (not persist as false
+        positive)."""
+        async def _ensure_loaded():
+            return None
+        # Pre-filter: 3 matches spanning 3 classes (Trigger A would fire).
+        # Library filter excludes 2 SL matches → only 1 Browser match
+        # remains → Trigger A can't fire (need ≥3 matches). Trigger B
+        # also doesn't fire (query is opinionated 'click').
+        discover_mock = AsyncMock(return_value={
+            "success": True,
+            "matches": [
+                {
+                    "keyword_name": "Click",
+                    "library": "Browser",
+                    "confidence": 0.85,
+                    "arguments": [],
+                    "argument_types": [],
+                    "documentation": "",
+                    "usage_example": "",
+                    "tags": ["PageContent", "Setter"],
+                },
+                {
+                    "keyword_name": "Get Text",
+                    "library": "SeleniumLibrary",
+                    "confidence": 0.7,
+                    "arguments": [],
+                    "argument_types": [],
+                    "documentation": "",
+                    "usage_example": "",
+                    "tags": [],
+                },
+                {
+                    "keyword_name": "Wait Until Element Is Visible",
+                    "library": "SeleniumLibrary",
+                    "confidence": 0.65,
+                    "arguments": [],
+                    "argument_types": [],
+                    "documentation": "",
+                    "usage_example": "",
+                    "tags": [],
+                },
+            ],
+            "total_matches": 3,
+            "recommendations": [],
+            # Matcher set the flag based on pre-filter top-3 divergence
+            "low_confidence_top_match": True,
+        })
+        sess_mgr = MagicMock()
+        sess_mgr.get_session = MagicMock(return_value=None)
+        engine = MagicMock()
+        engine.session_manager = sess_mgr
+        engine.search_keywords = MagicMock(return_value=[])
+        with patch.dict(os.environ, {"ROBOTMCP_MATCHER_RERANK": "1"}), patch(
+            "robotmcp.server.keyword_matcher.discover_keywords", discover_mock,
+        ), patch(
+            "robotmcp.server._ensure_all_session_libraries_loaded",
+            _ensure_loaded,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ), patch(
+            "robotmcp.server.execution_engine", engine,
+        ):
+            result = await _fn(find_keywords)(
+                query="click button",  # opinionated class
+                strategy="semantic",
+                library_name="Browser",
+            )
+        res = result["result"]
+        # Only 1 Browser match remains after filter
+        assert len(res["matches"]) == 1
+        # Flag CLEARED (Trigger A can't fire on <3 matches; Trigger B
+        # only on unknown queries).
+        assert res.get("low_confidence_top_match") is None or res.get("low_confidence_top_match") is False
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — OBS-33 wired into session strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSessionStrategyStrictLibrary:
+    """OBS-33 ``strict_library=True`` must filter the unified
+    ``result.matches`` for the session strategy (not silently bypass)."""
+
+    async def test_session_strict_library_excludes_neutrals(self):
+        """Browser session with strict_library=True excludes all
+        non-Browser libraries (including BuiltIn neutrals)."""
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(return_value={
+            "success": True,
+            "session_id": "sess-x",
+            "library_keywords": [
+                {"name": "Click", "library": "Browser",
+                 "full_name": "Browser.Click"},
+                {"name": "Log", "library": "BuiltIn",
+                 "full_name": "BuiltIn.Log"},
+                {"name": "Click Element", "library": "SeleniumLibrary",
+                 "full_name": "SeleniumLibrary.Click Element"},
+            ],
+            "resource_keywords": [],
+            "libraries_count": 3,
+            "total_before_trim": 3,
+            "total_after_filter": 3,
+        })
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            result = await _fn(find_keywords)(
+                query="", strategy="session",
+                session_id="sess-x",
+                library_name="Browser",
+                strict_library=True,
+            )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # Only Browser in matches; BuiltIn + SL excluded.
+        assert libs == {"Browser"}
+        # library_filter.mode signals strict mode.
+        lf = result.get("library_filter")
+        assert lf is not None
+        assert lf["mode"] == "strict"
+
+    async def test_session_default_keeps_neutrals(self):
+        """strict_library=False (default) keeps BuiltIn alongside the
+        preferred library (only plugin-incompatible siblings excluded)."""
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(return_value={
+            "success": True,
+            "session_id": "sess-x",
+            "library_keywords": [
+                {"name": "Click", "library": "Browser"},
+                {"name": "Log", "library": "BuiltIn"},
+                {"name": "Click Element", "library": "SeleniumLibrary"},
+            ],
+            "resource_keywords": [],
+            "libraries_count": 3,
+        })
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            result = await _fn(find_keywords)(
+                query="", strategy="session",
+                session_id="sess-x",
+                library_name="Browser",
+                # strict_library defaults to False
+            )
+        libs = {m["library"] for m in result["result"]["matches"]}
+        # SL excluded (incompatible); Browser + BuiltIn kept.
+        assert libs == {"Browser", "BuiltIn"}
+        lf = result.get("library_filter")
+        assert lf is not None
+        assert lf["mode"] == "compatible"
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — session_id preserved in unified-shape response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSessionIdPreserved:
+    """The legacy backend payload carries ``session_id`` at top level.
+    The unified-shape wrapper must continue surfacing it for
+    backwards-compat (pre-fix dropped it)."""
+
+    async def test_session_id_present_at_top_level(self):
+        mock_mgr = MagicMock()
+        mock_mgr.list_available_keywords = MagicMock(return_value={
+            "success": True,
+            "session_id": "my-session-id",  # backend top-level field
+            "library_keywords": [
+                {"name": "Click", "library": "Browser"},
+            ],
+            "resource_keywords": [],
+            "libraries_count": 1,
+        })
+        with patch(
+            "robotmcp.server.get_rf_native_context_manager",
+            return_value=mock_mgr,
+        ), patch(
+            "robotmcp.server._externalize_response",
+            side_effect=lambda *a: a[-1],
+        ), patch(
+            "robotmcp.server._track_tool_result", MagicMock(),
+        ):
+            result = await _fn(find_keywords)(
+                query="", strategy="session",
+                session_id="my-session-id",
+            )
+        # session_id preserved at top level (legacy callers read it
+        # to identify the session).
+        assert result.get("session_id") == "my-session-id"


### PR DESCRIPTION
## Summary

Wave 3 of the discovery-tools improvement series. Five stories
implemented per the Wave 2 designs, then cross-LLM-reviewed by four
parallel reviewers (Codex CLI gpt-5.4, Copilot CLI claude-sonnet-4.6,
Kilo CLI minimax/MiniMax-M2.7, Claude sub-agent). Five cross-validated
blockers identified and fixed in follow-up commits.

| Story | Initial commit | Scope |
|---|---|---|
| OBS-23A | `20b0c2e` | `find_keywords(strategy="session")` honour `query` + `limit` |
| OBS-33 | `10836ec` | `strict_library=True` filter mode |
| OBS-20 | `1b846ca` | Discovery filter mirrors Browser plugin's imported-libraries fallback |
| OBS-23B-impl | `b172424` | Session strategy unified shape + Phase 1 dual-emit |
| OBS-18B | `d313bc9` | Matcher action-class reranker + confidence cap |
| **Review fixes** | `681b9a4` | All five cross-LLM-validated blockers (see below) |
| **Pinned regression** | `200ad94` | Real-matcher end-to-end baseline tests |

## User's hard constraint — "no regression in keyword finding/search"

Pre-Wave-3 baseline: 6002 unit tests. **Post-Wave-3: 6166 passed**, +164 net.

End-to-end pinned regression baselines (real matcher, no mocks):

| Scenario | Expected (OBS-18A v2 design) | Post-Wave-3 (verified) |
|---|---|---|
| S01 (`click button` + Browser) | click-class top | ✅ Browser.Click |
| **S02 (`select dropdown...` + SL)** | **`Select From List By Label`** | **✅ FIXED — was `Element Should Be Visible` pre-Wave-3** |
| S06 (`click` + Browser) | Browser.Click | ✅ Browser.Click |
| S07 (`navigate` + Browser) | Browser.Go To | ✅ Browser.Go To |
| **S10 (cross-domain + Browser)** | **`low_confidence_top_match: true` + cap 0.5** | **✅ FIXED — flag fires + capped value in recommendations** |
| **S12 (compound `wait... click...`)** | **click-class top (no regression)** | **✅ FIXED in round-1 review — was Wait For Condition** |
| S13 (BDD `When I click...`) | click-class top | ✅ Browser.Click |

## Cross-LLM review summary

| Reviewer | Output size | Verdict before fixes |
|---|---|---|
| Codex CLI (gpt-5.4) | 580 KB | OBS-18B BUGGY, OBS-23B-impl COMPAT-BREAK, OBS-33 AC-MISS, OBS-23A AC-MISS, OBS-20 TEST-INADEQUATE |
| Copilot CLI (sonnet-4.6) | 22 KB | OBS-18B AC-MISS+TEST-INADEQUATE (S12), OBS-23B-impl TEST-INADEQUATE, others READY |
| Kilo CLI (MiniMax M2.7) | 59 KB | OBS-23A BUGGY+COMPAT-BREAK, OBS-18B BUGGY+TEST-INADEQUATE, others READY |
| Claude sub-agent | (transcript) | OBS-18B BUGGY (S12 + cap-then-rebuild), OBS-33 AC-MISS, OBS-23B-impl minor |

### Convergent blockers (fixed in commit `681b9a4`)

1. **S12 regression** (Copilot + Claude): compound query `"wait for X and click Y"` was classified as `wait` due to trigger ordering, demoting click-class top match. **Fix**: queries matching multiple opinionated classes now classify as `ambiguous`; reranker abstains.
2. **Cap-then-rebuild ordering** (Codex + Claude + Kilo): `_rebuild_post_filter_recommendations` ran BEFORE the post-filter cap, producing `matches[0].confidence=0.5` but `recommendations[0]` showing 0.72. **Fix**: cap FIRST, then rebuild.
3. **OBS-33 session strategy bypass** (Codex + Claude + Kilo): `strict_library=True` had no effect on `strategy="session"`. **Fix**: session branch now applies the same library filter as other strategies.
4. **OBS-23B-impl drops `session_id`** (Codex): legacy backend payload's top-level `session_id` field was dropped by the unified-shape wrapper. **Fix**: preserved at top level.
5. **Stale `low_confidence_top_match`** (Codex): pre-filter cap could set the flag, then library filter shuffles top into non-divergent set, flag persisted as false positive. **Fix**: post-filter cap path explicitly clears the flag when no trigger fires.

### Test-quality fix (commit `200ad94`)

Codex + Claude flagged the original `TestRegressionBaselines` as tautological (only tested the query classifier on synthetic queries). Added `TestPinnedTopMatchEndToEnd` with 7 async tests that call `find_keywords` end-to-end against real matcher data.

## Tests

- **+164 new unit tests** across 7 test files
- Full suite: **6166 passed, 1 skipped, 0 failures**

| Test file | Tests | Coverage |
|---|---|---|
| `test_obs_18b_matcher_reranker.py` | 94 (87 original + 7 pinned end-to-end) | Classifier, reranker, cap, real-matcher regression |
| `test_obs_20_discovery_execution_symmetry.py` | 8 | Asymmetric Browser/SL fallback rules |
| `test_obs_23a_session_query_limit.py` | 12 | Name filter + limit, diagnostic fields |
| `test_obs_23b_session_unified_shape.py` | 19 | Unified `result.matches[]` + legacy dual-emit |
| `test_obs_33_strict_library_mode.py` | 9 | Strict mode excludes neutrals |
| `test_wave3_review_fixes.py` | 22 | All 5 cross-LLM-review fixes |

## Notable design decisions / knobs

- **Feature flag**: `ROBOTMCP_MATCHER_RERANK` (default `1` ON, set `0` to disable for rollback)
- **Reranker tunables**: `ROBOTMCP_RERANK_DOWNWEIGHT` (default 0.6), `ROBOTMCP_RERANK_CAP` (default 0.5)
- **OBS-33 + session**: `strict_library=True` works on session strategy too (after review-fix commit)
- **OBS-23B dual-emit**: legacy `library_keywords`/`resource_keywords`/`libraries_count`/`session_id` preserved at top level. Phase 2 deprecation (OBS-34, target v0.34) → Phase 3 removal (OBS-35, v0.36) tracked as follow-up stories.

## Known token-cost shifts (not regressions in result quality)

- **S07** (`navigate` + Browser): inline_tokens 725 → 2060 (+184%). Reranker preserves more navigate-class matches in top-10 at full confidence (Go To, New Page, New Browser, etc., all classified `navigate`). Top match unchanged. The agent gets more navigate options surfaced; the token cost is the trade-off.
- **S06** (`click` + Browser): similar pattern (412 → 919). Quality improvement at moderate token cost.

If these shifts become a problem, consider tightening the matcher's pre-rerank 0.3 confidence floor or adding a per-class result limit. Filed implicitly for Wave 4 polish.

## What's NOT in this PR (deferred)

Wave 4 polish stories: OBS-26 (unscoped fuzzy typo), OBS-27 (pattern results externalisation), OBS-28 (library_filter diagnostics in recs prose), OBS-29 (truncate args), OBS-31 (pattern_scope parameter).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)