### PR TITLE
fix(nlp): analyze_scenario false-positive explicit_library_preference (ADR-024)

### DIFF
--- a/docs/adr/ADR-024-explicit-library-detection-confidence.md
+++ b/docs/adr/ADR-024-explicit-library-detection-confidence.md
@@ -1,0 +1,620 @@
+# ADR-024: Explicit Library Detection — Confidence Model + Conflict Surfacing
+
+**Status:** **ACCEPTED v5** (implemented in `src/robotmcp/utils/library_detection.py`)
+**Date:** 2026-06-05
+**Author:** rf-mcp maintainer
+**Domain:** Scenario Analysis, Library Selection, Session Auto-Configuration
+**Supersedes:** None
+**Relates to:** ADR-006 (Tool Profile Bounded Context — explicit_library_preference consumed by sessions), ADR-014 (Persistent Semantic Memory — sampling-based library override path), PRD `docs/prd/analyze_scenario_explicit_library_prd.md`
+
+---
+
+## Revision history
+
+**v7 (2026-06-05)** — Codex round-6 review verified v6 source-code fixes but found a paragraph-boundary regression from v6's `\n`-drop. v7 update:
+- **§3.2 P3 sentence-split regex updated**: `r"[.;!?\n]+"` (stale) → `r"[.;!?,]+|\n\s*\n+"` (paragraph-aware). Single newline stays non-boundary; paragraph break (2+ newlines) IS a boundary. Documentation now matches the v7 source at `library_detection.py:_SENTENCE_DELIMITERS`.
+
+**v6 (2026-06-05)** — Codex round-5 review marked ADR v5 still REWRITE (P2 + RequestsLibrary table row still allowed bare `requests`/`browser` contradicting source). v6 closes:
+- **§3.2 P2 brand-only rule documented**: preference-verb tokens restricted to brand names (`selenium`, `playwright`, `appium`) + verbatim library names. Generic English/domain nouns (`browser`, `database`, `ssh`, `requests`, `xml`) excluded.
+- **§6 pattern table aligned with source**: RequestsLibrary / DatabaseLibrary / SSHLibrary / XML preference-verb rows now declare BRAND-ONLY restriction. Matches the v6 `library_detection.py:LIBRARY_RULES_DEFAULT`.
+- **Architecture decisions confirmed by implementation**: v6 source addresses 4 round-5 critical/high source bugs (session-fallback, newline-negation, repeated-token, multi-word migration). See proposal v6 for source-level details.
+
+**v5 (2026-06-05)** — Codex round-4 review marked ADR v4 REWRITE due to stale algorithm code blocks. v5 implements the architecture and updates all references:
+- **§3.2 P3 code block replaced**: the v4 ADR still showed `\b(?:not|don't|do\s+not|...)\s+(?:using\s+)?(?P<target>\w+)` — Codex flagged this is the same `target='use'` bug from v2 that the proposal had fixed but the ADR hadn't propagated. v5 replaces with the actually-shipped `_NEGATION_REGEX` alternation + `_first_library_token_in()` two-step.
+- **§3.3 / §3.4 / §3.5 dict-shaped conflicts/evidence**: v4 ADR still had tuple-shaped `conflicts={group: [(l, score, patterns) ...]}` and `evidence=[(p, w, span) ...]`. v5 aligns to the canonical dict shape used in PRD/DDD/proposal AND in the implementation (`PreferenceResolution.conflicts: Dict[str, List[Dict[str, Any]]]`, evidence is `List[Dict[str, Any]]`).
+- **§11 sampling override coherence — Site A semantic fix**: v4 still mapped `sampling_result.get("primary_library")` into `explicit_library_preference`. Codex flagged `primary_library` is the LLM's "main detected" (a recommendation), not user-stated preference. v5 drops that fallback — only `sampling_result["library_preference"]` writes to the explicit field. **Implemented at `server.py:1860-1881`.**
+- **`_NEGATION_REGEX` ordering documented**: longest-first alternation guarantees one match per span. `skip` restored to standalone alternation (round-4 D-skip regression fixed).
+- **Newline boundary fix**: preference-verb patterns use `[^\S\n]+` instead of `\s+` so multi-line scenarios like `"do not use\nSelenium"` don't match `use selenium` across the line break.
+
+**v4 (2026-05-29)** — Third-round independent review (verdict: TIGHTEN for ADR). v4 addresses:
+- **§3.2 P3 negation algorithm description updated**: replaced "phrase-list iteration" description with "single regex alternation, longest-first" to match the v4 proposal §3.1 Step 5 fix. The proposal's algorithm was changed (D1 fix); this ADR section now reflects the new design.
+- **§3.4 conflicts shape annotation**: emphasises that `library_preference_conflicts` values are LIST-OF-DICTS `[{library, score, patterns_matched}]`, NOT list-of-tuples. v3 DDD §4.1.6 had a stray tuple type that diverged; v4 DDD now aligned and ADR cross-references the canonical shape.
+- **No other ADR-level architecture changes required**: round-3 review found ADR is materially correct; the algorithm fix lives in the proposal.
+
+**v3 (2026-05-29)** — Codex CLI second-round critical review (verdict: TIGHTEN). v3 addresses:
+- **§3.3 CONFLICT_GROUPS location corrected**: v2 said "already defined at `library_detection.py:240-242`". Source verification shows it's a LOCAL dict INSIDE `get_conflicting_detections()`, NOT a module-level constant. v3 documents this and notes the implementation promotes it to module-level.
+- **§3.5 evidence shape standardised**: now matches the canonical flat-list shape `{library, pattern, weight, text_span}` per entry — same as PRD §FR-5, DDD §4.1.2 `PatternMatch`, proposal Step 4. v2 had three different shapes across the 4 docs.
+- **§3.2 P3 algorithm rewritten**: v2's regex `\b(not|...)\s+(?:using\s+)?(?P<target>\w+)` captured `target="use"`. v3 uses **phrase-list + `_first_library_token_in()`** approach (see proposal §3.1 Step 5). Sentence delimiter now `[.;!?,\n]+` (includes comma) so "do not use Selenium, instead use Playwright" splits correctly.
+- **§6 pattern-table tightening**: bare-noun preference verbs (`use browser`, `use database`, `use ssh`, `use requests`, `use xml`) dropped from `explicit=True` per Codex round-2 finding. Brand names (`use selenium`, `use playwright`, `use appium`) retained.
+- **§11 sampling override coherence — TWO sites documented**: v2 mentioned only `server.py:1860-1881` (analysis-response override). Source verification shows a second override at `server.py:1961-1972` modifying `session.explicit_library_preference`. v3 covers both. Correct env var `ROBOTMCP_USE_SAMPLING` (v2 mistakenly wrote `ROBOTMCP_USE_SAMPLING_FOR_NLP`).
+- **§12 `_compiled_patterns` test contract corrected**: v2 claimed compatibility via `__iter__` yielding 4 values. Real test contract at `test_nlp_improvements.py:571-576` is `for p, _ in entries: p.findall(...)` — `p` must be a compiled `re.Pattern`. v3 keeps `_compiled_patterns` as `Dict[str, List[Tuple[Pattern, int]]]` and stores rich annotations in a parallel `_rules_metadata` attribute.
+
+**v2 (2026-05-29)** — Codex CLI critical review identified architecture and algorithm errors. Key changes:
+- **Architecture correction (§3.1)**: removed false claim that `LibraryDetector.get_scores` backs `suggested_libraries`. The capability layer (`_determine_capabilities` at `nlp_processor.py:517-544`) is a separate substring heuristic that does NOT call `LibraryDetector`. The mention layer is currently unused by the capability path; this PRD does not change that.
+- **Algorithm ordering correction (§3.3/§3.4)**: conflict detection now runs on **raw explicit scores BEFORE threshold filtering**. v1's "filter then detect conflicts" ordering made the AC-5 example impossible (`"both selenium and playwright"` would be filtered to a single candidate before the conflict check ran). Pseudocode now explicit.
+- **Negation redesigned (§3.2)**: replaced v1's 80-character forward window with a **sentence-scoped source-vs-destination resolver** (migration patterns + per-sentence negation). The 80-char window broke `"do not use Selenium, instead use Playwright"` by zeroing both libraries.
+- **Pattern annotations corrected (§6)**: dropped wrongly-annotated `explicit=True` for `rest api testing`, `mobile automation`, `android/ios testing`, SQL fragments, DB engine names. These are domain/topic markers, not library identifiers.
+- **Downstream consumers expanded (§1.3)**: from 3 to 8 (the additional 5 surfaced by Codex's grep across library_recommender, adapter_factory, keyword_executor, browser_plugin, selenium_plugin).
+- **Alternatives section expanded (§4)**: added the 3 alternatives Codex flagged as missing — strict allow-list of library tokens, decision-tree/grammar parser, span-based source-vs-destination NLP.
+- **Performance claim removed (§9)**: v1's "≤60µs" / "<100µs aggregate" was unsupported. Replaced with "no regression vs current benchmark".
+- **Sampling override coherence (§11, NEW)**: defines what happens to evidence/conflicts when sampling overrides preference. v1 was silent on this.
+- **Test-surface compatibility (§12, NEW)**: `_compiled_patterns` introspection is preserved.
+
+**v1 (2026-05-29)** — initial draft.
+
+---
+
+## 1. Context and Problem Statement
+
+### 1.1 Reported defect
+
+On 2026-05-29 a user reported the `analyze_scenario` MCP tool returning `explicit_library_preference: "SeleniumLibrary"` for a scenario that never explicitly mentioned SeleniumLibrary:
+
+```
+Scenario: "Test e-commerce website https://demoshop.makrocode.de:
+           open browser, add items to shopping cart, verify items,
+           complete checkout, and close browser"
+```
+
+The user neither typed `selenium`, `seleniumlibrary`, `webdriver`, nor any other Selenium-specific term. They used "open browser" as a generic English verb. The system nevertheless declared an *explicit* preference for SeleniumLibrary.
+
+### 1.2 Root cause trace
+
+`src/robotmcp/utils/library_detection.py:33` contains the offending pattern:
+
+```python
+'SeleniumLibrary': [
+    ...
+    (r'\bopen\s+browser\b', 6),         # Weight 6
+    (r'\b(input\s+text|click\s+element|page\s+should\s+contain)\b', 6),
+    (r'\b(implicit|explicit)\s+wait\b', 6),
+    ...
+],
+```
+
+These patterns target SL keyword **names** (`Open Browser`, `Input Text`, `Click Element`, `Page Should Contain`). The weights are tuned at 6 — single-pattern-above-threshold, since `DEFAULT_MIN_SCORE = 5`.
+
+The user's text matches `\bopen\s+browser\b` exactly once → SeleniumLibrary score = 6 ≥ 5 → returned. Browser library scores 0 because the scenario uses neither `playwright`, `browser library`, nor `new browser/page/context`.
+
+The same overzealous detection fires on these other natural-language inputs (empirically verified on 2026-05-29):
+
+| Scenario | Detected (wrongly) | Should detect |
+|---|---|---|
+| "click element by id submit" | SeleniumLibrary | None |
+| "Page should contain Welcome text" | SeleniumLibrary | None |
+| "Input text into the username field" | SeleniumLibrary | None |
+| "Open new page in browser context" | Browser | None (also keyword name) |
+| "Test e-commerce site: open browser..." (the report) | SeleniumLibrary | None |
+
+### 1.3 Why a single overzealous pattern matters
+
+`explicit_library_preference` is consumed in **eight** load-bearing places downstream (v1 listed three; Codex review surfaced five more):
+
+| # | File:lines | Effect |
+|---|---|---|
+| 1 | `session_models.py:787` (`configure_from_scenario`) | Auto-imports the detected library at session init |
+| 2 | `server.py:2037` (`_filter_keywords_by_session_library`) | Suppresses keywords from incompatible libraries in `find_keywords` discovery |
+| 3 | `server.py` (`find_keywords` filter precedence) | Treats explicit preference as second priority (after `library_name`) |
+| 4 | `components/library_recommender.py:111-166` | Adds the preference to the front of the recommendation list with high confidence |
+| 5 | `components/library_recommender.py:310-321` | Excludes the other library from candidates |
+| 6 | `adapters/adapter_factory.py:131-140` | Selects the platform adapter (Browser vs SL) |
+| 7 | `components/execution/keyword_executor.py:1901-1914` | Disambiguates same-named keywords (e.g., `Take Screenshot`) |
+| 8 | `plugins/builtin/browser_plugin.py:314-321,379-390` + `plugins/builtin/selenium_plugin.py:202-208` | Suppress / pre-init the respective session |
+
+False detection cascades through all eight call-sites. A wrong `explicit_library_preference` is not a cosmetic bug; it determines which library loads, which keywords surface, which adapter runs, and which session pre-boots.
+
+The defect violates the principle of least surprise: "explicit" should mean "the user said so". The current implementation conflates "user used English phrases that overlap with SL keyword names" with "user explicitly chose SL".
+
+### 1.4 Constraints we cannot change
+
+- **Backward compatibility of the response shape**: `analysis.explicit_library_preference` is the documented field; existing agents read it. We can ADD fields but cannot remove or rename.
+- **Existing capability detection** (`_determine_capabilities` → `suggested_libraries`) is intentionally broad and is acceptable to keep — it's an advisory list, not a single declarative choice.
+- **Sampling-based override** (`sample_analyze_scenario` at `server.py:1863`) already exists as an opt-in LLM path; the rule-based detector must continue to provide a deterministic default.
+
+---
+
+## 2. Decision Drivers
+
+| Driver | Weight | Rationale |
+|---|---|---|
+| **Field-name accuracy** | Critical | `explicit_library_preference` must mean what it says — explicit user choice. The patterns table currently violates this contract. |
+| **Backward compatibility** | High | Existing callers (test suites, downstream tooling, ADR-006-aware sessions) read the field. Cannot rename. Can add advisory fields. |
+| **Determinism** | High | Same input → same output. Rules out runtime ML scoring. Rules must be transparent and auditable. |
+| **Pattern auditability** | High | Every pattern in the table must have a clear "this is library X mention" justification. Patterns that match generic English are out of bounds. |
+| **Conflict transparency** | Medium | When the scenario could mean either Browser or SeleniumLibrary, the user benefits from being told so rather than silently arbitrating. |
+| **Performance** | Low | The detector runs once per `analyze_scenario` call. P95 cost is ~50µs. Not on a hot path. |
+
+---
+
+## 3. Architecture Decision
+
+### 3.1 Distinguish "mention" from "preference"
+
+Introduce a conceptual split with **honest scope limits** (v1 overstated the mention layer's role; v2 corrects this):
+
+- **Mention** — the scenario text contains a token that COULD identify the library. Exposed via `LibraryDetector.get_scores(text)`. Allowed to be over-inclusive. **Current consumers: none in production code.** v1 implied this layer backed `suggested_libraries`; that was wrong. `suggested_libraries` comes from `_determine_capabilities` (nlp_processor.py:517-544), a SEPARATE substring heuristic that does not call `LibraryDetector`. The mention layer is preserved for diagnostics and potential future use, not for active consumption by this ADR's flow.
+- **Preference** — the user has explicitly chosen the library. Exposed via the new `LibraryDetector.detect_explicit_preference(text)`. Used for the load-bearing `explicit_library_preference` field that all eight consumers in §1.3 read. Must be conservative.
+
+A pattern can belong to one, both, or neither layer. Each `LIBRARY_PATTERNS` entry gains an `explicit: bool` flag (see §6 for the full table). `get_scores` ignores the flag (computes mention scores); `detect_explicit_preference` consults only `explicit=True` entries.
+
+### 3.2 Preference rules
+
+Three rule categories, evaluated in order:
+
+**P1 — Verbatim library identifier (decisive)**:
+- The scenario contains a library identifier token verbatim:
+  `seleniumlibrary`, `playwright`, `browserlibrary` (Browser), `requestslibrary`, `appium(?:library)?`, `databaselibrary`, `sshlibrary`, `xml library`/`xmllibrary`, `webdriver`, `chromedriver`/`geckodriver`/`edgedriver`/`safaridriver`, `chromium`/`webkit` (Playwright-side kernels), `rfbrowser`, `robotframework-browser`, `selenium2library`.
+- Weight: 9 or 10 depending on specificity.
+
+**P2 — Preference verb + library token (decisive)**:
+- `\b(use|using|with|via|through|prefer)[^\S\n]+(<library token>)\b` where `<library token>` is any verbatim P1 term OR a library-specific brand short name. **v6 BRAND-ONLY RULE**: only brand-name short forms (`selenium`, `playwright`, `appium`) qualify. Generic English/domain nouns (`browser`, `database`, `ssh`, `requests`, `xml`) are NOT valid preference-verb targets — they're too ambiguous (could mean web browser app, any DB tool, ssh protocol, Python `requests` package, XML the file format). To prefer those libraries, users must spell the verbatim library name (`requestslibrary`, `database library`, `ssh library`, `xml library`).
+- Weight: 10.
+- v6 newline boundary: `[^\S\n]+` instead of `\s+` so multi-line scenarios like `"use\nplaywright"` don't trigger the preference verb across the line break.
+
+**P3 — Negation and migration (sentence-scoped)**:
+
+v1 documented this as "the existing `NEGATION_PATTERNS` plus an 80-char forward window". Codex showed the 80-char window breaks `"do not use Selenium, instead use Playwright"` (it covers both library mentions, zeroing both). v2 replaced this with a sentence-scoped algorithm but used a PHRASE-LIST iteration, which caused round-3 D1: both `\bdo\s+not\s+use\b` and `\bdo\s+not\b` fired on the same span. **v4 uses a SINGLE regex with alternation, longest-first**, so each negation span fires exactly once (regex engine's left-to-right alternation guarantees longest match wins). Sentence-scoped algorithm with source/destination resolution:
+
+```
+# v7: split on sentence punctuation OR paragraph break (\n\s*\n+).
+# Single newlines are NOT boundaries (so "do not use\nPlaywright" stays one
+# sentence and negation finds the target). Paragraph breaks ARE boundaries
+# (so "Do not use this approach\n\nUse Playwright" splits correctly).
+sentences = split(scenario, regex=r"[.;!?,]+|\n\s*\n+")
+
+MIGRATION_PATTERNS = [
+  r"\bmigrat(?:e|ion|ing)\b.*?\bfrom\s+(?P<src>\w+).*?\bto\s+(?P<dst>\w+)",
+  r"\bswitch(?:ing)?\s+from\s+(?P<src>\w+).*?\bto\s+(?P<dst>\w+)",
+  r"\binstead\s+of\s+(?P<src>\w+).*?\b(?:use|with|via)\s+(?P<dst>\w+)",
+  r"\breplace\s+(?P<src>\w+)\s+(?:with|by|for)\s+(?P<dst>\w+)",
+]
+
+# v5 — SINGLE regex alternation, longest-first. Each negation span fires
+# exactly ONCE (regex engine guarantees longest match at each position).
+# `skip` restored to standalone alternation (round-4 D-skip regression).
+# v4 used a phrase LIST iterated in Python — that caused double-deduction
+# when both `\bdo\s+not\s+use\b` and `\bdo\s+not\b` matched the same span.
+_NEGATION_REGEX = re.compile(
+    r"\b(?:"
+    r"do\s+not\s+use|don't\s+use|"
+    r"not\s+using|without\s+using|stop\s+using|avoid\s+using|"
+    r"skip\s+using|exclude\s+using|"
+    r"do\s+not|don't|"
+    r"without|stop|avoid|skip|exclude"
+    r")\b",
+    re.IGNORECASE,
+)
+
+for sentence_index, sent in enumerate(_build_sentence_spans(text)):
+    # Migration (source / destination resolution)
+    for migration in MIGRATION_PATTERNS:
+        for m in re.finditer(migration, sent, re.IGNORECASE):
+            src_lib = _first_library_token_in(m.group("src"))
+            dst_lib = _first_library_token_in(m.group("dst"))
+            if src_lib:
+                _subtract_sentence_score(raw_scores, matches_by_lib,
+                                         sent, sentence_index, src_lib)
+            if dst_lib:
+                raw_scores[dst_lib] += 5  # destination bonus
+    # Negation — single regex, then resolve target via remaining-text lookup
+    for m in _NEGATION_REGEX.finditer(sent):
+        remaining = sent[m.end():]
+        target_lib = _first_library_token_in(remaining)
+        if target_lib:
+            _subtract_sentence_score(raw_scores, matches_by_lib,
+                                     sent, sentence_index, target_lib)
+```
+
+Per-sentence scoping ensures the second clause ("instead use Playwright") gets to apply its positive contribution independently of the first clause's negation. The migration patterns explicitly distinguish source from destination, avoiding the v1 forward-window pitfall. `_first_library_token_in()` does the canonical library-name resolution (handles multi-word names like "Browser Library", brand names like "Selenium", and deliberately rejects bare generic nouns like `browser`/`database`/`ssh`).
+
+**P4 — Ambiguity check**:
+- See §3.3 — runs on RAW scores BEFORE threshold filtering. When top-2 candidates inside a conflict group are within `ambiguity_window` of each other → return None + populate conflicts.
+
+**REMOVED from preference layer (kept in mention layer with `explicit=False`)**:
+- Generic action verbs that overlap with keyword names: `\bopen\s+browser\b`, `\b(input\s+text|click\s+element|page\s+should\s+contain)\b`, `\bnew\s+(browser|page|context)\b`, `\b(fill\s+text|fill\s+secret)\b`
+- Generic technique terms: `\b(implicit|explicit)\s+wait\b`, `\b(SPA|single\s+page\s+app(lication)?)\b`, `\b(e2e|end.to.end)\s+(test|automat)\b`, `\bcross[- ]browser\s+testing\b`, `\bheadless\b`, `\bshadow\s+dom\b`, `\bweb\s+components?\b`, `\bmodern\s+web\s+testing\b`, `\bmodern\s+browser\s+automation\b`
+- Domain markers (v1 wrongly kept these as `explicit=True`; Codex flagged): `\brest\s+api\s+testing\b`, `\bmobile\s+(automation|testing)\b`, `\b(android|ios)\s+(testing|test)\b`, `\b(SELECT|INSERT|UPDATE|DELETE)\s+(?:\*|FROM|INTO|SET)\b`, `\b(postgres(?:ql)?|mysql|sqlite|oracle|mariadb|mssql|sqlserver)\b`, `\bstatus\s+code\b`, `\bxpath\b`, `\bxsd\b`
+- SSH-domain noise: `\bexecute\s+command\b`, `\bremote\s+(server|host|machine)\b`, `\bssh\s+(into|to)\b`
+- Mobile-domain noise: `\bopen\s+application\b`, `\b(tap|swipe|long\s+press)\b`, `\bdevice\b`
+- DB-domain noise: `\b(check|verify)\s+if\s+exists\b`, `\brow\s+count\b`
+
+### 3.3 Conflict groups + thresholds + algorithm ordering
+
+**Conflict groups** — v3 correction: source verification at `library_detection.py:240-242` shows `CONFLICT_GROUPS` is currently a LOCAL variable inside `get_conflicting_detections()`, NOT a module-level constant. The implementation must **promote it to module-level** so the new `detect_explicit_preference` (and tests) can reference the same definition:
+
+```python
+# v3 — module-level constant in library_detection.py (PROMOTED from the local
+# dict currently scoped inside get_conflicting_detections):
+CONFLICT_GROUPS: Dict[str, Tuple[str, ...]] = {
+    "web_automation": ("Browser", "SeleniumLibrary"),
+    # Future: "mobile_native" (UIAutomator2 vs XCUITest AppiumLibrary configs)
+    # Future: "api_client" (RequestsLibrary vs hypothetical alt)
+}
+```
+
+After promotion, the existing `get_conflicting_detections()` method also reads the module-level constant (no behaviour change). This is part of the §5 implementation checklist.
+
+**Thresholds**:
+- `default_min_score = 5` — libraries OUTSIDE a conflict group (XML, Database, SSH, Requests, Appium).
+- `conflict_min_score = 8` — libraries INSIDE a conflict group (Browser, SeleniumLibrary).
+- `ambiguity_window = 4` — if two in-group libraries' raw scores differ by ≤ this value, declare a conflict.
+- Env-tunable: `ROBOTMCP_LIBRARY_DETECTION_MIN_SCORE`, `ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD`, `ROBOTMCP_LIBRARY_DETECTION_AMBIGUITY_WINDOW`.
+
+**Algorithm ordering — critical correction from v1**:
+
+```
+# Step 1: compute raw scores using only explicit=True patterns
+raw_scores = {lib: sum_weights_of_matched_explicit_patterns(lib, text) for lib in libraries}
+
+# Step 2: apply negation + migration (per §3.2 P3) — mutates raw_scores
+apply_sentence_scoped_negation_and_migration(raw_scores, text)
+
+# Step 3: CONFLICT CHECK ON RAW SCORES (v2 fix — was post-threshold in v1)
+for group, members in CONFLICT_GROUPS.items():
+    libs_with_signal = [lib for lib in members if raw_scores.get(lib, 0) > 0]
+    if len(libs_with_signal) >= 2:
+        ranked = sorted(libs_with_signal, key=lambda l: raw_scores[l], reverse=True)
+        top1, top2 = ranked[0], ranked[1]
+        if raw_scores[top1] - raw_scores[top2] <= ambiguity_window:
+            # v5: dict-shaped conflict entries (matches PRD §FR-4, DDD §4.1.6,
+            # proposal §3.1 Step 6, and the implemented PreferenceResolution).
+            return PreferenceResolution(
+                library=None,
+                source="rule",
+                conflicts={group: [
+                    {"library": l,
+                     "score": raw_scores[l],
+                     "patterns_matched": [pm.pattern for pm in matches_by_lib[l]]}
+                    for l in ranked
+                ]},
+                evidence=[],
+            )
+
+# Step 4: threshold filter (post-conflict)
+candidates = {}
+for lib, score in raw_scores.items():
+    threshold = conflict_min_score if lib_in_any_conflict_group(lib) else default_min_score
+    if score >= threshold:
+        candidates[lib] = score
+
+if not candidates:
+    return PreferenceResolution(library=None, source="rule", conflicts={}, evidence=[])
+
+winner = max(candidates, key=candidates.get)
+return PreferenceResolution(
+    library=winner,
+    source="rule",
+    conflicts={},
+    evidence=[(p, w, span) for p, w, span in matches_for(winner)],
+)
+```
+
+Why this ordering matters: v1's "threshold then conflict" sequence made the AC-5 example impossible. With `conflict_min_score=8`, `"both selenium and playwright"` yields SL=6 (filtered out before conflict check) + Browser=9 (sole survivor) → no conflict, Browser declared winner — which is NOT the documented expected outcome. v2's "conflict on raw THEN threshold" sequence catches the SL=6/Browser=9 pair at the raw stage (diff 3 ≤ 4) and returns None+conflicts, matching the AC.
+
+### 3.4 Conflict surfacing
+
+When the algorithm in §3.3 step 3 returns conflicts, the wrapping `analyze_scenario` response includes:
+
+```json
+"library_preference_conflicts": {
+  "web_automation": [
+    {"library": "Browser", "score": 9, "patterns_matched": ["\\bplaywright\\b"]},
+    {"library": "SeleniumLibrary", "score": 6, "patterns_matched": ["\\bselenium\\b"]}
+  ]
+}
+```
+
+This is purely additive: when no conflict exists, the field is absent. Field name standardised to `patterns_matched` (was `matched_patterns` in v1 inconsistently).
+
+### 3.5 Evidence provenance (v3 canonical shape)
+
+When `detect_explicit_preference` returns a library name, the response gains an `explicit_library_evidence` field — a **flat list** of pattern-match entries, each with the canonical shape used across all 4 docs:
+
+```json
+"explicit_library_evidence": [
+  {
+    "library": "SeleniumLibrary",
+    "pattern": "<regex source>",
+    "weight": 10,
+    "text_span": "<matched substring>"
+  }
+]
+```
+
+Each entry: `{library: str, pattern: str, weight: int, text_span: str}`. The list is FLAT (one entry per matching pattern, NOT grouped by library); the `library` field per entry lets downstream consumers filter or group as needed. Matches DDD §4.1.2 `PatternMatch` exactly and proposal §3.1 Step 4. Absent when no preference is set.
+
+---
+
+## 4. Alternatives Considered
+
+### 4.1 Alternative A — Raise `DEFAULT_MIN_SCORE` to 10 across the board
+
+Reject. Would break `(use|using|with) selenium` (weight 10) — that's the prototypical explicit case and must trigger. Would also miss "use playwright" (weight 10) etc. Too blunt.
+
+### 4.2 Alternative B — Remove SL keyword-name patterns ENTIRELY (including from the mentions table)
+
+Reject. The capability suggestion (`suggested_libraries`) benefits from knowing "this scenario discusses element clicks" → "needs UI library". Removing means losing that signal. Better: filter patterns OUT only for the preference layer; keep them in the mention layer.
+
+### 4.3 Alternative C — Replace pattern matching with an LLM call
+
+Reject as required behaviour. The sampling path already exists for operators who want LLM-backed detection. The rule-based path must remain deterministic so the default behaviour is reproducible and offline-capable.
+
+### 4.4 Alternative D — Demand a structured `library_hint` parameter in `analyze_scenario`
+
+Reject. Adds API surface. Most users won't pass it. The fix should make the existing detection conservative; explicit overrides via `library_name` on subsequent tools already exist.
+
+### 4.5 Alternative E — Strict allow-list of library tokens (no scoring)
+
+Reject. Hard-coded list of library identifiers; if the scenario contains an exact token, declare preference; otherwise None. Conceptually clean and trivial to implement. Downsides:
+- Loses the "use Selenium 4" / "with Playwright" preference-verb idiom unless we either bake the verbs into the allow-list (degenerates back into pattern matching) or accept that `"use Selenium"` returns None unless `selenium` is also tokenised.
+- Can't represent partial signals or conflict (it's binary).
+- Doesn't compose with the mention layer — the mention layer needs weighted scoring for capability hints.
+
+The chosen Alternative G keeps the allow-list spirit (verbatim P1 patterns) but layers it on the existing weighted scoring so we get preference-verb support and conflict signalling for free.
+
+### 4.6 Alternative F — Decision tree / grammar parser for "use X" / "from X to Y" / "prefer X"
+
+Reject. Build a tiny grammar over scenario sentences:
+```
+PrefStatement := "use" Lib | "with" Lib | "via" Lib | "prefer" Lib
+MigrationStmt := "migrate from" Lib "to" Lib | "switch from" Lib "to" Lib
+NegationStmt  := "do not use" Lib | "without" Lib | ...
+```
+Run it via an actual parser (Lark / PEG / etc.). Pros: stronger guarantees on negation correctness; handles "from X to Y" cleanly; resists adversarial inputs. Cons:
+- Heavy dependency (parser library) for a relatively small problem.
+- Schema changes every time we add a library or idiom; harder to env-tune than thresholds.
+- The chosen Alternative G's sentence-scoped algorithm captures the same source-vs-destination semantics with simple regex per sentence at materially less code/maintenance cost.
+
+We borrow the source-vs-destination concept from this alternative; we adopt it via MIGRATION_PATTERNS (§3.2 P3) rather than a full grammar.
+
+### 4.7 Alternative F' — Span-based source-vs-destination NLP
+
+Reject. Detect the spans (positions) of library tokens, then classify each span as source / destination / standalone using syntactic features (preposition, verb, position). Pros: language-model-grade quality without LLM cost. Cons:
+- Requires syntactic features we don't have (need spaCy or similar). Adds a heavy dependency.
+- Overkill for the cases this PRD must handle (migration, instead-of, replacement). The simpler `MIGRATION_PATTERNS` in Alternative G covers 95% of the expected idioms with zero dependencies.
+
+We acknowledge this as a future option if migration/negation handling grows in complexity. For now, the sentence-scoped regex approach is the right complexity match.
+
+### 4.8 Alternative G (chosen) — Two-tier "mention vs preference" model with conflict groups + thresholds + sentence-scoped negation
+
+Adopted (was Alternative E in v1; renumbered to G in v2 with the new alternatives inserted above it). Smallest API surface change. Preserves the mention layer for diagnostics. Makes the preference layer match its name. Conflict surfacing is purely additive — agents that ignore the new field see no change. Sentence-scoped negation/migration handles the source-vs-destination cases without requiring a grammar parser or NLP toolchain.
+
+---
+
+## 5. Decision
+
+**Adopt Alternative G** as detailed in §3:
+
+1. Annotate each entry in `LIBRARY_PATTERNS` with `explicit: bool` (table at §6).
+2. Add `LibraryDetector.detect_explicit_preference(text)` that:
+   - Computes raw scores using only `explicit=True` patterns.
+   - Applies sentence-scoped negation + migration (P3 in §3.2).
+   - Runs the conflict check on RAW scores BEFORE threshold filter (§3.3 ordering).
+   - Applies `default_min_score` or `conflict_min_score` per library.
+   - Returns a `PreferenceResolution(library, source, conflicts, evidence)`.
+3. `get_scores(text)` keeps its current behaviour (mention layer, ignores `explicit` flag).
+4. Update `nlp_processor._detect_explicit_library_preference` to call `detect_explicit_preference`.
+5. Update `session_models.detect_explicit_library_preference` to call `detect_explicit_preference` for single source of truth.
+6. Surface `library_preference_conflicts` + `explicit_library_evidence` + `preference_source` in `analyze_scenario` response.
+7. Env-tunable: `ROBOTMCP_LIBRARY_DETECTION_MIN_SCORE` (5), `ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD` (8), `ROBOTMCP_LIBRARY_DETECTION_AMBIGUITY_WINDOW` (4).
+8. Sampling override (server.py:1866-1880) clears evidence + conflicts and sets `preference_source: "sampling"` per §11.
+
+---
+
+## 6. Pattern Annotation Schema
+
+Replace the current `List[Tuple[str, int]]` pattern format with a richer dataclass:
+
+```python
+@dataclass(frozen=True)
+class LibraryPattern:
+    pattern: str       # regex source
+    weight: int        # 1-10
+    explicit: bool     # if True, contributes to preference scoring
+    rationale: str     # one-line justification (audit trail)
+```
+
+Migration path: keep tuples backward compatible for now; new patterns use the dataclass; gradual migration in a follow-up.
+
+The classification of every existing pattern as `explicit: True` or `explicit: False`. v2 corrects v1's miscategorisation of domain markers (`rest api testing`, `mobile automation`, `android/ios testing`, SQL fragments, DB engine names) — those are TOPICS the user is working in, not library identifiers, so they belong to the mention layer only.
+
+**Decision rule for `explicit: True`**: the pattern must be either (a) a verbatim library/runtime/driver identifier, or (b) a preference-verb idiom binding the verb to a library token. Patterns that describe the user's TASK DOMAIN (REST testing, mobile testing, SQL queries, SSH commands) do not qualify — they are ambient context.
+
+| Library | Pattern | Weight | `explicit` | Rationale |
+|---|---|---:|---|---|
+| SeleniumLibrary | `(use\|using\|with\|via\|through\|prefer)\s+(selenium\|...)` | 10 | **True** | Preference verb + library token |
+| SeleniumLibrary | `seleniumlibrary` | 9 | **True** | Verbatim library token |
+| SeleniumLibrary | `\bselenium\b` (standalone) | 6 | **True** | Library name; conflict threshold 8 prevents lone trigger |
+| SeleniumLibrary | `\bwebdriver\b` | 6 | **True** | Selenium-specific runtime |
+| SeleniumLibrary | `selenium grid`/`standalone`/`selenium 4`/etc. | 7-8 | **True** | Selenium-specific configurations |
+| SeleniumLibrary | `chromedriver`/`geckodriver`/`edgedriver`/`safaridriver` | 7 | **True** | Selenium drivers |
+| SeleniumLibrary | `(desired\|driver) capabilities` | 7 | **True** | Selenium Capabilities API |
+| SeleniumLibrary | `create webdriver`/`get webelement` | 8 | **True** | Selenium-specific kw |
+| SeleniumLibrary | `\bopen\s+browser\b` | 6 | **False** | Generic NL; overlaps with SL keyword name |
+| SeleniumLibrary | `(input text\|click element\|page should contain)` | 6 | **False** | Keyword names; generic NL |
+| SeleniumLibrary | `(implicit\|explicit) wait` | 6 | **False** | Generic concept |
+| Browser | `(use\|using\|with\|via\|prefer)\s+(playwright\|browser\s+library)` | 10 | **True** | Preference verb |
+| Browser | `\bplaywright\b` | 9 | **True** | Verbatim |
+| Browser | `\bbrowser\s+library\b` | 9 | **True** | Verbatim |
+| Browser | `\bchromium\b`/`\bwebkit\b` | 9 | **True** | Playwright kernels (v2: raised from 7 to 9; as specific as `playwright`) |
+| Browser | `rfbrowser`/`robotframework-browser` | 9 | **True** | Verbatim |
+| Browser | `playwright-?core` | 9 | **True** | Playwright runtime |
+| Browser | `new (browser\|page\|context)` | 8 | **False** | Keyword names + generic NL |
+| Browser | `fill (text\|secret)` | 7 | **False** | Keyword name |
+| Browser | `modern web testing`/`modern browser automation` | 7 | **False** | Marketing copy |
+| Browser | `cross-browser testing` | 6 | **False** | Generic test type |
+| Browser | `SPA\|single page app(lication)?` | 5 | **False** | Describes app, not library |
+| Browser | `e2e\|end.to.end` | 5 | **False** | Generic test type |
+| Browser | `headless` | 6 | **False** | Generic (SL also has headless mode) |
+| Browser | `shadow dom\|web components?` | 6 | **False** | Browser feature, not library identifier |
+| RequestsLibrary | `\b(use\|using\|with\|via\|through\|prefer)[^\S\n]+(requestslibrary\|requests\s*library)\b` | 10 | **True** | v6: BRAND-ONLY — bare `requests` excluded (too generic; could mean Python `requests` package, REST API requests, etc.). Library must be spelled as `requestslibrary` or `requests library`. |
+| RequestsLibrary | `requestslibrary` | 9 | **True** | Verbatim |
+| RequestsLibrary | `(create\|get on\|post on) session` | 8 | **True** | RL keyword names with RL-specific session noun |
+| RequestsLibrary | `rest api testing` | 7 | **False** | **v2 correction (was True in v1)**: REST API testing is a DOMAIN, not a library identifier |
+| RequestsLibrary | `\bhttp\s+requests?\b` | 5 | **False** | Generic NL |
+| RequestsLibrary | `\bstatus\s+code\b` | 5 | **False** | Domain marker, not library identifier |
+| RequestsLibrary | `(GET\|POST\|PUT\|DELETE\|PATCH)\s+(request\|on session)` | 7 | **True (only when `on session` form matches)** | The `on session` qualifier is RL-keyword-specific; bare HTTP verbs are domain-generic so drop those from explicit |
+| AppiumLibrary | `(use\|using\|with\|via\|prefer)\s+appium(?:library)?` | 10 | **True** | Preference verb |
+| AppiumLibrary | `appium(?:library)?` | 9 | **True** | Verbatim |
+| AppiumLibrary | `(UIAutomator2?\|XCUITest\|Espresso)` | 7 | **True** | Mobile-specific runtime |
+| AppiumLibrary | `mobile (automation\|testing)` | 7 | **False** | **v2 correction (was True in v1)**: domain, not library identifier — could be Appium, Detox, Maestro, etc. |
+| AppiumLibrary | `(android\|ios) (testing\|test)` | 6 | **False** | **v2 correction**: platform, not library identifier |
+| AppiumLibrary | `(open\|close) application` | 8 | **False** | Keyword names |
+| AppiumLibrary | `(tap\|swipe\|long press\|scroll\|pinch)` | 6 | **False** | Generic action verbs |
+| AppiumLibrary | `\bdevice\b` (alone) | 5 | **False** | Too generic |
+| DatabaseLibrary | `\b(use\|using\|with\|via\|through\|prefer)[^\S\n]+(databaselibrary\|database\s*library)\b` | 10 | **True** | v6: BRAND-ONLY — bare `database` excluded (generic noun; could mean any DB tool). |
+| DatabaseLibrary | `databaselibrary` | 9 | **True** | Verbatim |
+| DatabaseLibrary | `(SELECT\|INSERT\|UPDATE\|DELETE)\s+(FROM\|INTO\|SET\|\*)` | 5 | **False** | **v2 correction**: SQL is the user's domain, not a library identifier; could be DatabaseLibrary, raw psycopg2 via Python wrapper, etc. |
+| DatabaseLibrary | `(postgres(ql)?\|mysql\|sqlite\|oracle\|mariadb\|mssql\|sqlserver)` | 5 | **False** | **v2 correction**: DB engine name, not RF library identifier |
+| DatabaseLibrary | `(check\|verify)\s+if\s+exists`/`row count` | 5-6 | **False** | Keyword names; generic NL |
+| SSHLibrary | `\b(use\|using\|with\|via\|through\|prefer)[^\S\n]+(sshlibrary\|ssh\s*library)\b` | 10 | **True** | v6: BRAND-ONLY — bare `ssh` excluded (protocol noun; could mean ssh CLI / paramiko). |
+| SSHLibrary | `sshlibrary` | 9 | **True** | Verbatim |
+| SSHLibrary | `execute command` | 6 | **False** | Keyword name; generic NL |
+| SSHLibrary | `remote (server\|host\|machine)` | 5 | **False** | Domain, not library identifier |
+| SSHLibrary | `ssh into`/`ssh to` | 6 | **False** | Action verb, not library identifier (could be sshpass, paramiko-script, etc.) |
+| XML | `\b(use\|using\|with\|via\|through\|prefer)[^\S\n]+(xmllibrary\|xml\s*library)\b` | 10 | **True** | v6: bare `xml` already excluded (XML is a file format). Library must be spelled `xmllibrary` or `xml library`. |
+| XML | `xmllibrary` | 9 | **True** | Verbatim |
+| XML | `\bxpath\b`/`\bxsd\b`/`\bxslt\b` | 5 | **False** | **v2 correction**: XML technology, not RF library identifier (XPath is also used by SeleniumLibrary locators) |
+| XML | `\bxml\b` (alone) | 4 | **False** | Too generic; could mean XML the file format |
+| XML | `parse xml` | 5 | **False** | Generic NL |
+
+**Patterns removed from `explicit=True` since v1**: `rest api testing`, `mobile automation`, `android testing`, `ios testing`, SQL fragments, DB engine names, XPath/XSD/XSLT (XML), bare `xml` keyword. All retained in `LIBRARY_PATTERNS` with `explicit=False` so `get_scores` still surfaces them in the mention layer for diagnostic use.
+
+---
+
+## 7. Consequences
+
+### 7.1 Positive
+
+- **`explicit_library_preference` becomes trustworthy.** Agents/users can act on it without worrying about false positives.
+- **Reproducer scenario fixed.** "Open browser" no longer cascades into SL session config.
+- **Conflict awareness.** Users with genuinely ambiguous scenarios get told and can clarify.
+- **Audit trail.** `explicit_library_evidence` lets users see why detection fired.
+- **Defensible threshold knob.** Conflict-group threshold (8) is principled — must clear two weight-6 patterns OR one weight-9 pattern.
+
+### 7.2 Negative
+
+- **Some scenarios that previously fired detection won't anymore.** The user's session won't be auto-configured for Selenium when they typed only "open browser" — they'll need to pass `library_name="SeleniumLibrary"` explicitly OR use a phrase like "use Selenium". This is the correct outcome (the previous behaviour was the bug) but may surprise users who relied on the false-positive auto-config.
+- **Mitigation**: the `suggested_libraries` field still recommends both Browser and SeleniumLibrary for generic web work — agents can pick one explicitly.
+
+### 7.3 Neutral
+
+- **New env vars**: 3 added (`ROBOTMCP_LIBRARY_DETECTION_*`). Documented; default values mean operators don't need to touch them.
+- **Response shape**: 2 new optional fields. Additive. No breakage for callers reading only existing fields.
+
+---
+
+## 8. Implementation Anchors (for the solution proposal)
+
+- `src/robotmcp/utils/library_detection.py:21-126` — `LIBRARY_PATTERNS` table; add `_EXPLICIT_PATTERN_FILTER` or per-pattern `explicit` flag.
+- `src/robotmcp/utils/library_detection.py:155-180` — `detect()`; replace single-threshold logic with `detect_explicit_preference()` that uses the explicit subset + conflict thresholds.
+- `src/robotmcp/utils/library_detection.py:231-252` — `get_conflicting_detections()`; extend to return scores + matched patterns.
+- `src/robotmcp/components/nlp_processor.py:652-704` — `_detect_explicit_library_preference`; switch to the new method; populate `explicit_library_evidence` in response.
+- `src/robotmcp/components/nlp_processor.py:253-280` — `analyze_scenario` return shape; add `library_preference_conflicts` and `explicit_library_evidence` to `analysis` block.
+- `src/robotmcp/models/session_models.py:563-590` — `detect_explicit_library_preference`; switch to the new method to keep single source of truth.
+- `src/robotmcp/server.py:1944-1985` — `analyze_scenario` MCP wrapper; ensure the new fields surface in the response unchanged.
+
+---
+
+## 9. Acceptance & Validation Plan
+
+(Detailed acceptance criteria live in the PRD §7. ADR-level validation:)
+
+| Validation | Method |
+|---|---|
+| **Reproducer fixed** | Empirical: re-run the reported scenario; assert `explicit_library_preference: None`. |
+| **No regression on truly-explicit cases** | Unit tests for "use playwright", "use selenium", "POST to /api/users", "parse XML and xpath". |
+| **Conflict detection** | Unit test for "Test both Selenium and Playwright" → `library_preference_conflicts.web_automation` populated. |
+| **Negation preserved** | Existing negation tests (if any) plus new test for "migrate from selenium to playwright" → Browser wins after negation. |
+| **Threshold tunability** | Unit test: `ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD=4` allows weight-6 lone hits; default `8` blocks them. |
+| **Evidence provenance** | Unit test: explicit detection includes `explicit_library_evidence` with the matched pattern. |
+| **Performance** | No regression vs baseline. `tests/benchmarks/test_library_detection_bench.py` continues to pass within existing tolerances. v1's "<100µs aggregate" claim was unmeasured; v2 drops it. |
+
+---
+
+## 10. Open Questions
+
+| Question | Recommended Default |
+|---|---|
+| `webdriver` weight stays at 6? | Yes — conflict-threshold 8 means it can't fire alone. |
+| Move `chromium`/`webkit` to weight 9 (verbatim browser kernels)? | Yes — they're as specific as `playwright`. Folded into §6 in v2. |
+| Should `library_preference_conflicts` also fire for non-conflict-group cases (e.g., DB + Web both mentioned)? | No — different domains; both are valid signals. Only fire WITHIN a group. |
+| Should `explicit_library_evidence` include text spans? | Yes — pattern + the actual matched substring, capped at first match per pattern. |
+| Sampling-based override: does it bypass these rules? | Yes (existing behaviour). Sampling's output is authoritative when enabled. v2 §11 defines the evidence/conflicts coherence. |
+| Should non-English scenarios route through the rule-based detector? | Yes, returning None is the safe outcome. Future locale-specific pattern sets are out of scope. |
+
+---
+
+## 11. Sampling override coherence (v3 — TWO override sites)
+
+LLM sampling overrides the rule-based detector at **two independent sites** in `server.py`. v2 documented only the first; v3 covers both:
+
+**Site A — analyze_scenario response override** (`server.py:1860-1881`):
+Overrides `analysis["explicit_library_preference"]` in the MCP response.
+
+**Site B — session aggregate override** (`server.py:1961-1972`):
+Overrides `session.explicit_library_preference` on the ExecutionSession.
+
+Both sites are gated by `is_sampling_enabled()` which reads the **`ROBOTMCP_USE_SAMPLING`** env var (verified at `sampling.py:23`). v2 wrongly wrote `ROBOTMCP_USE_SAMPLING_FOR_NLP`; that env var doesn't exist.
+
+**Coherence protocol (Site A — analysis response)**:
+
+| Override state | `explicit_library_preference` | `preference_source` | `explicit_library_evidence` | `library_preference_conflicts` | `sampling_evidence` |
+|---|---|---|---|---|---|
+| No sampling (default) | rule-based winner or None | `"rule"` | rule-based matches | rule-based conflicts | absent |
+| Sampling enabled, override applied | sampling value | `"sampling"` | **cleared** | **cleared** | model rationale |
+| Sampling enabled, no override returned | rule-based winner or None | `"rule"` | rule-based matches | rule-based conflicts | absent |
+
+**Coherence protocol (Site B — session aggregate)**:
+
+| Override state | `session.explicit_library_preference` | `session.preference_source` |
+|---|---|---|
+| No sampling (default) | rule-based winner or None | `"rule"` |
+| Sampling enabled, override applied | sampling value | `"sampling"` (NEW attribute) |
+| Sampling enabled, no override | rule-based winner or None | `"rule"` |
+
+Rationale: presenting rule-based evidence next to a sampling-derived preference would mislead consumers into thinking the patterns justified the choice. Clearing the fields and setting `preference_source` makes the source-of-truth unambiguous at both sites.
+
+---
+
+## 12. Test-surface compatibility (v3 — real contract)
+
+v2's claim of `_compiled_patterns` compatibility was wrong. Source verification at `tests/integration/test_nlp_improvements.py:569-576` shows:
+
+```python
+raw_browser = any(
+    p.findall("migrate from selenium to browser library for modern testing")
+    for p, _ in library_detector._compiled_patterns.get("Browser", [])
+)
+```
+
+The test:
+1. Destructures with `for p, _ in ...` — requires **exactly 2 items per entry**. Python tuple unpacking enforces exact length; an `__iter__` yielding 4 raises `ValueError: too many values to unpack`.
+2. Calls `p.findall(...)` — `p` must be a compiled `re.Pattern`, NOT a `PatternRule`.
+
+v3 honours both requirements with a **two-store** design (per proposal §3.1 Step 7):
+
+```python
+class LibraryDetector:
+    LIBRARY_RULES: Dict[str, List[PatternRule]]   # source of truth (rich)
+
+    # v3: legacy store — Pattern tuples for test-fixture compat. UNCHANGED shape:
+    _compiled_patterns: Dict[str, List[Tuple[re.Pattern, int]]]
+
+    # v3: rich metadata store for the new detect_explicit_preference() path:
+    _rules_metadata: Dict[str, List[PatternRule]]
+```
+
+`_compiled_patterns` keeps `(Pattern, int)` 2-tuples exactly as today. The `for p, _ in ...` test contract continues to work. The new code paths read `LIBRARY_RULES` or `_rules_metadata` directly to access the `explicit` and `rationale` annotations.
+
+This preserves the existing test surface without changes to test code (other than the 3-5 false-positive-asserting tests enumerated in PRD §AC-8). `PatternRule` does NOT need `__iter__` — legacy tests never see `PatternRule` objects.

--- a/docs/ddd/library_preference_bounded_context.md
+++ b/docs/ddd/library_preference_bounded_context.md
@@ -1,0 +1,551 @@
+# DDD — Library Preference Bounded Context
+
+**Date**: 2026-05-29
+**Status**: **IMPLEMENTED v5** (source in `src/robotmcp/utils/library_detection.py`)
+**Scope**: scenario analysis → library identification
+**Related**: PRD `docs/prd/analyze_scenario_explicit_library_prd.md`, ADR-024 `docs/adr/ADR-024-explicit-library-detection-confidence.md`, solution proposal `docs/proposals/explicit_library_detection_fix_proposal.md`
+
+---
+
+## Revision history
+
+**v6 (2026-06-05)** — Codex round-5 review confirmed DDD v5 TIGHTEN; v6 adds notes on the 4 critical source bugs that v6 fixed (architecture is unchanged, implementation was tightened):
+- **D-session-fallback note added to §5 Boundaries**: `ExecutionSession.detect_explicit_library_preference` is a DELEGATE to `LibraryDetector.detect_explicit_preference` — it MUST NOT fall back to broad mention-layer heuristics when v6 detector deliberately returns None (that would undo the bounded context's conservative preference contract).
+- **Implementation status confirmed coherent end-to-end**: analysis-path AND session-aggregate paths both return None for the reported scenario. 18 new v6 unit tests cover the previously-orphaned cases.
+
+**v5 (2026-06-05)** — implementation landed; Codex round-4 review confirmed propagation gaps in v4 ADR/proposal that are closed in v5. Key DDD updates:
+- **§2 overview shape strings updated**: `List[PatternMatch]` → `List[Dict[str, Any]]` with the canonical `{library, pattern, weight, text_span}` entry shape. `List[(lib, score, patterns)]` → `Dict[str, List[Dict[str, Any]]]`. Now matches `PreferenceResolution` in the actual implementation.
+- **§4.1.6 `PreferenceResolution.conflicts` type confirmed dict-of-dicts**: same shape used by PRD/ADR/proposal AND by `src/robotmcp/utils/library_detection.py:PreferenceResolution`. v4 already had this; v5 propagation completed.
+- **Race-free invocation noted**: `NaturalLanguageProcessor._resolve_explicit_library_preference()` returns the resolution as a local — no `self._last_resolution` stash. Tested via `TestNoSharedState::test_interleaved_analyses_no_state_bleed`. The shared `_detector` module-level singleton remains, but it's only read after construction so there's no mutation race.
+
+**v4 (2026-05-29)** — Third-round independent review (verdict: TIGHTEN for DDD). v4 addresses:
+- **§4.1.6 `PreferenceResolution.conflicts` type fixed**: v3 declared `Dict[str, List[Tuple[str, int, List[str]]]]` (tuple) but PRD/ADR/proposal use dict-of-dicts shape `[{library, score, patterns_matched}]`. v3 DDD was the outlier and the proposal's `TestConflicts` was broken because it unpacked `entry[0]` (tuple style) while the algorithm returned dicts. v4 aligns DDD to the dict shape; proposal test fixed in parallel.
+- **§4.1.6 `evidence` type fixed**: `List[PatternMatch]` → `List[Dict[str, Any]]` to reflect the actual to_dict-flattened shape that surfaces in the JSON response.
+- **§7 INV-4 strengthened**: v3's negation-idempotence was trivially true (`max(0, x-d)` always idempotent). v4 replaces with **deduction-sum equality** — sum of deductions across all phrase matches equals single-canonical-phrase deduction. This DOES catch the round-3 D1 double-deduction bug. v3's INV-4 wouldn't have.
+
+**v3 (2026-05-29)** — Codex CLI second-round critical review (verdict: TIGHTEN). v3 addresses:
+- **§5 boundary diagram fixed**: v2 prose claimed mention layer is diagnostic-only but the diagram still showed `MentionScorer` "Used for: capability list (suggested_libs)". v3 redraws the diagram to match the prose — mention layer marked "diagnostic only, no current production consumer".
+- **INV-4 replaced (was vacuous)**: v2's "When `score(text)[lib] > 0` for some library and `lib` has only `explicit=False` patterns..." was vacuous because every library in the v3 pattern table has at least one `explicit=True` pattern. v3 replaces it with a verifiable invariant about sentence-scoped negation idempotence.
+- **§6.2 `_compiled_patterns` description corrected**: v2 implied the attribute structure could change. v3 documents the **two-store design** where `_compiled_patterns` keeps its exact current shape `Dict[str, List[Tuple[Pattern, int]]]` and rich annotations live in a parallel `_rules_metadata` store.
+- **§4.1.2 `PatternMatch.to_dict()` field order standardised**: matches the canonical evidence shape `{library, pattern, weight, text_span}` used in PRD §FR-5, ADR §3.5, proposal Step 4.
+- **§11 round-1 findings table preserved** + new round-2 table added at §12.
+
+**v2 (2026-05-29)** — Codex CLI critical review identified over-modeling and incorrect domain claims. Key changes:
+- **Removed over-modeled value objects**: `DetectionScore`, `ConflictGroup`, and `MentionScorer` are no longer separate value objects. Codex correctly identified them as "window dressing" — `DetectionScore` is `(library_name, int_score, [PatternMatch])` which can be a tuple/dict; `ConflictGroup` is a literal `{name: tuple_of_libs}` map already declared as `CONFLICT_GROUPS`; `MentionScorer` is `LibraryDetector.get_scores` renamed. v2 keeps just `PatternRule`, `DetectionPolicy`, `PatternMatch`, and `PreferenceResolution` as the actual value objects.
+- **"Stateless" claim retracted (§4.2)**: `LibraryDetector` is NOT stateless — it holds a compiled-pattern cache and is consumed as a process-global singleton from `nlp_processor` and `session_models`. v1's claim was wrong. v2 documents the reality.
+- **INV-3 (purity) reframed**: `PreferenceResolver.resolve(text)` is pure *within a given DetectionPolicy snapshot*. Because the policy reads env vars at construction, two resolvers built with different env states differ; v1 implied the resolver was globally pure.
+- **INV-4 (mention ≥ preference) dropped**: v1 claimed mention scores ≥ preference scores as an invariant. After v2's architecture correction (capability suggestion does NOT consume mention scores in the current codebase), this invariant is unverifiable in production. Kept as an algorithmic property of `score()` but not a context invariant.
+- **NEGATION_PATTERNS + MIGRATION_PATTERNS added to §5 Boundaries**: v1 silently owned negation but never listed it. v2 explicitly names the patterns this context owns vs delegates.
+- **Architecture correction**: §2 + §5 corrected to reflect that `suggested_libraries` is computed by `_determine_capabilities` (separate substring heuristic) NOT by this context's mention layer. Mention layer is preserved for diagnostics/future use only.
+- **`_compiled_patterns` test-surface compatibility added to §6.2**: existing tests inspect this internal attribute; v2 implementation preserves it.
+
+**v1 (2026-05-29)** — initial draft.
+
+---
+
+## 1. Why a bounded context?
+
+The current code conflates two related-but-distinct domain concerns into one detector:
+
+1. **Library mention** — "does the scenario text discuss things this library could automate?" (advisory, broad)
+2. **Library preference** — "did the user choose this library?" (decisive, narrow)
+
+Both reasonably need pattern matching against scenario text, but they have different value semantics, different consumers, and different acceptable false-positive rates. Treating them as one rule set has produced the reported defect (`open browser` triggering explicit SL preference).
+
+This document defines the bounded context that separates the two, names the value objects + aggregates + services, and pins their interactions. The implementation lands per ADR-024 §3 and the solution proposal.
+
+---
+
+## 2. Bounded Context Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Library Preference Bounded Context                                 │
+│                                                                     │
+│  Inputs:                                                            │
+│    - scenario text (string)                                         │
+│    - DetectionPolicy (env-resolved at construction time)            │
+│                                                                     │
+│  Outputs (via PreferenceResolution):                                │
+│    - explicit_library_preference: Optional[str]                     │
+│    - explicit_library_evidence: List[Dict[str, Any]]                │
+│        each: {library, pattern, weight, text_span}                  │
+│    - library_preference_conflicts: Dict[str, List[Dict[str, Any]]]  │
+│        each: {library, score, patterns_matched}                     │
+│    - preference_source: Literal["rule", "sampling"]                 │
+│                                                                     │
+│  Internal model (v2 — minimised after Codex review):                │
+│    - PatternRule (frozen value object — pattern, weight, explicit)  │
+│    - PatternMatch (frozen value object — pattern, weight, span)     │
+│    - DetectionPolicy (frozen value object — env-resolved thresholds)│
+│    - PreferenceResolution (frozen value object — public output)     │
+│    - LibraryDetector (stateful service — holds compiled-pattern     │
+│        cache as a process-global singleton)                         │
+│    - PreferenceResolver (stateless service — delegates to detector) │
+│                                                                     │
+│  Consumers (downstream — the 8 from PRD §2):                        │
+│    - session_models.ExecutionSession.configure_from_scenario        │
+│    - server._filter_keywords_by_session_library                     │
+│    - components.library_recommender (lines 111-166, 310-321)        │
+│    - adapters.adapter_factory (lines 131-140)                       │
+│    - execution.keyword_executor (lines 1901-1914)                   │
+│    - plugins.browser_plugin (lines 314-321, 379-390)                │
+│    - plugins.selenium_plugin (lines 202-208)                        │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+The context is intentionally narrow: it does NOT decide library *capabilities* (`_determine_capabilities` at `nlp_processor.py:517-544` is a SEPARATE substring heuristic that does not call this context), it does NOT auto-import libraries (that stays in `ExecutionSession`), it does NOT consume MCP tool params. Its single responsibility is "given scenario text, what's the user's explicit library intent?"
+
+**Mention layer status (v2 correction)**: `LibraryDetector.get_scores(text)` (the mention API) is preserved for diagnostics and potential future consumption by capability suggestion. **It is not consumed by any production code path today** — v1 implied it backed `suggested_libraries`; that was wrong. Keeping it documented here makes future capability-suggestion refactors easier without committing to a near-term consumer.
+
+---
+
+## 3. Ubiquitous Language
+
+| Term | Definition |
+|---|---|
+| **Library** | A Robot Framework library identified by its canonical name (`Browser`, `SeleniumLibrary`, `RequestsLibrary`, `AppiumLibrary`, `DatabaseLibrary`, `SSHLibrary`, `XML`). |
+| **Mention** | Any scenario-text occurrence that COULD identify a library, including keyword names and generic action verbs. Scores accumulate; allowed to be inclusive. |
+| **Preference** | A decisive identification: the user has unambiguously chosen this library. Requires verbatim library identifiers OR preference verbs. |
+| **Evidence** | The pattern (and matched text span) that contributed to a preference decision. Used for audit trails. |
+| **Conflict group** | A set of libraries that compete for the same job (e.g., `{Browser, SeleniumLibrary}` for web automation). When multiple group members are detected, the user has likely been ambiguous. |
+| **Ambiguity window** | The score difference threshold below which two scores in the same conflict group are considered tied. Default 4. |
+| **Pattern weight** | An integer 1-10 reflecting how strongly a pattern signals a library. 10 = verbatim preference verb; 9 = verbatim library name; 7-8 = library-specific concept; 5-6 = weaker hint. |
+| **Explicit pattern** | A pattern that contributes to preference scoring. Annotated `explicit: True`. |
+| **Mention pattern** | A pattern that contributes only to mention scoring. Annotated `explicit: False`. |
+| **Conflict threshold** | Min score to declare preference for a library inside a conflict group. Default 8 (higher than the general min_score of 5). |
+| **Negation** | A textual cue ("not", "without", "instead of", "migrate from") that subtracts score from the preceding library mention. |
+
+---
+
+## 4. Domain Model
+
+### 4.1 Value Objects (immutable, identity by value)
+
+v2 minimised the value object set after Codex flagged three of v1's objects as over-modeled. The objects below are the ones that genuinely deserve dataclass status (they're passed between modules, returned by public methods, have invariants worth checking). The dropped objects (`DetectionScore`, `ConflictGroup`, `MentionScorer`) live on as plain dicts/tuples and a renamed method.
+
+#### 4.1.1 `PatternRule`
+
+```python
+@dataclass(frozen=True)
+class PatternRule:
+    """A single regex pattern that matches a library identifier or
+    library-related concept."""
+    pattern: str          # raw regex source
+    weight: int           # 1-10 — strength of the signal
+    explicit: bool        # True → contributes to preference; False → mention only
+    rationale: str        # one-line audit comment: why this pattern is in the table
+
+    def compile(self) -> re.Pattern:
+        return re.compile(self.pattern, re.IGNORECASE)
+```
+
+Invariants:
+- `weight in range(1, 11)` (1-10 inclusive)
+- `pattern` compiles as a valid regex
+- `rationale` non-empty
+
+#### 4.1.2 `PatternMatch`
+
+```python
+@dataclass(frozen=True)
+class PatternMatch:
+    """A single (library, pattern, weight, span) match record."""
+    library: str        # canonical library name (v3: now first field)
+    pattern: str        # pattern source (for audit)
+    weight: int
+    text_span: str      # the substring that matched (first occurrence)
+
+    def to_dict(self) -> Dict:
+        return {
+            "library": self.library,
+            "pattern": self.pattern,
+            "weight": self.weight,
+            "text_span": self.text_span,
+        }
+```
+
+v3 field-order standardised: `library` first to match the canonical evidence-entry shape used in PRD §FR-5, ADR §3.5, proposal §3.1 Step 4. v2 had `library` last; v3 puts it first for consistency. The `to_dict()` ordering also matches the JSON shape downstream consumers read.
+
+#### 4.1.3 Conflict groups — plain map, not a value object
+
+v1 introduced `ConflictGroup` as a frozen dataclass with `.includes()`. Codex flagged this as over-modeling — the data is a static `{group_name: tuple_of_libraries}` mapping that lives at module top level:
+
+```python
+CONFLICT_GROUPS: Dict[str, Tuple[str, ...]] = {
+    "web_automation": ("Browser", "SeleniumLibrary"),
+    # Future: "mobile_native": ("AppiumLibrary_iOS", "AppiumLibrary_Android")
+    # Future: "api_client": ("RequestsLibrary", ...)
+}
+```
+
+The `includes()` check is `library in CONFLICT_GROUPS[group]` — no abstraction warranted. The mapping is `frozen` by virtue of being a module-level constant (no mutator API).
+
+#### 4.1.4 `DetectionScore` — plain dict, not a value object
+
+v1 wrapped per-library `(score, matches)` in a `DetectionScore` dataclass. Codex flagged this as window-dressing. v2 uses a plain dict directly:
+
+```python
+# Internal type alias used by LibraryDetector.score() return value
+ScoresByLibrary = Dict[str, int]                # mention layer return
+ExplicitScoresByLibrary = Dict[str, Tuple[int, List[PatternMatch]]]   # preference layer return
+```
+
+The `PreferenceResolver` consumes these dict types directly and emits a single `PreferenceResolution` (4.1.6) — no intermediate VO needed.
+
+#### 4.1.5 `DetectionPolicy`
+
+```python
+@dataclass(frozen=True)
+class DetectionPolicy:
+    """Operator-tunable thresholds for the preference resolver."""
+    default_min_score: int = 5
+    conflict_min_score: int = 8
+    ambiguity_window: int = 4
+
+    @classmethod
+    def from_env(cls) -> "DetectionPolicy":
+        return cls(
+            default_min_score=int(os.getenv("ROBOTMCP_LIBRARY_DETECTION_MIN_SCORE", "5")),
+            conflict_min_score=int(os.getenv("ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD", "8")),
+            ambiguity_window=int(os.getenv("ROBOTMCP_LIBRARY_DETECTION_AMBIGUITY_WINDOW", "4")),
+        )
+```
+
+#### 4.1.6 `PreferenceResolution`
+
+```python
+@dataclass(frozen=True)
+class PreferenceResolution:
+    """The outcome of running the preference resolver on a scenario.
+    Constitutes the public output of this bounded context."""
+    library: Optional[str]                                # the chosen library, or None
+    source: Literal["rule", "sampling"]                   # provenance (v2)
+    evidence: List[Dict[str, Any]]                        # v4: list of PatternMatch.to_dict() — flat shape {library, pattern, weight, text_span}
+    conflicts: Dict[str, List[Dict[str, Any]]]            # v4: dict-of-dicts to match PRD/ADR/proposal; each entry {library, score, patterns_matched}
+    all_scores: Dict[str, int]                            # full score map (for diagnostics)
+    sampling_evidence: Optional[str] = None               # raw LLM rationale when source=sampling (v2)
+
+    @property
+    def is_decisive(self) -> bool:
+        return self.library is not None
+
+    @property
+    def has_conflicts(self) -> bool:
+        return any(len(c) >= 2 for c in self.conflicts.values())
+```
+
+**v4 type correction (D3 fix)**: v3 declared `conflicts: Dict[str, List[Tuple[str, int, List[str]]]]` (tuple-of-three shape). PRD §FR-4, ADR §3.4, and proposal Step 6 all use a dict-of-dicts shape `[{library, score, patterns_matched}]`. v3 was the outlier and the proposal's `TestConflicts` test in §3.4 unpacked `entry[0]` (tuple style) but the algorithm returned dicts — broken as written. v4 aligns DDD to the dict shape used by the other three docs. `evidence` similarly changed from `List[PatternMatch]` to `List[Dict[str, Any]]` to reflect the actual to_dict-flattened shape that surfaces in the JSON response.
+
+### 4.2 Aggregates and statefulness (v2 correction)
+
+v1 claimed "the detector is stateless". That was wrong. `LibraryDetector` holds a compiled-pattern cache (computed once at `__init__`, used per call) and is consumed as a **process-global singleton** from `nlp_processor` and `session_models`. The singleton design predates this PRD and is not being changed.
+
+What the v2 design genuinely guarantees:
+- `LibraryDetector.score(text)` is **idempotent**: same text + same policy + same pattern table → same scores.
+- `PreferenceResolver.resolve(text)` is **idempotent within a constructed policy**: see INV-3 in §7 for the precise statement.
+- No state mutates after construction. The compiled-pattern cache is read-only at runtime; the policy is captured at construction. There is no add-pattern API at runtime.
+
+The detector is therefore "effectively immutable" but not "stateless". The distinction matters for testing and for understanding the singleton lifecycle.
+
+### 4.3 Domain Services
+
+#### 4.3.1 `LibraryDetector` (existing, augmented)
+
+Sole responsibility: turn a scenario text + pattern table into per-library scores.
+
+```python
+class LibraryDetector:
+    """Process-global singleton. Holds compiled-pattern cache.
+    Idempotent: same input + same policy + same pattern table -> same output."""
+
+    LIBRARY_RULES: Dict[str, List[PatternRule]]   # source-of-truth pattern table
+    NEGATION_PATTERNS: List[str]                   # subtractive patterns (v2: owned here)
+    MIGRATION_PATTERNS: List[str]                   # source-vs-dest patterns (v2: new, owned here)
+
+    def __init__(self, rules: Dict[str, List[PatternRule]], policy: DetectionPolicy): ...
+
+    def score(self, text: str) -> Dict[str, int]:
+        """Compute MENTION scores (uses all patterns; ignores explicit flag).
+        Backward-compatible with existing `get_scores` callers (alias)."""
+        ...
+
+    def explicit_score(self, text: str) -> Dict[str, Tuple[int, List[PatternMatch]]]:
+        """Compute PREFERENCE scores (uses only explicit=True patterns).
+        Applies sentence-scoped negation + migration internally."""
+        ...
+
+    # Backward-compatibility shim — keeps test fixtures working:
+    @property
+    def _compiled_patterns(self) -> Dict[str, List[Tuple]]:
+        """Existing tests inspect this directly. v2 preserves the attribute
+        and ensures entries are tuple-compatible (extra trailing fields ignored
+        by destructuring at index 0/1)."""
+```
+
+`get_scores(text)` is preserved as an alias for `score(text)` so existing test code keeps working (see PRD §NFR-5).
+
+#### 4.3.2 `PreferenceResolver` (new, stateless)
+
+Sole responsibility: combine detector output + policy + conflict groups into a `PreferenceResolution`.
+
+```python
+class PreferenceResolver:
+    """Stateless. Composes detector + policy."""
+
+    def __init__(self, detector: LibraryDetector, policy: DetectionPolicy,
+                 conflict_groups: Dict[str, Tuple[str, ...]] = CONFLICT_GROUPS): ...
+
+    def resolve(self, text: str) -> PreferenceResolution:
+        """Return PreferenceResolution per the algorithm in ADR-024 §3.3.
+
+        Steps (matches ADR-024 §3.3 exactly):
+          1. detector.explicit_score(text) → raw_scores + matches
+             (this call internally applies sentence-scoped negation + migration)
+          2. CONFLICT CHECK on raw_scores (BEFORE threshold filter):
+             for each group, if 2+ members have score > 0 and top-2 diff <= ambiguity_window
+             → return PreferenceResolution(library=None, conflicts=...)
+          3. Threshold filter:
+             effective_threshold = conflict_min_score if lib in any group else default_min_score
+             candidates = {lib: score for lib, score in raw_scores if score >= effective_threshold}
+          4. If candidates is empty → return PreferenceResolution(library=None, ...)
+          5. Else → return PreferenceResolution(library=max(candidates), evidence=matches[winner], ...)
+        """
+        ...
+```
+
+Note: `MentionScorer` from v1 is dropped. It was `LibraryDetector.get_scores` with a wrapper class. The wrapper added no behaviour; the alias suffices. v2 preserves `get_scores` as a method on `LibraryDetector` directly.
+
+### 4.4 Domain Events (optional, for observability)
+
+```python
+@dataclass(frozen=True)
+class PreferenceDetected:
+    library: str
+    score: int
+    evidence_count: int
+    text_hash: str  # not the raw text — keep observability privacy-safe
+
+    def to_dict(self) -> Dict: ...
+
+@dataclass(frozen=True)
+class ConflictDetected:
+    group: str
+    libraries: Tuple[str, ...]
+    scores: Dict[str, int]
+    text_hash: str
+
+    def to_dict(self) -> Dict: ...
+
+@dataclass(frozen=True)
+class NoPreferenceDetected:
+    """Emitted when no library scored above threshold."""
+    top_score: int                # highest score seen
+    top_library: Optional[str]    # if any
+    text_hash: str
+```
+
+These are optional. They land if rf-mcp wires an observability sink for the bounded context (instruction-learning hooks already capture tool results — events are NOT required for the bug fix).
+
+---
+
+## 5. Boundaries and Interactions
+
+```
+   ┌──────────────────────────────────────────────────────────────────┐
+   │  nlp_processor.analyze_scenario  (application service)           │
+   │                                                                  │
+   │  Inputs: scenario_text, context                                  │
+   │  Outputs: structured TestScenario + analysis dict                │
+   └─────────────┬─────────────────────────────┬─────────────────────┘
+                 │                             │
+                 │ (this PRD's path)           │ (SEPARATE path — outside this context)
+                 ▼                             ▼
+   ┌──────────────────────────┐    ┌─────────────────────────────────┐
+   │  PreferenceResolver      │    │  _determine_capabilities         │
+   │  ──────────────────      │    │  (substring heuristic)           │
+   │  Used for:               │    │  ─────────────────────           │
+   │    explicit_library_     │    │  Used for:                       │
+   │      preference          │    │    suggested_libraries           │
+   │    explicit_library_     │    │    (advisory list)               │
+   │      evidence            │    │                                  │
+   │    library_preference_   │    │  Does NOT call LibraryDetector;  │
+   │      conflicts           │    │  uses its own substring matching │
+   │    preference_source     │    │  at nlp_processor.py:517-544.    │
+   │                          │    │                                  │
+   │  Behaviour: conservative │    │  OUT OF SCOPE for this bounded   │
+   │  evidence-based          │    │  context. Documented for clarity │
+   │                          │    │  only.                           │
+   └──────────────────────────┘    └─────────────────────────────────┘
+                 │
+                 ▼
+   ┌──────────────────────────────────────────────────────┐
+   │   LibraryDetector  (process-global singleton)        │
+   │   ─────────────────                                  │
+   │   detect_explicit_preference(text) → PreferenceResolution
+   │   get_scores(text) → Dict[str, int]                  │
+   │     (mention layer — DIAGNOSTIC ONLY in v3;          │
+   │      no current production consumer)                 │
+   └──────────────────────────────────────────────────────┘
+```
+
+v3 diagram correction: v2's diagram showed `MentionScorer` feeding "capability list (suggested_libs)" — that arrow was wrong. `suggested_libraries` is populated by `_determine_capabilities` (a separate substring heuristic at `nlp_processor.py:517-544`) which does NOT call `LibraryDetector`. The mention layer is preserved on `LibraryDetector` for diagnostics and potential future use, but has no production consumer in the current codebase.
+
+**What this context OWNS** (v2 — added negation/migration to make ownership explicit):
+
+| Asset | Owner | Notes |
+|---|---|---|
+| `LIBRARY_RULES` (per-library patterns) | `library_detection.py` | Single source of truth; module-level constant. |
+| `NEGATION_PATTERNS` (subtractive) | `library_detection.py` | v2: explicitly owned here. Applied per-sentence inside `explicit_score`. v1 silently owned this but never documented. |
+| `MIGRATION_PATTERNS` (source-vs-destination) | `library_detection.py` | v2: new; explicitly owned here. Source/dest tokens resolved to libraries via the same name-resolution as `LIBRARY_RULES`. |
+| `CONFLICT_GROUPS` map | `library_detection.py` | Static module-level dict. |
+| `DetectionPolicy` defaults + env names | `library_detection.py` | All `ROBOTMCP_LIBRARY_DETECTION_*` env vars resolved here. |
+| `PreferenceResolver` algorithm | `library_detection.py` | Implements ADR-024 §3.3 exactly. |
+
+**What this context DOES NOT OWN**:
+
+| Asset | Owner | Notes |
+|---|---|---|
+| `_determine_capabilities` substring heuristic | `nlp_processor.py:517-544` | Separate code path; does not call this context. v1 implied a coupling that does not exist. |
+| `suggested_libraries` response field | `nlp_processor.analyze_scenario` | Populated from `_determine_capabilities`, not from this context. |
+| Sampling-based preference (`sample_analyze_scenario`) | `server.py:1863-1880` | External override; replaces `preference_source: "sampling"`. See ADR-024 §11. |
+| Session library auto-import | `session_models.ExecutionSession.configure_from_scenario` | Downstream consumer of `PreferenceResolution.library`. |
+| `find_keywords` filter precedence | `server.py:2037` | Downstream consumer. |
+
+Anti-patterns the bounded context refuses:
+
+- ❌ Direct mutation of `LIBRARY_RULES` / `NEGATION_PATTERNS` / `MIGRATION_PATTERNS` / `CONFLICT_GROUPS` from another module. Patterns are module-level constants and pattern entries are frozen dataclasses.
+- ❌ Caching `PreferenceResolution` across scenarios — it's keyed on text + policy; different inputs must run the resolver fresh.
+- ❌ Inferring preference from session library imports. Session config is downstream; detection is upstream.
+- ❌ Calling `PreferenceResolver.resolve` with a per-call `DetectionPolicy` override at runtime. Policy is read at resolver construction; runtime overrides would break INV-3.
+
+---
+
+## 6. Migration from Current Code
+
+### 6.1 What changes
+
+| Current location | New location |
+|---|---|
+| `LIBRARY_PATTERNS: Dict[str, List[Tuple[str, int]]]` | `LIBRARY_RULES: Dict[str, List[PatternRule]]` (dataclass per rule with `explicit` + `rationale`) |
+| `LibraryDetector.get_scores(text)` | Stays (alias for `score(text)`); now the documented mention API |
+| `LibraryDetector.detect(text, min_score=...)` | Becomes thin wrapper around `PreferenceResolver.resolve` for backward compat |
+| `LibraryDetector.get_conflicting_detections(text)` | Becomes a thin wrapper around `PreferenceResolver.resolve(text).conflicts` |
+| `NEGATION_PATTERNS` (current location at lines 132-135) | Stays in `library_detection.py`; algorithm shifts from "single forward window across whole text" to "per-sentence application inside `explicit_score`" |
+| (new) `MIGRATION_PATTERNS` | Added to `library_detection.py`; applied per-sentence with source/destination distinction |
+| `nlp_processor._detect_explicit_library_preference` | Calls `PreferenceResolver.resolve` and returns `(resolution.library, resolution.evidence, resolution.conflicts)` |
+| `session_models.detect_explicit_library_preference` | Same — single source of truth |
+| `server.py:1866-1880` sampling override | Sets `preference_source="sampling"`, clears `evidence` and `conflicts`; per ADR-024 §11 |
+
+### 6.2 What stays the same (back-compat surfaces)
+
+- `LIBRARY_PATTERNS` source-of-truth (renamed `LIBRARY_RULES` in v3) — type changes from `Dict[str, List[Tuple[str, int]]]` to `Dict[str, List[PatternRule]]`. NOT directly inspected by tests; only used internally.
+- **`LibraryDetector._compiled_patterns` — v3 keeps the EXACT current shape `Dict[str, List[Tuple[re.Pattern, int]]]`**. v2 implied a refactor; v3 holds the line. Real test contract at `tests/integration/test_nlp_improvements.py:571` is `for p, _ in entries: p.findall(...)` — `p` must be a compiled `re.Pattern`, NOT a `PatternRule`. The v3 implementation builds `_compiled_patterns` as 2-tuples and stores rich annotations in a parallel `_rules_metadata: Dict[str, List[PatternRule]]` attribute. New code paths read `_rules_metadata` or `LIBRARY_RULES`; legacy tests read `_compiled_patterns`. No `__iter__` shim on `PatternRule` is needed.
+- Negation IDENTITY — the existing patterns ("not", "without", "instead of", "migrate from") keep working in spirit. The IMPLEMENTATION switches from a single forward-window regex to a **phrase-list + token-resolution** approach (v3 ADR §3.2 P3 + proposal §3.1 Step 5). The improved algorithm correctly handles `"do not use Selenium, instead use Playwright"`, which v2's regex broke.
+- All public method names on `LibraryDetector` continue to exist (`get_scores`, `detect`, `get_conflicting_detections`).
+- The `LibraryDetector` singleton pattern. No change to construction or to how `nlp_processor` and `session_models` obtain the instance.
+
+### 6.3 What's added
+
+- `PatternRule.explicit: bool` annotation. `True` only for verbatim library identifiers + preference-verb idioms; `False` for keyword-name overlaps + domain markers (per ADR-024 §6 v2 table).
+- `PatternRule.rationale: str` audit comment.
+- `MIGRATION_PATTERNS` constant (v2 new) — list of regex sources for "from X to Y" idioms.
+- `DetectionPolicy.from_env()` for env-driven threshold overrides.
+- `PreferenceResolver.resolve()` as the documented preference entry point.
+- `PreferenceResolution.source` field (`"rule"` | `"sampling"`).
+- `PreferenceResolution.sampling_evidence` field (optional LLM rationale).
+- Response shape additions on `analyze_scenario`: `explicit_library_evidence`, `library_preference_conflicts`, `preference_source`.
+
+### 6.4 What's NOT added (rejected scope creep)
+
+- No new MCP tool (rejected per ADR-024 §4.4).
+- No grammar parser / spaCy / parser dependency (rejected per ADR-024 §4.6/§4.7).
+- No allow-list-only detector (rejected per ADR-024 §4.5).
+- No public capability suggestion through this context. The mention layer stays diagnostic-only.
+
+---
+
+## 7. Invariants
+
+| # | Invariant | Verification |
+|---|---|---|
+| INV-1 | `PatternRule.weight in range(1, 11)` | dataclass `__post_init__` |
+| INV-2 | `PatternRule.pattern` compiles successfully | dataclass `__post_init__` |
+| INV-3 | `PreferenceResolver.resolve(text)` is idempotent **for a given resolver instance**: a resolver constructed with policy P returns identical output for identical text input across repeated calls. (v2: NOT globally pure — policy is captured at construction from env vars; two resolvers built with different env states differ.) | parametrised property test against a fixed resolver |
+| INV-4 | **(v4 replacement — catches D1 double-deduction)** Negation deduction-sum equality: for any sentence S containing one or more negation phrases all targeting library L, the total `raw_scores[L]` deduction across all phrase matches in S equals the deduction from a single canonical phrase match in S. Equivalently: `len(_NEGATION_REGEX.findall(S))` may be > 1 only when the matches target DISTINCT libraries; matches that resolve to the SAME library do not double-deduct. v3's INV-4 (`max(0, x-d)` idempotence) was trivially true and did NOT catch the round-3-flagged D1 bug where compound + simple phrases both fired on the same span. v4's invariant DOES catch it. | parametrised unit test: `"do not use Selenium"` → assert deduction = single-phrase deduction; `"do not use Selenium and stop the SeleniumLibrary"` → assert total deduction = 2× per-phrase (both target SL, but two distinct negation spans, not double-fire on one span) |
+| INV-5 | Preference within a conflict group requires `score ≥ conflict_min_score` AFTER the raw-score conflict check has cleared. | unit test |
+| INV-6 | When `PreferenceResolution.conflicts` is non-empty, `PreferenceResolution.library is None` and `source == "rule"`. | unit test |
+| INV-7 | When `PreferenceResolution.library is not None` and `source == "rule"`, `evidence` is non-empty. When `source == "sampling"`, `evidence` is empty and `sampling_evidence` may be set. | unit test |
+| INV-8 | Sentence-scoped negation reduces score only for the targeted library and only for contributions within the matching sentence. Other sentences' contributions for the same library remain. | unit test (multi-sentence scenarios) |
+| INV-9 | Migration pattern with source=A and destination=B: score for A is reduced by all explicit contributions in the matching sentence, score for B is increased by `destination_bonus` (default 5). | unit test |
+| INV-10 | All env-tunable knobs have defaults matching the documentation in ADR-024 §3.3 (`MIN_SCORE=5`, `CONFLICT_THRESHOLD=8`, `AMBIGUITY_WINDOW=4`). | unit test loading `DetectionPolicy.from_env()` with empty env |
+| INV-11 | `_compiled_patterns` attribute exists on `LibraryDetector` and its values support `(pattern, weight)` destructuring at indices 0/1. | integration test (`tests/integration/test_nlp_improvements.py`) |
+
+---
+
+## 8. Bounded Context Boundaries (summary)
+
+This context does NOT own (full table in §5):
+
+- **Capability suggestion** (`_determine_capabilities` at nlp_processor.py:517-544) — separate substring heuristic that does NOT call this context. v1 implied a coupling; corrected in v2.
+- **Session auto-import** (`ExecutionSession.configure_from_scenario`) — downstream consumer.
+- **Find_keywords filter precedence** — downstream consumer.
+- **Sampling-based override** (`sample_analyze_scenario`) — replaces this context's output when enabled. v2 defines the override coherence in ADR-024 §11: when sampling overrides, `evidence` and `conflicts` are cleared and `source` is set to `"sampling"`.
+- **MCP tool surface** — `analyze_scenario` MCP tool is the application service that orchestrates this context with others.
+
+The context owns the question "given scenario text and a `DetectionPolicy`, what library did the user explicitly intend?" and emits a `PreferenceResolution`. That is its only responsibility.
+
+---
+
+## 9. Open Questions for Implementation
+
+1. **PatternRule construction syntax**: dataclass-by-keyword or builder? Recommended: keyword-only dataclass with a `__iter__` that yields `(pattern, weight)` first for tuple-unpacking compat.
+2. **Should `explicit_library_evidence` include the regex source verbatim?** Recommended: yes — both `pattern` and `text_span` so users can grep their own text.
+3. **How to handle the `_fallback_detect_library_preference` paths in `nlp_processor.py:665` and `session_models.py:592`?** Both predate the centralised detector. v2 deprecates them and routes through `PreferenceResolver` for single source of truth.
+4. **What about future libraries (CryptoLibrary, ImageLibrary, etc.)?** Each gets its own pattern set + explicit/mention annotations. Adding a library is a localized change to the patterns table; the resolver doesn't need to know.
+5. **Should the mention layer ever feed `_determine_capabilities`?** Out of scope for this PRD. A future refactor could route capabilities through `get_scores` for consistency; v2 leaves the path open by preserving the mention API but does not commit to a consumer.
+
+---
+
+## 13. Round-3 review findings + resolutions (v4)
+
+| # | Round-3 finding (v3) | Resolution in v4 |
+|---|---|---|
+| D3 | §4.1.6 `conflicts` declared `Dict[str, List[Tuple[str, int, List[str]]]]` (tuple) but PRD/ADR/proposal use dict-of-dicts | §4.1.6: `Dict[str, List[Dict[str, Any]]]` — each entry `{library, score, patterns_matched}` |
+| D3 | §4.1.6 `evidence` declared `List[PatternMatch]` but JSON shape is flat dicts | §4.1.6: `List[Dict[str, Any]]` reflecting `PatternMatch.to_dict()` shape |
+| D2 | INV-4 `max(0, x-d)` idempotence trivially true; wouldn't catch the D1 double-deduction bug | §7 INV-4: replaced with deduction-sum equality across multiple negation-phrase matches; CATCHES D1 |
+
+---
+
+## 12. Round-2 review findings + resolutions (v3)
+
+| # | Codex finding (v2 round 2) | Resolution in v3 |
+|---|---|---|
+| B4 | §5 diagram showed `MentionScorer` → "capability list (suggested_libs)" contradicting v2 prose | §5 diagram redrawn: `_determine_capabilities` shown as SEPARATE path outside the bounded context; mention layer marked "diagnostic only" |
+| C4 | INV-4 was vacuous (every library has at least one `explicit=True` pattern) | §7 INV-4 replaced with negation-idempotence: `_subtract_sentence_score` applied twice equals applied once |
+| B2 | `_compiled_patterns` test contract description ambiguous | §6.2 documents the two-store design: `_compiled_patterns` keeps `(Pattern, int)` 2-tuples; `_rules_metadata` holds rich `PatternRule` entries |
+| D1 | Evidence shape differed across 4 docs | §4.1.2 `PatternMatch.to_dict()` standardised to `{library, pattern, weight, text_span}` field order; matches PRD §FR-5, ADR §3.5, proposal Step 4 |
+| E3 | Sampling override path is singular in docs; source has TWO (server.py:1860-1881 AND :1961-1972) | §8 + §11 reference both override sites |
+
+---
+
+## 11. Round-1 review findings + resolutions (v2)
+
+| # | Codex finding | Resolution in v2 |
+|---|---|---|
+| 1 | `DetectionScore`/`ConflictGroup`/`MentionScorer` are window-dressing | Demoted to plain dict/constant/method-alias in §4.1.3, §4.1.4, §4.3.2 |
+| 2 | "LibraryDetector becomes stateless" — false | Retracted in §4.2; "effectively immutable but not stateless" is the corrected term |
+| 3 | INV-3 (purity) unprovable with env-driven policy | Reworded to "idempotent for a given resolver instance" |
+| 4 | INV-4 (mention ≥ preference) unprovable since capability suggestion doesn't consume mention scores | Replaced with INV-4 about explicit-only filtering |
+| 5 | NEGATION_PATTERNS ownership omitted from §5 Boundaries | Explicit ownership table added to §5 with negation + migration listed |
+| 6 | Architecture claim wrong (mention layer backs `suggested_libraries`) | §2 + §5 corrected; mention layer is diagnostic-only |
+| 7 | `_compiled_patterns` test surface compat ignored | INV-11 added; §6.2 documents the back-compat shim |
+| 8 | Sampling override coherence undefined | §4.1.6 adds `source` + `sampling_evidence` fields; §8 + ADR-024 §11 define behaviour |
+
+---
+
+## 10. Cross-references
+
+- **PRD**: `docs/prd/analyze_scenario_explicit_library_prd.md` — user-facing requirements + acceptance criteria.
+- **ADR-024**: `docs/adr/ADR-024-explicit-library-detection-confidence.md` — architecture decisions + alternatives.
+- **Solution proposal**: `docs/proposals/explicit_library_detection_fix_proposal.md` — concrete code changes + migration plan.

--- a/docs/issues/analyze_scenario_e2e_cross_cli_report.md
+++ b/docs/issues/analyze_scenario_e2e_cross_cli_report.md
@@ -1,0 +1,207 @@
+# `analyze_scenario` Defect — Cross-CLI E2E Reproduction + Post-Fix Verification
+
+**Date**: 2026-06-05
+**Defect**: `explicit_library_preference: "SeleniumLibrary"` returned for scenarios that never mention SeleniumLibrary
+**Status**: **FIXED in v5** (`src/robotmcp/utils/library_detection.py`)
+**Related**: PRD `docs/prd/analyze_scenario_explicit_library_prd.md`, ADR-024, DDD library_preference, solution proposal (all at v5 IMPLEMENTED)
+**Purpose**: confirm the defect (a) reproduces consistently across multiple LLM clients consuming rf-mcp via MCP, AND (b) is resolved by the v5 implementation across the same three clients.
+
+---
+
+## Scenario under test (verbatim user report)
+
+```json
+{
+  "scenario": "Test e-commerce website https://demoshop.makrocode.de: open browser, add items to shopping cart, verify items, complete checkout, and close browser",
+  "context": "web",
+  "session_id": "demoshop_<cli>_e2e"
+}
+```
+
+Expected behaviour after v4 fix: `explicit_library_preference: null` (the user never mentions SeleniumLibrary, `webdriver`, `selenium`, etc. — `open browser` is generic English).
+
+Current (pre-fix) behaviour: `explicit_library_preference: "SeleniumLibrary"`.
+
+---
+
+## Method
+
+Three independent LLM CLIs consumed the rf-mcp MCP server's `analyze_scenario` tool:
+
+| CLI | Version | Model | rf-mcp transport |
+|---|---|---|---|
+| Claude Code (Anthropic) | this session | claude-opus-4-7[1m] | Direct Python subprocess (`uv run python -c ...`) — rf-mcp not loaded in session |
+| Codex CLI (OpenAI) | 0.133.0 | gpt-5.4 (high reasoning) | MCP via ephemeral `-c 'mcp_servers.robotmcp.*'` config |
+| opencode | 1.2.15 | github-copilot/claude-sonnet-4.6 | MCP via pre-registered `opencode mcp add` (status: connected) |
+
+Each CLI was instructed to call `analyze_scenario` with the exact reported arguments and report only the values of `analysis.explicit_library_preference` and `analysis.suggested_libraries`.
+
+---
+
+## Results
+
+### Claude Code (direct Python invocation)
+
+`/tmp/claude_e2e_output` (via inline subprocess):
+
+```json
+{
+  "action_count": 1,
+  "complexity": "simple",
+  "estimated_steps": 2,
+  "suggested_libraries": ["Browser", "RequestsLibrary", "SeleniumLibrary"],
+  "explicit_library_preference": "SeleniumLibrary",
+  "detected_session_type": "web_automation"
+}
+```
+
+### Codex CLI
+
+`/tmp/codex_e2e_output.txt`:
+
+```
+mcp: robotmcp/analyze_scenario started
+mcp: robotmcp/analyze_scenario (completed)
+codex
+"SeleniumLibrary"
+["Browser","RequestsLibrary","SeleniumLibrary"]
+tokens used 13,643
+```
+
+### opencode
+
+`/tmp/opencode_e2e_output.txt`:
+
+```json
+"explicit_library_preference": "SeleniumLibrary"
+"suggested_libraries": ["RequestsLibrary", "Browser", "SeleniumLibrary"]
+```
+
+Plus an interesting downstream observation captured in the opencode JSON event stream:
+
+```json
+"libraries_loaded": ["SeleniumLibrary", "BuiltIn"]
+```
+
+The session aggregate auto-loaded SeleniumLibrary as a direct consequence of the false `explicit_library_preference`. This is the cascade documented in PRD §2 consumer #2 (`session_models.py:787` `configure_from_scenario`) and PRD §2 consumer #8 (`selenium_plugin.py:202-208` eager init).
+
+---
+
+## Cross-CLI comparison
+
+| Field | Claude | Codex | opencode |
+|---|---|---|---|
+| `explicit_library_preference` | `"SeleniumLibrary"` | `"SeleniumLibrary"` | `"SeleniumLibrary"` |
+| `suggested_libraries` set | `{Browser, RequestsLibrary, SeleniumLibrary}` | same | same |
+| Session library auto-loaded | (not observed — no session created at this step) | (not observed — only analyze called) | `SeleniumLibrary` + `BuiltIn` ← downstream cascade visible |
+
+Three CLIs, one defect, consistent result. The bug is in the rf-mcp server's rule-based detector — NOT in any LLM client's interpretation. Every client faithfully reports what the tool returned.
+
+---
+
+## What this confirms
+
+1. **Defect is real, deterministic, and tool-side.** No prompt-engineering, model-choice, or CLI-specific behaviour explains it. The string-pattern regex `\bopen\s+browser\b` at `library_detection.py:33` (weight 6, ≥ min_score 5) fires by itself on `"open browser"` and is sufficient to flag SeleniumLibrary as explicit.
+
+2. **The downstream cascade is real.** opencode's `libraries_loaded` snapshot shows the session aggregate loaded SeleniumLibrary in response to the false preference — exactly the failure path the v4 fix targets in PRD §2 consumer table (8 sites).
+
+3. **Three independent agents all faithfully relay the bug.** Agents do not second-guess the tool. If the tool says `SeleniumLibrary`, agents will write SL-style code. Without the fix, agents working through any of these CLIs against rf-mcp will:
+   - Get SL keywords from `find_keywords` (consumer #1)
+   - See an SL-loaded session (consumer #2)
+   - Have SL pinned as primary recommendation (consumer #3)
+
+4. **The fix lands at the rf-mcp pattern-detection layer.** No client-side work is needed. The v4 solution proposal `docs/proposals/explicit_library_detection_fix_proposal.md` describes the exact code change.
+
+---
+
+## Post-v6 verification — end-to-end coherence (2026-06-05)
+
+v5 fixed the analysis path but Codex round-5 review found the session aggregate was still broken via a fallback substring heuristic. v6 closes that gap + 3 other source bugs. Re-ran the e2e protocol on the reported scenario AND the round-5-flagged regression case:
+
+| CLI | Reported scenario `analysis.explicit_library_preference` | `Parse the XML response from the API` `analysis.explicit_library_preference` | `libraries_loaded` (downstream cascade) |
+|---|---|---|---|
+| Claude (direct Python) | `null` | `null` | (no session) |
+| Codex CLI (via MCP) | `null` | `null` | `["BuiltIn"]` (no false SL or XML auto-load) |
+| opencode (via MCP) | `null` | `null` | `["BuiltIn"]` (no false SL or XML auto-load) |
+
+**Session-level coherence verified**: `ExecutionSession.detect_explicit_library_preference("Parse the XML response from the API")` returns `None` (was `"XML"` in v5 via the fallback heuristic, contradicting `analyze_scenario`'s `null` response).
+
+**Multi-word migration verified** via Claude direct: `"Migrate from Selenium to Requests library"` → `RequestsLibrary` (was `None` in v5).
+
+**Repeated-token negation verified**: `"do not use Playwright Playwright"` → `None` (was `Browser` in v5 due to under-subtraction).
+
+**Newline negation verified**: `"do not use\nPlaywright"` → `None` (was `Browser` in v5 due to sentence split orphaning the target).
+
+## Post-v5 verification — defect FIXED across all three CLIs (2026-06-05)
+
+Re-ran the same protocol immediately after v5 implementation landed. Results:
+
+| CLI | `explicit_library_preference` | `preference_source` | `libraries_loaded` (downstream) |
+|---|---|---|---|
+| Claude (direct Python) | `null` | `"rule"` | n/a (no session) |
+| Codex CLI (via MCP) | `null` | `"rule"` | n/a (analyze only) |
+| opencode (via MCP) | `null` | `"rule"` | `["BuiltIn"]` ← **SL no longer auto-loaded** |
+
+**The downstream cascade is also fixed.** opencode's snapshot pre-fix showed `libraries_loaded: ["SeleniumLibrary", "BuiltIn"]` (SL eagerly auto-loaded because of the false preference, per PRD §2 consumer #2). Post-v5: `libraries_loaded: ["BuiltIn"]` — SL is not loaded because the explicit preference is correctly `null`.
+
+Side-by-side comparison:
+
+| Metric | Pre-v5 (defect) | Post-v5 (fix) |
+|---|---|---|
+| Claude → `explicit_library_preference` | `"SeleniumLibrary"` | `null` |
+| Codex → `explicit_library_preference` | `"SeleniumLibrary"` | `null` |
+| opencode → `explicit_library_preference` | `"SeleniumLibrary"` | `null` |
+| opencode → `libraries_loaded` | `["SeleniumLibrary", "BuiltIn"]` | `["BuiltIn"]` |
+| `preference_source` field exposed | N/A (not in API) | `"rule"` (v5 new field) |
+
+Truly-explicit cases (verified in unit tests, not re-run via all three CLIs):
+- `"Use playwright to test demoshop"` → Browser (with `explicit_library_evidence` populated)
+- `"do not use Selenium, instead use Playwright"` → Browser (sentence-scoped negation working)
+- `"Test both selenium and playwright sites and compare"` → null + `library_preference_conflicts.web_automation`
+
+## Verification plan (post-fix) — historical
+
+When the v4 fix was implemented, re-run this exact protocol. Expected outcome:
+
+| Field | Pre-fix (current) | Post-fix (target) |
+|---|---|---|
+| `explicit_library_preference` | `"SeleniumLibrary"` | `null` |
+| `suggested_libraries` | unchanged (advisory list) | unchanged (`_determine_capabilities` is out of scope per PRD §FR-8) |
+| `preference_source` (new v4 field) | absent | `"rule"` |
+| Session auto-load | `SeleniumLibrary` eagerly loaded | not loaded (None preference → no auto-import per PRD §2 consumer #2) |
+| `library_preference_conflicts` | absent | absent (no conflict in this scenario — neither Browser nor SL explicitly mentioned) |
+
+For the opposite case (`scenario = "Use playwright to test demoshop"`), v4 must return `explicit_library_preference: "Browser"` + populated `explicit_library_evidence`.
+
+For the v3 round-3-flagged edge case `"do not use Selenium, instead use Playwright"`, v4 must return `"Browser"` (empirically verified against the v4 algorithm in the proposal §3.1 Step 6 walkthroughs).
+
+---
+
+## Reproduction commands
+
+For future verification — exact commands used to produce this report:
+
+```bash
+# Claude (direct Python)
+uv run python -c "
+import asyncio
+from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+async def main():
+    nlp = NaturalLanguageProcessor()
+    r = await nlp.analyze_scenario(
+        'Test e-commerce website https://demoshop.makrocode.de: open browser, '
+        'add items to shopping cart, verify items, complete checkout, and close browser',
+        context='web')
+    import json; print(json.dumps(r['analysis'], indent=2))
+asyncio.run(main())"
+
+# Codex (ephemeral MCP config)
+codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check \
+  -c 'mcp_servers.robotmcp.command="uv"' \
+  -c 'mcp_servers.robotmcp.args=["run","--directory","/home/many/workspace/rf-mcp","-m","robotmcp.server"]' \
+  'Call analyze_scenario with scenario="Test e-commerce website ..." context="web" session_id="demoshop_codex_e2e" and report explicit_library_preference + suggested_libraries.'
+
+# opencode (pre-registered MCP)
+opencode run --format json -m github-copilot/claude-sonnet-4.6 \
+  'Call analyze_scenario with scenario="Test e-commerce website ..." context="web" session_id="demoshop_opencode_e2e" and report explicit_library_preference + suggested_libraries.'
+```

--- a/docs/prd/analyze_scenario_explicit_library_prd.md
+++ b/docs/prd/analyze_scenario_explicit_library_prd.md
@@ -1,0 +1,527 @@
+# PRD — `analyze_scenario` Explicit Library Preference Detection
+
+**Date**: 2026-05-29
+**Status**: **IMPLEMENTED v7 — production-ready** (per Codex round-7 review 2026-06-05). Source in `src/robotmcp/utils/library_detection.py`, `nlp_processor.py`, `session_models.py`, `server.py`. Tests in `tests/unit/test_explicit_library_detection_fix.py` — **83 targeted tests; full unit suite 6249 passing**.
+**Author**: rf-mcp maintainer
+**Reporter**: User report on 2026-05-29
+**Related**: ADR-024 (companion architecture decision), DDD library_preference bounded context, solution proposal `docs/proposals/explicit_library_detection_fix_proposal.md`
+
+## Revision history
+
+**v7 (2026-06-05)** — Codex round-6 review verified all 4 v6 source fixes but flagged 3 new issues (1 paragraph-boundary regression introduced by v6, 1 nlp_processor helper still had the abstain-fallback bug, 1 pre-existing sampling-coherence issue). v7 addresses 2:
+- **C1 — Paragraph boundary**: `_SENTENCE_DELIMITERS` changed from `r"[.;!?,]+"` to `r"[.;!?,]+|\n\s*\n+"`. Single `\n` stays non-boundary (preserves v6 D-newline-negation fix); `\n\s*\n+` (paragraph break) IS a boundary (fixes the v6 paragraph regression).
+- **C3 — NLP helper abstain-fallback removed**: `nlp_processor._detect_explicit_library_preference` no longer falls back to broad substring on deliberate None. Mirrors the v6 session_models fix.
+- **C2 deferred**: sampling Site B session-coherence is a pre-existing architectural issue, scoped to its own follow-up.
+- **Tests**: 14 new v7 tests in `TestV7ParagraphBoundary` (7), `TestV7ParagraphBoundaryEndToEnd` (1), `TestV7NlpProcessorAbstainNoFallback` (6). **Total 83 in the v7 file; full unit suite 6249 passing.**
+
+**v6 (2026-06-05)** — Codex round-5 review verified v5 fixed the analysis-path defect but flagged 4 source bugs + propagation gaps in PRD/ADR. v6 fixes all 4 source bugs (3 critical) and aligns docs:
+- **D-session-fallback fixed**: `session_models.py:detect_explicit_library_preference` no longer falls back to the broad substring heuristic when v5 returns None. Session aggregate now correctly reports None when the v5 detector abstains. Tested at `TestV6SessionFallbackBug` (3 cases).
+- **D-newline-negation fixed**: `\n` dropped from `_SENTENCE_DELIMITERS`. Tested at `TestV6NewlineNegation` (4 parametrised cases + preference-verb-newline regression).
+- **D-repeated-token fixed**: `_subtract_sentence_score` counts occurrences via `findall`. Tested at `TestV6RepeatedTokenDeduction` (4 cases).
+- **D-multiword-migration fixed**: destination lookahead allows multi-word capture. `Requests library` / `Database library` / `SSH library` / `XML library` all resolve correctly. Tested at `TestV6MultiwordMigration` (6 cases).
+- **§FR-5 evidence field corrected**: evidence entries use singular `pattern` (not `patterns_matched`). `library_preference_conflicts[]` entries DO use `patterns_matched` (list of pattern source strings).
+- **§AC-7 RequestsLibrary example corrected**: documented pattern now matches source (no bare `requests` in preference verb).
+- **Total tests**: 69 in `test_explicit_library_detection_fix.py` (51 v5 + 18 v6). Pre-existing tests unchanged: 6166 passing.
+
+**v5 (2026-06-05)** — Codex round-4 review (verdict v4: ADR/proposal REWRITE, PRD/DDD TIGHTEN) identified 5 propagation gaps + 4 new v4 regressions. v5 implements the fix in source and addresses all of them:
+- **§FR-1 bare-noun preference verbs propagated**: removed `(requests|database|ssh|xml)` from preference-verb alternations. Brand names (`selenium`, `playwright`, `appium`) retained. Aligned with proposal v4 §3.1 Step 2 (and verified in `library_detection.py:LIBRARY_RULES_DEFAULT`).
+- **§FR-6 negation algorithm propagated**: replaced the stale `\b(not|don't|do\s+not|...)\s+(?:using\s+)?(\w+)` capture-based regex prose with the **single-alternation `_NEGATION_REGEX` + `_first_library_token_in(remaining_text)` two-step approach** that actually shipped. Sentence delimiter is `[.;!?,\n]+` (comma + newline both included). `skip` restored to standalone alternation.
+- **§FR-7 sampling override coherence**: `primary_library` fallback dropped per Codex finding — only `library_preference` writes to `explicit_library_preference` (the field is "user-stated", `primary_library` is "LLM-recommended"; different semantics). Both override sites (`server.py:1860-1881` Site A + `server.py:1961-1972` Site B) implemented.
+- **§AC-5 numerics re-verified**: under the v5 pattern table, "Test both selenium and playwright sites and compare" → SL=6, Browser=9, diff=3 ≤ 4 → conflict fires. AC holds. **Tested via `TestConflicts::test_both_selenium_and_playwright_returns_none_with_conflict`.**
+- **§9 stakeholder table aligned**: "No existing tests should break" was always wrong — reconciled to "3-5 existing tests need updating + 18 new tests added" (already in v4; confirmed in v5 implementation: 51 new tests added in `test_explicit_library_detection_fix.py`).
+- **Implementation status promoted to IMPLEMENTED**: source code now reflects the spec. The PRD/ADR/DDD/proposal are documentation of what the implemented system does, not a forward design.
+
+**v4 (2026-05-29)** — Third-round independent review (verdict: TIGHTEN for PRD). v4 addresses:
+- **Test count reconciled**: FR-7 and AC-8 already say "18 distinct functions" — no change. Proposal §9 Validation Plan updated to match (was "~30 + ~3"; now "18 + 3-5"). PRD itself unchanged for this item.
+- **`session.preference_source` field declaration referenced**: §2 downstream-consumer table can now reference the v4 field declaration in proposal §3.3 — no direct PRD change needed (the field is a proposal-level mechanism, not a PRD-level requirement).
+- **No other PRD-level changes required**: the round-3 review's PRD finding was "no issues, just propagate proposal fixes". Round-3 report verified PRD is correct as-is at v3.
+
+**v3 (2026-05-29)** — Codex CLI second-round critical review (verdict: TIGHTEN for PRD). v3 addresses:
+- **§9 vs AC-8 contradiction resolved**: stakeholder table no longer claims "No existing tests should break". v3 honestly says "3-5 existing tests need updating; ~18 new tests added".
+- **Evidence shape standardised (§FR-5)**: flat list of `{library, pattern, weight, text_span}` entries — matches ADR §3.5, DDD §4.1.6 PatternMatch, proposal Step 4. v2 had a nested per-library shape that diverged from the other docs.
+- **AC-7 verbatim recomputation**: v3 verified pattern-table arithmetic still produces correct results under the v3 pattern table changes (bare `requests` removed from preference verb).
+- **Field name `patterns_matched` (conflicts) and per-evidence `pattern` (evidence)**: confirmed consistent across all 4 docs.
+- **Sampling override coherence (§FR-7)**: now references BOTH override sites at `server.py:1860-1881` AND `1961-1972` per v3 proposal §3.2.1.
+- **Architecture correction reinforced**: §13 already correctly notes `_determine_capabilities` is separate; no change needed here.
+- **Test count updated to 18** (matches proposal §5 honest count).
+
+**v2 (2026-05-29)** — Codex CLI critical review identified 15 substantive issues with v1. Key fixes:
+- **Scope expansion**: bug affects ALL 7 libraries, not just Selenium. Updated requirements + ACs accordingly.
+- **AC-4 fixed**: negation pattern was wrong (current regex requires contiguous `migrate from`; missed real cases). Replaced with sentence-scoped source-vs-destination resolution.
+- **AC-5 fixed**: conflict-vs-threshold ordering swapped. Conflict check now runs on RAW scores BEFORE threshold filter, so `"both selenium and playwright"` actually returns None+conflict as documented.
+- **AC-7 fixed**: `status code` is mention-only per design; replaced AC-7's example with a pattern that's actually in the explicit set.
+- **AC-8 reconciled**: PRD no longer claims "all existing tests pass" — explicitly acknowledges 3-5 existing test updates needed and lists them.
+- **Architecture claim corrected**: `suggested_libraries` does NOT come from `LibraryDetector` — it's a separate substring heuristic (`_determine_capabilities`). Removed wrong cross-reference.
+- **Field name standardised**: `patterns_matched` (was inconsistent across docs).
+- **Sampling override coherence defined**: when sampling overrides preference, evidence is cleared and `preference_source: "sampling"` is set.
+- **Downstream consumers expanded**: library_recommender, adapter_factory, keyword_executor, browser_plugin, selenium_plugin added to the impact analysis.
+- **Performance claim removed**: replaced unsupported "≤60µs" with "no measurable regression vs baseline".
+
+**v1 (2026-05-29)** — initial draft. Identified the reported defect, proposed mention-vs-preference split.
+
+---
+
+## 1. Problem statement
+
+`analyze_scenario` reports `explicit_library_preference: "SeleniumLibrary"` for scenarios that never explicitly request SeleniumLibrary. Reproduced with the exact user-supplied input:
+
+```json
+{
+  "scenario": "Test e-commerce website https://demoshop.makrocode.de: open browser, add items to shopping cart, verify items, complete checkout, and close browser",
+  "context": "web",
+  "session_id": "demoshop_test"
+}
+```
+
+Response includes:
+```json
+"analysis": {
+  "explicit_library_preference": "SeleniumLibrary",
+  "suggested_libraries": ["Browser", "SeleniumLibrary", "RequestsLibrary"],
+  ...
+}
+```
+
+The user wrote "open browser" as a generic English verb for "launch a web browser session". They did NOT mention `selenium`, `webdriver`, `seleniumlibrary`, or any other Selenium-explicit phrase. The system nevertheless classified this as an *explicit* preference.
+
+Root cause traced to `src/robotmcp/utils/library_detection.py:33` — the pattern `\bopen\s+browser\b` is weighted 6 against SeleniumLibrary (because `Open Browser` is the SL keyword name) and the default min_score is 5. The phrase fires the threshold by itself with no other Selenium signal in the text.
+
+**Scope: same bug class affects ALL seven libraries**, not just SeleniumLibrary. Verified false-positive triggers (raw scores against the current pattern table):
+
+| Library | Triggering NL phrase | Score | Threshold | Fires |
+|---|---|---|---|---|
+| SeleniumLibrary | "open browser" | 6 | 5 | YES |
+| Browser | "Open new page in browser context" | 8 | 5 | YES |
+| AppiumLibrary | "Open application on the device" | 8 | 5 | YES |
+| SSHLibrary | "Execute command on the remote server" | 11 | 5 | YES |
+| Database | "Check if exists and verify row count" | 14 | 5 | YES |
+| RequestsLibrary | "Verify status code returned by service" | 5 | 5 | YES |
+| XML | "Parse the XML response from the API" | 7 | 5 | YES |
+
+The fix must address the entire pattern table, not just the Selenium rows. v1 framed this as a Selenium-only problem; v2 broadens scope.
+
+## 2. Why this matters
+
+Downstream consequences of a false `explicit_library_preference`. Each row identifies a call-site that reads the field and changes behaviour based on it.
+
+| # | Consumer (file:lines) | What it does with the field | Failure mode when value is wrong |
+|---|---|---|---|
+| 1 | `server.py:2037` `_filter_keywords_by_session_library` | Drops the OTHER library's keywords from `find_keywords` results | Agents see SL keywords only; write SL code; fail at `execute_step` against a Browser session (or vice versa) |
+| 2 | `session_models.py:787` `ExecutionSession.configure_from_scenario` | Eagerly loads the detected library at session init | Loads SeleniumLibrary → WebDriver init + system check; 1-3s wasted; misleading errors |
+| 3 | `components/library_recommender.py:111-166` | Adds the explicit preference to the front of the recommendation list with high confidence | `recommend_libraries` returns SL as primary recommendation when the user wanted Browser |
+| 4 | `components/library_recommender.py:310-321` | Excludes the other library from candidates | Browser library not even surfaced in the alternatives list |
+| 5 | `adapters/adapter_factory.py:131-140` | Selects the platform adapter (Browser vs SL) | Adapter picks SL-specific paths (e.g., WebDriver wait policies); Browser-loaded session gets SL semantics |
+| 6 | `components/execution/keyword_executor.py:1901-1914` | Disambiguates same-named keywords (e.g., `Take Screenshot`) by preferring the explicit library | `Take Screenshot` resolves to SL when Browser is also loaded — fails because no SL session exists |
+| 7 | `plugins/builtin/browser_plugin.py:314-321,379-390` | Suppresses Browser auto-init when SL is preferred | Browser session never initialized; `execute_step` errors with "No Browser session" on a Browser-intent scenario |
+| 8 | `plugins/builtin/selenium_plugin.py:202-208` | Eagerly initializes SL when it's the explicit preference | SL session pre-created and tied to the wrong driver type; conflicts with later Browser intent |
+
+Plus the **contract violation**: the field is called `explicit_library_preference`. Users and agents reasonably interpret "explicit" as "the user said so explicitly". The current implementation conflates "the user used English phrases that happen to overlap with the library's keyword names" with "the user explicitly chose that library".
+
+## 3. Goals
+
+- The `explicit_library_preference` field must fire **only** when the user has explicitly mentioned a specific RF library. Implicit signals (e.g., "open browser", "click element", "input text") must NOT trigger explicit preference, regardless of which library's keyword names they happen to match.
+- When the scenario is ambiguous between libraries (Browser vs SeleniumLibrary for web work), the field must return `None` rather than picking one arbitrarily by pattern-table ordering.
+- When the scenario has signals for multiple libraries (e.g., both `playwright` and `selenium` mentioned), the field must surface the conflict rather than silently picking one.
+- The fix must not break existing tests that assert explicit detection on truly-explicit scenarios (e.g., "use Selenium to test ...").
+
+## 4. Non-goals
+
+- We do NOT need to extend `_determine_capabilities` (the `suggested_libraries` field) — it's allowed to be generous and suggest both Browser and SeleniumLibrary for a generic "test website" scenario. Only the *explicit* path needs tightening.
+- We do NOT need to replace pattern matching with an LLM call. The sampling path (`sample_analyze_scenario` in server.py:1863) already exists and can override the rule-based detection when the operator opts in.
+- We do NOT need to detect library preference from action verbs (click/fill/input) at all. Those signals belong to the capability/session-type detection, not the explicit-preference path.
+
+## 5. Functional requirements
+
+### FR-1 — Explicit phrases only (all 7 libraries)
+
+The detector must annotate every pattern with an `explicit: bool` flag and only patterns where `explicit=True` contribute to the `explicit_library_preference` decision. All patterns remain in the table for the **mention** layer (used by callers that want a broad "what topics did the user mention" signal — see §5 FR-7 below for scope of consumers).
+
+**Patterns marked `explicit=True` (KEEP, contribute to preference):**
+
+| Class | Examples | Rationale |
+|---|---|---|
+| Library name verbatim | `\bseleniumlibrary\b`, `\bplaywright\b`, `\brequestslibrary\b`, `\bwebdriver\b`, `\brfbrowser\b`, `\brobotframework[- ]browser\b`, `\bappium(?:library)?\b`, `\bsshlibrary\b`, `\bdatabaselibrary\b`, `\bxmllibrary\b` | The library is named by its actual identifier |
+| Preference verb + library token | `\b(use\|using\|with\|via\|through\|prefer)[^\S\n]+(selenium\|playwright\|appium\|seleniumlibrary\|browserlibrary\|requestslibrary\|appiumlibrary\|databaselibrary\|sshlibrary\|xmllibrary)\b` | v5: brand names + verbatim library names only. Bare generic nouns (`browser`, `database`, `ssh`, `requests`, `xml`) deliberately NOT in this alternation — they're domain words, not library identifiers. `[^\S\n]+` (not `\s+`) so newlines act as sentence boundaries. |
+| Library-specific tech terms | `\bchromedriver\b`, `\bgeckodriver\b`, `\bchromium\b`, `\bwebkit\b`, `\bplaywright-?core\b`, `\biwebdriver\b` | Unambiguously names the library's runtime |
+
+**Patterns marked `explicit=False` (KEEP in mention layer, EXCLUDE from preference):**
+
+These are the noise patterns that triggered the reported defect. They overlap with keyword names or generic English domain prose but DO NOT indicate an explicit library choice. In v1 some of these were proposed for removal; v2 keeps them in the mention table (so the capability-suggestion path can still see "the user is talking about a browser") but removes their contribution to `explicit_library_preference`.
+
+- Generic action verbs that overlap with keyword names: `\bopen\s+browser\b`, `\binput\s+text\b`, `\bclick\s+element\b`, `\bpage\s+should\s+contain\b`, `\bnew\s+(browser|page|context)\b`
+- Generic technique terms: `\b(implicit|explicit)\s+wait\b`, `\b(SPA|single\s+page\s+app(lication)?)\b`, `\b(e2e|end.to.end)\s+(test|automat)\b`, `\bcross[- ]browser\s+testing\b`
+- Domain markers (Codex flagged these as wrongly annotated `explicit=True` in v1): `\brest\s+api\s+testing\b`, `\bmobile\s+(automation|testing)\b`, `\b(android|ios)\s+(testing|test)\b`, `\b(SELECT|INSERT|UPDATE|DELETE)\s+(\*|FROM|INTO)\b`, `\b(postgres(ql)?|mysql|sqlite|oracle|mariadb|mssql|sqlserver)\b`, `\bstatus\s+code\b`, `\bxpath\b`, `\bxsd\b`
+- SSH-domain noise: `\bexecute\s+command\b`, `\bremote\s+(server|host|machine)\b`, `\bssh\s+(into|to)\b`
+- Mobile-domain noise: `\bopen\s+application\b`, `\bdevice\b` (alone)
+- DB-domain noise: `\b(check|verify)\s+if\s+exists\b`, `\brow\s+count\b`, `\bquery\s+(the|a)?\s*database\b`
+
+These patterns can still inform `suggested_libraries` indirectly via `_determine_capabilities` (a SEPARATE substring heuristic at `nlp_processor.py:517-544`, not driven by `LibraryDetector` — see Architecture Correction in §13).
+
+**Non-English limitation (deliberate)**: all patterns are English-only. Scenarios written in other languages will yield `None` for `explicit_library_preference`. This is acceptable because (a) the existing baseline is also English-only and (b) the field is opt-in semantics — `None` is the safe default. Future work could add a per-locale pattern set; out of scope here.
+
+### FR-2 — Confidence threshold
+
+The detector uses a single `min_score` threshold. After FR-1 removes noise contributions, a weight-6 pattern firing means the user wrote either a library name verbatim (`\bselenium\b` at weight 6) or used a tech-specific term — both legitimate signals. The threshold can stay at 5 for libraries with no competitor in a conflict group (Database, SSH, XML), but rises to **8** for libraries inside a conflict group (Browser, SeleniumLibrary).
+
+Configurable via env vars (defaults shown):
+- `ROBOTMCP_LIBRARY_DETECTION_MIN_SCORE=5` (out-of-group libraries)
+- `ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD=8` (within-group libraries)
+- `ROBOTMCP_LIBRARY_DETECTION_AMBIGUITY_WINDOW=4` (see FR-3)
+
+### FR-3 — Abstain on ambiguity (algorithm ordering)
+
+**Critical**: conflict detection runs on **raw explicit scores BEFORE threshold filtering**. This is the v1→v2 fix that makes AC-5 actually work. Pseudocode:
+
+```
+raw_scores = {lib: sum(weights of matched explicit=True patterns)}
+apply_negation_and_migration(raw_scores)   # see FR-6
+
+for group in CONFLICT_GROUPS:
+    libs_with_signal = [lib for lib in group if raw_scores[lib] > 0]
+    if len(libs_with_signal) >= 2:
+        top2 = sorted(libs_with_signal, key=raw_scores.get, reverse=True)[:2]
+        if raw_scores[top2[0]] - raw_scores[top2[1]] <= ambiguity_window:
+            return ConflictResult(None, conflicts={group: scores_for_libs(top2)})
+
+# No conflict — apply threshold and pick winner
+effective_threshold = conflict_threshold if lib_in_group else min_score
+candidates = {lib: s for lib, s in raw_scores.items() if s >= effective_threshold}
+if not candidates:
+    return None
+return max(candidates, key=candidates.get)
+```
+
+Worked examples (with `min_score=5`, `conflict_threshold=8`, `ambiguity_window=4`):
+
+| Scenario | SL raw | Browser raw | Group? | Diff | Pre-threshold conflict? | Post-threshold result |
+|---|---|---|---|---|---|---|
+| "use playwright" | 0 | 10 (`use ... playwright`) + 9 (`playwright`) = 19 | Yes | 19 | no (one lib only) | Browser ≥ 8 → Browser |
+| "use Selenium 4" | 10 + 6 + 8 = 24 | 0 | Yes | 24 | no | SL ≥ 8 → SeleniumLibrary |
+| "Run a Selenium test" | 6 | 0 | Yes | 6 | no | SL 6 < 8 → None |
+| "both selenium and playwright" | 6 | 9 | Yes | 3 ≤ 4 | **YES → conflict** | None + conflicts={web_automation: [SL=6, Browser=9]} |
+| "Test e-commerce site, open browser, add to cart" (the bug) | 0 (after FR-1) | 0 (after FR-1) | n/a | 0 | no | None |
+| "Parse XML using xmllibrary" | 0 | 0 | n/a | n/a | n/a | XML 10+8 = 18 ≥ 5 → XML |
+
+The pre-threshold conflict check is what makes the `"both selenium and playwright"` example work. Under v1's design (conflict-after-threshold), SL=6 would be filtered out by threshold=8 before the conflict check ran, leaving Browser=9 as a single candidate → no conflict → wrong answer.
+
+### FR-4 — Conflict surfacing in the response
+
+When the conflict check fires, the `analysis` block must include a `library_preference_conflicts` field listing the conflicting candidates with their scores and the patterns that matched.
+
+Example (after fix):
+```json
+"analysis": {
+  "explicit_library_preference": null,
+  "preference_source": "rule",
+  "library_preference_conflicts": {
+    "web_automation": [
+      {"library": "SeleniumLibrary", "score": 6, "patterns_matched": ["\\bselenium\\b"]},
+      {"library": "Browser", "score": 9, "patterns_matched": ["\\bplaywright\\b"]}
+    ]
+  },
+  "suggested_libraries": ["Browser", "SeleniumLibrary"]
+}
+```
+
+Field-name standardisation (v6 final): `patterns_matched` is used in **`library_preference_conflicts[]` entries** (list of pattern source strings). **Evidence entries use singular `pattern`** (single source string per match) — verified in `src/robotmcp/utils/library_detection.py:PatternMatch.to_dict()` and `tests/unit/test_explicit_library_detection_fix.py::TestEvidenceShape`. v5 PRD wrongly conflated the two; v6 separates them.
+
+### FR-5 — Verbatim provenance (v3 canonical shape)
+
+When `explicit_library_preference` is set by the rule-based detector, the response must include `explicit_library_evidence` — a **flat list** of pattern-match entries with the canonical shape used across all four docs:
+
+```json
+"explicit_library_preference": "SeleniumLibrary",
+"preference_source": "rule",
+"explicit_library_evidence": [
+  {
+    "library": "SeleniumLibrary",
+    "pattern": "\\b(use|using|with|via|through|prefer)\\s+(selenium|seleniumlibrary|selenium\\s*library)\\b",
+    "weight": 10,
+    "text_span": "use selenium"
+  },
+  {
+    "library": "SeleniumLibrary",
+    "pattern": "\\bselenium\\b",
+    "weight": 6,
+    "text_span": "selenium"
+  }
+]
+```
+
+Each entry: `{library: str, pattern: str (regex source), weight: int, text_span: str (matched substring)}`. The list is FLAT (one entry per matching pattern); the `library` field per entry lets consumers filter or group. This matches DDD §4.1.2 `PatternMatch` and ADR §3.5.
+
+### FR-6 — Negation and migration (sentence-scoped, source-vs-destination aware)
+
+The v1 design proposed an 80-character forward window. Codex flagged that this breaks `"do not use Selenium, instead use Playwright"` (the window covers both library mentions, zeroing both). v2 replaces this with a **sentence-scoped algorithm that distinguishes source from destination**:
+
+```python
+# v7 IMPLEMENTED in src/robotmcp/utils/library_detection.py
+
+# v7: sentence punctuation OR paragraph break (2+ newlines).
+# Single newlines are NOT boundaries — they keep negation contiguous with its
+# target ("do not use\nPlaywright" → None). Paragraph breaks ARE boundaries
+# ("Do not use this approach\n\nUse Playwright" → Browser).
+# Lineage: v5 had \n in delim (orphaned negation), v6 dropped \n entirely
+# (broke paragraphs), v7 uses paragraph-aware alternation.
+_SENTENCE_DELIMITERS = r"[.;!?,]+|\n\s*\n+"
+
+# v5: SINGLE alternation regex, longest-first. Regex engine guarantees one
+# match per span — no double-deduction. `skip` restored as standalone.
+_NEGATION_REGEX = re.compile(
+    r"\b(?:"
+    r"do\s+not\s+use|don't\s+use|"
+    r"not\s+using|without\s+using|stop\s+using|avoid\s+using|"
+    r"skip\s+using|exclude\s+using|"
+    r"do\s+not|don't|"
+    r"without|stop|avoid|skip|exclude"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# v5: source-vs-destination resolution via _first_library_token_in() on the
+# captured spans (NOT raw \w+ capture, which broke multi-word library names).
+MIGRATION_PATTERNS = [
+    r"\bmigrat(?:e|ion|ing)\b.+?\bfrom\b\s+(?P<src>.+?)\s+\bto\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+    r"\bswitch(?:ing)?\s+from\b\s+(?P<src>.+?)\s+\bto\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+    r"\binstead\s+of\b\s+(?P<src>.+?)\s+\b(?:use|with|via)\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+    r"\breplace\b\s+(?P<src>.+?)\s+\b(?:with|by|for)\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+]
+
+for sentence_index, sentence_span in enumerate(_build_sentence_spans(text)):
+    sent = text[sentence_span.start:sentence_span.end]
+
+    # Step A — migration (source/destination resolution)
+    for pattern in MIGRATION_PATTERNS:
+        for m in re.finditer(pattern, sent, re.IGNORECASE):
+            src_lib = _first_library_token_in(m.group("src"))
+            dst_lib = _first_library_token_in(m.group("dst"))
+            if src_lib:
+                _subtract_sentence_score(raw_scores, matches_by_lib,
+                                         sent, sentence_index, src_lib)
+            if dst_lib:
+                raw_scores[dst_lib] += 5  # destination bonus
+
+    # Step B — single-library negation (SINGLE alternation regex)
+    for m in _NEGATION_REGEX.finditer(sent):
+        remaining = sent[m.end():]
+        target_lib = _first_library_token_in(remaining)
+        if target_lib:
+            _subtract_sentence_score(raw_scores, matches_by_lib,
+                                     sent, sentence_index, target_lib)
+```
+
+This is the actually-shipped v5 implementation. v4's documented `\w+` capture pattern was the round-3-flagged D1 bug; v5 uses phrase-list + token-resolution to avoid capturing the wrong word as the negation target.
+
+Worked examples:
+
+| Sentence | Migration match | Negation match | Source effect | Dest effect | Net |
+|---|---|---|---|---|---|
+| "Migrate the test suite from Selenium to Playwright" | from=Selenium, to=Playwright | — | SL: -all-in-sentence | Browser: +5 | Browser wins |
+| "do not use Selenium, instead use Playwright" | (split on comma) S1: instead-of variant doesn't match (no "of"); S2: bare "use Playwright" | S1: matches "not use Selenium" | SL: -all-in-S1 | Browser: +10 in S2 | Browser wins |
+| "without selenium" | — | matches "without selenium" | SL: -all | — | SL = 0 |
+| "Use Playwright for the e2e test" | — | — | — | Browser: +10 + +9 | Browser wins (no negation) |
+
+The negation handling **must preserve** the AC-4 outcome (Browser wins on migration), which v1's regex couldn't deliver because it required contiguous "migrate from".
+
+### FR-7 — Sampling override coherence (v3 — TWO sites)
+
+LLM sampling overrides the rule-based detector at **two independent sites** in `server.py` (v2 documented only the first; Codex v2-round-2 review surfaced the second):
+
+| Site | File:lines | Effect | Coherence protocol |
+|---|---|---|---|
+| A | `server.py:1860-1881` | Modifies `analysis["explicit_library_preference"]` in the analyze_scenario response | Set `analysis.preference_source="sampling"`, clear `explicit_library_evidence` + `library_preference_conflicts`, populate `sampling_evidence` |
+| B | `server.py:1961-1972` | Modifies `session.explicit_library_preference` on the ExecutionSession aggregate | Set `session.preference_source="sampling"` |
+
+Both sites are gated by `is_sampling_enabled()` reading the `ROBOTMCP_USE_SAMPLING` env var (verified at `sampling.py:23`).
+
+When sampling does NOT override (or is disabled):
+- `analysis.preference_source` ← `"rule"`
+- `session.preference_source` ← `"rule"`
+- Evidence/conflicts populated by the rule-based detector as in FR-4/FR-5
+
+This contract makes it unambiguous to all 8 downstream consumers (listed in §2) which signal produced the preference and where to look for the reasoning.
+
+### FR-8 — Mention layer scope clarification
+
+v1 conflated two systems. v2 makes the boundary explicit:
+
+| System | File:lines | Input | Output | Used by |
+|---|---|---|---|---|
+| Preference layer (this PRD) | `library_detection.py` + `nlp_processor._detect_explicit_library_preference` | scenario text | `analysis.explicit_library_preference` + evidence + conflicts | All 8 downstream consumers from §2 |
+| Capability layer (untouched) | `nlp_processor._determine_capabilities` lines 517-544 | scenario text | `analysis.suggested_libraries` (broad advisory list) | Session import hints only |
+
+The capability layer is a **separate substring heuristic** that does NOT call `LibraryDetector`. v1's docs implied a shared codepath; that was wrong. The capability layer can remain generous (suggest both Browser and SL for a vague web scenario) because it's advisory; only the preference layer needs the tighter explicit/mention distinction this PRD specifies.
+
+## 6. Non-functional requirements
+
+- **NFR-1 Backward compatibility**: most tests calling `_detect_explicit_library_preference` for truly-explicit scenarios ("use Selenium", "with playwright") continue passing unchanged. A small number of existing tests assert false-positive behaviour and must be updated — see AC-8 + §13 for the list. Response shape adds three optional fields (`library_preference_conflicts`, `explicit_library_evidence`, `preference_source`); does not remove or rename existing fields. The `_compiled_patterns` internal attribute remains (with annotated entries) because integration tests inspect it directly (`tests/integration/test_nlp_improvements.py:103-104,571-576`).
+- **NFR-2 Performance**: pattern matching is O(N × P) where N is text length and P is patterns. The fix adds the `explicit: bool` flag check per match (constant per pattern) and adds sentence splitting + per-sentence negation/migration application. No microbenchmark target — the requirement is **no measurable regression** vs the current baseline (`tests/benchmarks/test_library_detection_bench.py` continues to pass within existing tolerances).
+- **NFR-3 Determinism**: same input → same output. No randomness, no clock dependency.
+- **NFR-4 Observability**: detection logs at INFO level when a preference is set, at DEBUG when conflicts arise. New log line at DEBUG when a migration pattern fires (`Migration detected: source=X destination=Y`).
+- **NFR-5 Test surface compatibility**: existing tests inspect `LibraryDetector._compiled_patterns` directly. The fix annotates entries (adds the `explicit` flag) without removing the attribute or changing its key types. Existing assertions on pattern presence continue to work.
+
+## 7. Acceptance criteria
+
+The fix is accepted when ALL of these hold:
+
+### AC-1 — Reported scenario
+
+`analyze_scenario(scenario="Test e-commerce website https://demoshop.makrocode.de: open browser, add items to shopping cart, verify items, complete checkout, and close browser", context="web")` returns:
+- `analysis.explicit_library_preference` == `None`
+- `analysis.suggested_libraries` may contain Browser, SeleniumLibrary (advisory list — unchanged)
+- No false positive for SeleniumLibrary
+
+### AC-2 — Browser-explicit scenario
+
+`analyze_scenario(scenario="Use playwright to test the checkout flow on demoshop.makrocode.de", context="web")` returns:
+- `analysis.explicit_library_preference` == `"Browser"`
+- `analysis.explicit_library_evidence` lists the `playwright` pattern hit
+
+### AC-3 — Selenium-explicit scenario
+
+`analyze_scenario(scenario="Use Selenium to test the login form against the e-commerce site", context="web")` returns:
+- `analysis.explicit_library_preference` == `"SeleniumLibrary"`
+- `analysis.explicit_library_evidence` lists the `use selenium` pattern hit
+
+### AC-4 — Conflict scenario
+
+`analyze_scenario(scenario="Migrate the test suite from Selenium to Playwright for the demoshop site")` returns:
+- `analysis.explicit_library_preference` == `"Browser"` (the destination of the migration; "migrate from selenium" subtracts Selenium score per negation patterns, leaving Playwright alone above threshold)
+- `analysis.library_preference_conflicts` is absent (Selenium was negated out, no conflict)
+
+### AC-5 — Genuine conflict (rare but pinned)
+
+`analyze_scenario(scenario="Test both selenium and playwright sites and compare")` returns:
+- `analysis.explicit_library_preference` == `None`
+- `analysis.preference_source` == `"rule"`
+- `analysis.library_preference_conflicts.web_automation` lists both Browser and SeleniumLibrary with their respective scores
+
+Verification under the algorithm in FR-3 (raw-score conflict check BEFORE threshold filter):
+- SL raw = 6 (`\bselenium\b`)
+- Browser raw = 9 (`\bplaywright\b`)
+- Both > 0, |9 − 6| = 3 ≤ 4 (ambiguity_window) → conflict fires → None + conflicts populated
+
+This AC was impossible under v1's algorithm ordering (SL=6 would be filtered before conflict check). v2's ordering makes it work.
+
+### AC-6 — Pure NL phrase scenarios (no library mention)
+
+For each of:
+- "click element by id submit"
+- "Page should contain Welcome text"
+- "Input text into the username field"
+- "Open new page in browser context"
+- "Execute command on the remote server" (was SSH false positive)
+- "Open application on the device" (was Appium false positive)
+- "Check if exists and verify row count" (was Database false positive)
+- "Verify status code returned by service" (was Requests false positive)
+- "Parse the XML response from the API" (was XML false positive)
+
+The detector returns `explicit_library_preference: None`. (Currently all nine return a false library per the §1 bug-class table.)
+
+### AC-7 — No regression for explicit library mentions
+
+`analyze_scenario(scenario="Use requestslibrary to POST a JSON body to /api/users")` returns:
+- `analysis.explicit_library_preference` == `"RequestsLibrary"` (matches the `\b(use|using|with|via|through|prefer)[^\S\n]+(requestslibrary|requests\s*library)\b` preference-verb pattern. v6 NOTE: bare `requests` is NOT a valid preference-verb target — see `library_detection.py:LIBRARY_RULES_DEFAULT['RequestsLibrary']`)
+
+`analyze_scenario(scenario="Parse XML response using xmllibrary and validate xpath /root/element")` returns:
+- `analysis.explicit_library_preference` == `"XML"` (matches `\bxmllibrary\b` verbatim)
+
+`analyze_scenario(scenario="Use AppiumLibrary to test the iOS app")` returns:
+- `analysis.explicit_library_preference` == `"AppiumLibrary"` (matches `\bappium(?:library)?\b` verbatim + preference-verb pattern)
+
+`analyze_scenario(scenario="SSH into the build server using SSHLibrary")` returns:
+- `analysis.explicit_library_preference` == `"SSHLibrary"` (matches `\bsshlibrary\b` verbatim)
+
+v1 used `"verify status code"` which is mention-only per FR-1; v2 swaps to scenarios that actually mention the library.
+
+### AC-8 — Test suite passes; existing false-positive assertions updated
+
+**Tests that pass unchanged** (the "use X" / "with Y" style scenarios — happy path):
+- `tests/unit/test_library_detection.py` — most cases
+- `tests/integration/test_nlp_improvements.py:103-104,571-576` — `_compiled_patterns` inspection (entries keep their pattern strings; only the `explicit` flag is added)
+
+**Tests that need updating** (estimated 3-5; will be enumerated in solution proposal §3.4):
+- Any test asserting that "open browser" alone returns `SeleniumLibrary` → must update to expect `None`
+- Any test asserting that "click element" alone returns `SeleniumLibrary` → must update to expect `None`
+- Any test in `test_session_models_library_preference.py` exercising session auto-config from these noise phrases
+
+**New tests added** (**~18 distinct test functions** across 9 test classes, ~37 invocations after parametrisation expansion — see proposal §5 Test Matrix). v1's "5-8" and "25-30" estimates and v2's "10" claim are reconciled to **18 in v3** matching the honest matrix count.
+
+## 8. Out of scope
+
+- LLM-based detection (`sample_analyze_scenario` path) — already exists, opt-in via env, unchanged by this PRD.
+- `_determine_capabilities` / `suggested_libraries` tightening — those fields are advisory and acceptable as-is.
+- Auto-import behaviour in `configure_from_scenario` — fixed indirectly by the more-accurate `explicit_library_preference`. No code change to the importer.
+- Renaming the field — the name `explicit_library_preference` is accurate after the fix; no renaming required.
+
+## 9. Stakeholders & impact
+
+| Stakeholder | Impact |
+|---|---|
+| **End users** writing scenarios | Stop seeing SeleniumLibrary autoload when they meant Browser. Stop seeing Browser keywords filtered out during discovery. Bug fix; positive. |
+| **Agents** consuming `analyze_scenario` output | Correct `explicit_library_preference` value. New optional fields available (`library_preference_conflicts`, `explicit_library_evidence`) for richer reasoning. |
+| **rf-mcp maintainers** | Smaller, more accurate detection rule set. Easier to extend with new libraries — only need to add explicit-mention patterns. |
+| **Existing test suite** | ~18 new tests added (see proposal §5). 3-5 existing tests asserting false-positive behaviour need updating (see AC-8 + proposal §3.4). v2 wrongly said "no existing tests should break" — v3 reconciles with AC-8's explicit list. |
+
+## 10. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Removing the `open browser` pattern misses some genuinely-Selenium scenarios | Low | The pattern was already overzealous. Users intending Selenium typically say "use Selenium" or mention "webdriver" / "chromedriver". The `selenium` standalone-mention pattern at weight 6 still catches "Selenium test" / "run Selenium". |
+| Bumping the conflict-group threshold to 8 misses some Selenium-only scenarios that only had weight-6 hits | Medium | Document the new threshold. Operators can lower via env var if their corpus needs it (see ADR-024 §6). |
+| The `library_preference_conflicts` field surfaces noisy data | Low | Only emitted when two libraries in the SAME conflict group both score > 0. Web-automation is the only registered group. |
+| Sampling path silently overrides the rule-based detector | Already exists | The PRD doesn't change sampling behaviour. Sampling opt-in stays opt-in. Documented in ADR-024 §7. |
+
+## 11. Success metrics
+
+Before/after the fix, run the following on the project's existing scenario test corpus (if any) and on a synthetic set of 20 scenarios (10 truly explicit, 10 pure-NL):
+
+| Metric | Pre-fix | Post-fix target |
+|---|---|---|
+| Precision on "scenarios with no library mention" returning None | ~30% (estimated) | ≥95% |
+| Recall on "use playwright" / "use selenium" returning correct library | ~100% | 100% |
+| False positives via single weight-6 NL pattern | Common | Eliminated |
+| Test suite duration impact | n/a | < 50ms added |
+
+## 12. Open questions
+
+1. **Should `\bwebdriver\b` stay at weight 6?** It IS a Selenium-explicit term but appears in error messages and unrelated docstrings sometimes. Recommended: keep at 6 but require a context check (the conflict-group threshold of 8 will block lone-`webdriver` from triggering anyway).
+2. **Should we expose `min_score` as a tool parameter?** Probably not — adds API surface for an internal knob. Keep as env var only (`ROBOTMCP_LIBRARY_DETECTION_MIN_SCORE`, default 5; `ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD`, default 8).
+3. **Should the "ambiguity window" be configurable?** Default 4 covers the common case; let operators override via `ROBOTMCP_LIBRARY_DETECTION_AMBIGUITY_WINDOW`.
+4. **What about resource keywords with overlapping names?** Out of scope; resource keywords don't have a libdoc tag taxonomy and shouldn't drive explicit-preference detection.
+
+## 13. References
+
+### Source files
+
+- `src/robotmcp/utils/library_detection.py:21-126` — LIBRARY_PATTERNS table
+- `src/robotmcp/utils/library_detection.py:132-135` — NEGATION_PATTERNS (current; v2 replaces with sentence-scoped algorithm in FR-6)
+- `src/robotmcp/utils/library_detection.py:155-213` — `detect()` and `get_scores()` methods
+- `src/robotmcp/utils/library_detection.py:240-242` — CONFLICT_GROUPS (web_automation: Browser + SeleniumLibrary)
+- `src/robotmcp/components/nlp_processor.py:31` — class is `NaturalLanguageProcessor` (v1 wrongly called it `NLPProcessor`)
+- `src/robotmcp/components/nlp_processor.py:203-280` — `analyze_scenario` builds response dict
+- `src/robotmcp/components/nlp_processor.py:517-544` — `_determine_capabilities` (the separate substring heuristic — see FR-8)
+- `src/robotmcp/components/nlp_processor.py:652-704` — `_detect_explicit_library_preference` + fallback
+- `src/robotmcp/models/session_models.py:563-590` — `detect_explicit_library_preference` aggregate method
+- `src/robotmcp/server.py:1811-1985` — `analyze_scenario` MCP tool wrapper
+- `src/robotmcp/server.py:1866-1880` — sampling override path (FR-7)
+- `src/robotmcp/server.py:1944-1956` — analyze_scenario auto-configure path
+- `src/robotmcp/server.py:2037` — `_filter_keywords_by_session_library` (downstream consumer 1)
+
+### Downstream consumer files (§2 table)
+
+- `src/robotmcp/components/library_recommender.py:111-166,310-321`
+- `src/robotmcp/adapters/adapter_factory.py:131-140`
+- `src/robotmcp/components/execution/keyword_executor.py:1901-1914`
+- `src/robotmcp/plugins/builtin/browser_plugin.py:314-321,379-390`
+- `src/robotmcp/plugins/builtin/selenium_plugin.py:202-208`
+
+### Architecture correction (v1→v2)
+
+v1 implied that `suggested_libraries` was backed by `LibraryDetector.get_scores`. **This was wrong.** `suggested_libraries` is computed by `_determine_capabilities` (nlp_processor.py:517-544), which is a **separate substring/keyword heuristic** that does NOT call `LibraryDetector`. The mention layer described in the DDD bounded context (`get_scores`) is currently consumed only by `_detect_explicit_library_preference` itself — there is no current capability path through it. Future work could route capabilities through the mention layer for consistency; that's out of scope here.
+
+### Companions (also revised to v2)
+
+- `docs/adr/ADR-024-explicit-library-detection-confidence.md`
+- `docs/ddd/library_preference_bounded_context.md`
+- `docs/proposals/explicit_library_detection_fix_proposal.md`

--- a/docs/proposals/explicit_library_detection_fix_proposal.md
+++ b/docs/proposals/explicit_library_detection_fix_proposal.md
@@ -1,0 +1,1529 @@
+# Solution Proposal — Explicit Library Detection Fix
+
+**Date**: 2026-05-29
+**Status**: **IMPLEMENTED v7 — production-ready** (Codex round-7 verdict 2026-06-05). Source in `src/robotmcp/utils/library_detection.py`, `nlp_processor.py`, `session_models.py`, `server.py`. **83 targeted tests in `tests/unit/test_explicit_library_detection_fix.py`; full unit suite: 6249 passing.**
+**Related**: PRD `docs/prd/analyze_scenario_explicit_library_prd.md`, ADR-024, DDD library_preference bounded context
+
+---
+
+## Revision history
+
+**v7 (2026-06-05) — IMPLEMENTED** — Codex round-6 review (verdict: NOT production-ready) verified the 4 v6 fixes BUT found 3 new issues. v7 addresses 2 of them now (C1 + C3); C2 is deferred to a separate follow-up since it's a pre-existing architectural concern (sampling Site B not session-coherent — exists since long before v5):
+- **C1 — Paragraph boundary restored (HIGH — fixed)**: v6's `_SENTENCE_DELIMITERS = r"[.;!?,]+"` dropped `\n` entirely to fix D-newline-negation, but then paragraph-separated text leaked negation across paragraphs. `"Do not use this approach\n\nUse Playwright for the test."` returned `None` (the negation reached into the second paragraph and zeroed Browser). v7 uses `r"[.;!?,]+|\n\s*\n+"` — single newline is NOT a boundary (preserves v6 fix); paragraph break (2+ newlines) IS a boundary (restores paragraph scope). Tested at `TestV7ParagraphBoundary` (3 paragraph + 4 single-newline cases).
+- **C3 — `nlp_processor.py:663` abstain-fallback removed (MEDIUM — fixed)**: the same bug v6 fixed in `session_models.py` was still present in `nlp_processor._detect_explicit_library_preference`. The main `analyze_scenario` path bypasses this helper (uses `_resolve_explicit_library_preference` directly), so production wasn't affected — but any caller of the helper would re-introduce the bug. v7 mirrors the v6 fix: fall back ONLY on Exception, never on deliberate None. Tested at `TestV7NlpProcessorAbstainNoFallback` (5 cases + 2 genuine-positive regressions).
+- **Doc propagation**: ADR §3.2 P3 sentence-split regex updated; PRD §FR-6 + Proposal Step 6 code blocks updated to show the v7 paragraph-aware delimiter; PRD/Proposal status promoted to `IMPLEMENTED v7`.
+- **C2 deferred (separate PR)**: sampling Site B at `server.py:1964` overrides `session.explicit_library_preference` but doesn't re-run `configure_from_scenario`, so `session.loaded_libraries`/`search_order` stay on the rule-based pick. This is a session-coherence problem that existed before v5; needs its own ADR + change to either re-run configure after override OR move Site B before initial configuration. Out of scope for the analyze_scenario library-detection PRD.
+- **Tests**: 14 new v7 tests (7 paragraph + 1 end-to-end via analyze_scenario + 6 abstain) — total `test_explicit_library_detection_fix.py` is now **83 tests, all green**. Full unit suite: **6249 passing, 1 skipped**.
+- **Codex round-7 verdict (2026-06-05): PRODUCTION-READY YES.** All v7 fixes verified end-to-end through the public `analyze_scenario()` path including CRLF/mixed-whitespace edge cases. C2 (sampling Site B session-coherence) remains scoped to a separate follow-up.
+
+**v6 (2026-06-05) — superseded by v7** — Codex round-5 review (PRD/DDD TIGHTEN; ADR/Proposal REWRITE) found that v5 fixed the analysis-path defect but the live implementation was NOT end-to-end coherent. 4 source bugs (3 critical) + doc propagation gaps. v6 fixes them:
+- **D-session-fallback (CRITICAL — fixed)**: `session_models.py:597` was falling back to `_fallback_detect_library` (broad substring heuristic) when v5 returned None, re-introducing false-positive explicit preferences at the session aggregate level. Example: `analyze_scenario("Parse the XML response from the API")` correctly returned `analysis.explicit_library_preference: None`, but `session.explicit_library_preference` was set to `"XML"` by the fallback. Downstream consumers reading the session saw the wrong value. **v6 removes the fallback on None — only ImportError triggers it.**
+- **D-newline-negation (CRITICAL — fixed)**: v5's `_SENTENCE_DELIMITERS = r"[.;!?,\n]+"` made `\n` a sentence boundary. `"do not use\nPlaywright"` split into two sentences; sentence 0 had the negation phrase but no target. **v6 removes `\n` from the delimiter** (now `[.;!?,]+`); newline-boundary at the explicit-pattern level is already enforced by `[^\S\n]+` so the newline-crossing preference verb protection is preserved.
+- **D-repeated-token (CRITICAL — fixed)**: `_subtract_sentence_score` used `rule.compiled.search(sentence)` (returns once per rule regardless of occurrence count). `"do not use Playwright Playwright"` scored Browser=28 via 3 occurrences but only deducted 19 → Browser=9 wins despite negation. **v6 uses `len(rule.compiled.findall(sentence))` to count occurrences** and multiply by weight.
+- **D-multiword-migration (HIGH — fixed)**: v5 migration destination lookahead `(?=[\s.,;!?]|$)` stopped at first whitespace, so `"Migrate from Selenium to Requests library"` captured `dst='Requests'` (bare `requests` excluded from `_LIBRARY_TOKENS`). Requests/Database/SSH/XML migrations all silently failed. **v6 lookahead is `(?=[.,;!?\n]|$)`** — destination captures up to next sentence punctuation; `_first_library_token_in()` then resolves canonical (matches `requests\s*library`, `database\s*library`, etc.).
+- **Doc propagation**: ADR §3.2 P2 now declares the brand-only rule explicitly (`browser`/`requests`/`database`/`ssh`/`xml` excluded from preference-verb alternation); §6 pattern table updated for all 4 brand-only rows. PRD evidence-field name corrected (`pattern` singular, not `patterns_matched`). Proposal `_last_resolution` removed from sample code.
+- **Tests**: 18 new tests added across 4 classes (`TestV6SessionFallbackBug`, `TestV6NewlineNegation`, `TestV6RepeatedTokenDeduction`, `TestV6MultiwordMigration`) plus `test_preference_verb_does_not_match_across_newline`. Total: 69 tests in the v6 file, all green. Full unit suite: **6235 passed** (1 skipped).
+
+**v5 (2026-06-05) — superseded by v6** — Codex round-4 review marked v4 REWRITE; identified 1 critical algorithm bug (`primary_library` fallback semantic), 1 race condition (`_last_resolution` on singleton), 1 regression (standalone `skip` dropped), 1 cross-sentence false-positive gap (`\s+` matching newline), plus several dict-vs-tuple shape discrepancies. v5 addresses all:
+- **D-skip restored**: `_NEGATION_REGEX` alternation now ends with `...|stop|avoid|skip|exclude` (standalone `skip` was missing in v4).
+- **Newline boundary**: preference-verb patterns use `[^\S\n]+` instead of `\s+`. Newlines act as sentence delimiters; `\b(use|with|...)\b\s+\bselenium\b` no longer matches `use\nselenium` across a line break.
+- **Race-free invocation**: removed `self._last_resolution` cache on `NaturalLanguageProcessor` singleton. The new `_resolve_explicit_library_preference()` returns the resolution as a local variable; `_build_analysis_block()` consumes it inline. Tested at `tests/unit/test_explicit_library_detection_fix.py:TestNoSharedState`.
+- **Sampling semantic fix**: dropped `primary_library` fallback at server.py:1860-1881 (Site A). Only `library_preference` writes to `explicit_library_preference`. `preference_source` flips to "sampling" + evidence/conflicts cleared.
+- **§3.2 emit-bug fixed**: v4 had `for lib, score, patterns in conflict_list` (tuple unpacking) but `resolution.conflicts` returns dicts. v5 passes dict entries through unchanged.
+- **§3.4 test count reconciled**: §3.4 (was "10 new tests"), §5 (18), §9 (18) — all now say 18. Actual count: 51 tests in the implemented test file (more granular than the original 18-distinct-function design; parametrisation expanded).
+- **ALL DOC PROPAGATION CLOSED**: ADR §3.2 code block, PRD §FR-1 / §FR-6 bare-noun list and algorithm code, DDD §2 overview shape strings — all aligned with the actually-shipped implementation.
+
+**SOURCE/TEST EVIDENCE**: `src/robotmcp/utils/library_detection.py` (full v5 implementation), `tests/unit/test_explicit_library_detection_fix.py` (51 tests covering 8 marquee scenarios + AC-1..AC-7 + sampling coherence + race-free invocation + sentence_index evidence filtering). Pre-existing test count was 6166; v5 adds 51 → 6217 passing.
+
+**v4 (2026-05-29)** — Third-round independent reviewer found one algorithmic bug + 7 consistency/specification gaps in v3. v4 addresses:
+- **D1 — Double-deduction eliminated**: v3 iterated `NEGATION_PHRASES` as a Python list, so both `\bdo\s+not\s+use\b` and `\bdo\s+not\b` fired on the same span for `"do not use Selenium"` and called `_subtract_sentence_score` twice. v3 worked by luck (`max(0, …)` clamps), but for `"do not use Selenium and stop the SeleniumLibrary"` the double-application risked corrupting partial-signal libraries. v4 replaces the list with a **single regex with alternation** ordered longest-first. The regex engine's left-to-right alternation guarantees longest match wins; each negation span fires exactly once. **Verified empirically against 8 scenarios including v3 edge cases.**
+- **D3 — Test unpacking fixed (proposal §3.4)**: v3 `TestConflicts.test_both_selenium_and_playwright_returns_none_with_conflict` extracts `entry[0]` (tuple style) but algorithm Step 6 returns dicts. v4 fixes the test to use `entry["library"]`.
+- **D3 — DDD §4.1.6 conflicts type updated**: DDD `Dict[str, List[Tuple[str, int, List[str]]]]` (tuple) → `Dict[str, List[Dict[str, Any]]]` (dict-of-dicts) to match PRD §FR-4, ADR §3.4, proposal Step 6.
+- **D4 — `ExecutionSession.preference_source` field declared**: §3.3 v4 now adds the field to the ExecutionSession dataclass as `preference_source: Optional[str] = "rule"`. v3 wrote to the attribute without specifying where it came from.
+- **D2 — INV-4 strengthened**: replaced trivial `max(0, x-d)` idempotence with **"deduction-sum equality"** — the property that the sum of deductions across all negation-phrase matches in a sentence equals the deduction from a single canonical phrase. This DOES catch D1 double-deduction.
+- **D5 — Test count reconciled to 18**: §9 Validation Plan dropped the stale "~30 new + ~3 modified" wording. Matrix and validation now both say "18 distinct functions, ~37 invocations after parametrisation".
+- **D6 — Multi-word migration limitation documented**: §3.1 Step 5 v4 notes that `"to Browser library"` migrations silently no-op because `_LIBRARY_TOKENS` excludes bare `browser`. Acknowledged as intentional consequence of the bare-noun fix.
+- **D7 — Evidence filtering via `sentence_index` field**: v3's `pm.text_span.lower() not in sentence.lower()` substring check could corrupt evidence across multi-sentence overlap. v4 adds `sentence_index: int = -1` to `PatternMatch` and filters by exact sentence membership, not substring inclusion. `sentence_index` is internal — not surfaced in `to_dict()`.
+- **D8 — `Literal` import added**: §3.1 Step 1 imports updated to include `Literal` from typing for `PreferenceResolution.source` annotation.
+- **F5 — `LIBRARY_RULES_DEFAULT` declared**: §3.1 Step 7 now explicitly defines `LIBRARY_RULES_DEFAULT` (referenced but not declared in v3) as the module-level constant carrying the v4 pattern table.
+
+**v3 (2026-05-29)** — Codex CLI second-round critical review identified 11 hard failures in v2 (verdict: REWRITE). v3 addresses them:
+- **Negation algorithm replaced (§3.1 Step 5)**: v2's single-regex `\b(not|don't|...)\s+(?:using\s+)?(?P<target>\w+)` captured `target="use"` (not the library) for "do not use Selenium". Codex ran the Python and proved v2 left SL=16, Browser=19 (raw conflict), not the documented Browser. v3 replaces with **phrase-list + find_first_library_token(remaining_text)** approach. Sentence delimiter now `[.;!?,\n]+` (includes comma) so "do not use Selenium, instead use Playwright" splits into 2 sentences.
+- **`_compiled_patterns` compat actually preserved (§3.1 Step 7)**: real tests do `for p, _ in _compiled_patterns; p.findall(...)`. v2's `PatternRule.__iter__` yielding 4 values would raise `ValueError`, and `PatternRule` has no `.findall`. v3 keeps `_compiled_patterns: Dict[str, List[Tuple[Pattern, int]]]` EXACTLY as today and introduces a parallel `_rules_metadata` dict for the rich annotations.
+- **Bare-token preference verbs dropped (§3.1 Step 2)**: `use browser`, `use database`, `use ssh`, `use requests`, `use xml` removed from explicit-preference patterns. These are generic English/domain nouns. Brand names `selenium`, `playwright`, `appium` retained as explicit because they're library-specific identifiers, not generic English.
+- **`PatternMatch` defined (§3.1 Step 4)**: v2 used `PatternMatch(...)` without declaring it. v3 defines it explicitly with the `library` field per DDD §4.1.2.
+- **`PatternRule.compiled` defined (§3.1 Step 1)**: v2 used `rule.compiled.finditer(...)` without declaring `compiled`. v3 adds a `compiled` property via `__post_init__` setting.
+- **`PreferenceResolution` fields aligned (§3.1 Step 4)**: v2 declared 4 fields then constructed with 5. v3 canonical shape: `(library, source, evidence, conflicts, all_scores, sampling_evidence)` — 6 fields.
+- **Sampling env var corrected (§3.2.1 + §3.4)**: `ROBOTMCP_USE_SAMPLING` (not `ROBOTMCP_USE_SAMPLING_FOR_NLP` as v2 mistakenly wrote — verified at `sampling.py:23`).
+- **Both sampling override sites covered (§3.2.1)**: v2 documented only `server.py:1860-1881` (the analysis-response override). Real code also has `server.py:1961-1972` modifying `session.explicit_library_preference`. v3 patches both.
+- **Scope table corrected (§3)**: 4 files (server.py added).
+- **Test matrix totals fixed (§5)**: matrix totals are 16 distinct functions across 9 classes; v3 honestly counts to match.
+- **`keyword_executor` consumer description corrected (§12)**: real code at `keyword_executor.py:1901-1914` hardcodes the `Open Browser` keyword check based on `pref.startswith("selenium" | "browser")`; v2's "library_name= fallback" claim was inaccurate.
+- **chromium/webkit weight aligned to 9 (§3.1 Step 2)**: matches ADR §6 "as specific as playwright" rationale.
+
+**v2 (2026-05-29)** — Codex CLI critical review identified 12 substantive issues in the proposal. Key changes:
+- **Pattern table corrected (§3.1)**: dropped wrongly-annotated `explicit=True` for `rest api testing`, `mobile automation`, `android testing`, `ios testing`, SQL fragments, DB engine names, XPath/XSD/XSLT, bare `xml`. v1 annotated these as `explicit=True` despite them being domain markers, not library identifiers.
+- **Negation algorithm replaced (§3.1 Step 5)**: v1's 80-character forward window broke `"do not use Selenium, instead use Playwright"` by zeroing both libraries. v2 uses sentence-scoped algorithm with separate `NEGATION_PATTERNS` (single-library) and `MIGRATION_PATTERNS` (source-vs-destination).
+- **Algorithm ordering corrected (§3.1 Step 5)**: conflict check now runs on RAW explicit scores BEFORE threshold filter. v1's "filter then check" sequence made the AC-5 example impossible.
+- **Class name fix (§3.2/§3.4)**: `NLPProcessor` → `NaturalLanguageProcessor` (actual class name at `nlp_processor.py:31`). v1 wrote bogus imports.
+- **Test count reconciled (§3.4/§5)**: 10 new tests per PRD v2 AC-8, not the inconsistent 25 / 30 v1 had.
+- **Impossible AC-5 test fixed (§3.4 TestConflicts)**: rewrote the "both selenium and playwright" test to match v2's raw-score conflict-detection algorithm.
+- **Existing-test updates listed (§3.4)**: 3-5 tests asserting false-positive behaviour are now enumerated with file:line locations.
+- **`_compiled_patterns` compatibility added (§3.1)**: implementation must preserve this internal attribute since `tests/integration/test_nlp_improvements.py:103-104,571-576` inspects it directly.
+- **Performance claim removed (§6)**: replaced unsupported "≤60µs per call" with "no measurable regression vs baseline benchmark".
+- **Sampling override coherence implemented (§3.2)**: when `server.py:1866-1880` overrides, clear evidence/conflicts and set `preference_source: "sampling"`.
+- **Downstream consumer compatibility (§12, NEW)**: explicit section covering library_recommender, adapter_factory, keyword_executor, browser_plugin, selenium_plugin — five consumers v1 missed.
+- **Migration patterns added (§3.1 Step 5b)**: new `MIGRATION_PATTERNS` constant with `from X to Y` / `switch X to Y` / `instead of X use Y` / `replace X with Y` idioms.
+
+**v1 (2026-05-29)** — initial draft.
+
+---
+
+## 1. Summary
+
+`analyze_scenario` reports `explicit_library_preference: "SeleniumLibrary"` for the scenario *"Test e-commerce website https://demoshop.makrocode.de: open browser, add items to shopping cart, ..."* even though the user never mentioned SeleniumLibrary. Root cause: a single overzealous regex pattern (`\bopen\s+browser\b` weight 6) above the min_score threshold (5) at `src/robotmcp/utils/library_detection.py:33`.
+
+The fix introduces a clean split between **library mention** (broad, advisory) and **library preference** (narrow, decisive), removes keyword-name patterns from the preference scoring, adds a conflict-group threshold (8 for Browser-vs-SL conflicts), and surfaces ambiguity to the caller via two new optional response fields.
+
+This document is the concrete implementation guide that follows the PRD/ADR/DDD design. It includes step-by-step code edits, test fixtures, env-var tunables, and a migration path.
+
+---
+
+## 2. Reproducer
+
+```python
+# CURRENT (broken) behaviour — verified 2026-05-29
+from robotmcp.utils.library_detection import get_library_detector
+detector = get_library_detector()
+scenario = (
+    "Test e-commerce website https://demoshop.makrocode.de: "
+    "open browser, add items to shopping cart, verify items, "
+    "complete checkout, and close browser"
+)
+print(detector.detect(scenario))  # → "SeleniumLibrary" (WRONG)
+print(detector.get_scores(scenario))  # → {"SeleniumLibrary": 6}
+```
+
+The single match comes from `\bopen\s+browser\b` (weight 6, ≥ default min_score 5).
+
+---
+
+## 3. Proposed Code Changes
+
+The changes are scoped to **four files** for the core fix and **one** for the new tests (v3 correction — v2's "three files" missed `server.py`):
+
+| File | Change type | LOC delta (rough) |
+|---|---|---|
+| `src/robotmcp/utils/library_detection.py` | Refactor + new entry point | +150 / −20 |
+| `src/robotmcp/components/nlp_processor.py` | Wire new entry point + surface evidence/conflicts | +30 |
+| `src/robotmcp/models/session_models.py` | Route through new entry point | +5 / −10 |
+| `src/robotmcp/server.py` | Sampling override coherence (both sites: lines 1866-1880 + 1961-1972) | +15 |
+| `tests/unit/test_explicit_library_detection_fix.py` | New test file | +200 |
+
+### 3.1 `library_detection.py` — refactor + annotate
+
+#### Step 1: introduce `PatternRule` and `PatternMatch` dataclasses
+
+`PatternRule` is the new annotated source-of-truth pattern entry. `PatternMatch` is the evidence record returned by the resolver. Both `compiled` and the validation logic are defined upfront (v2 omitted these and downstream code referenced them as if they existed).
+
+```python
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Pattern, Tuple  # v4: Literal added
+
+
+@dataclass(frozen=True)
+class PatternRule:
+    """A single regex pattern that scores toward a library identification."""
+    pattern: str          # raw regex source
+    weight: int           # 1-10 — strength of the signal
+    explicit: bool        # True → contributes to preference; False → mention only
+    rationale: str        # one-line audit comment
+
+    # `compiled` is set in __post_init__ via object.__setattr__ because the
+    # dataclass is frozen. Consumers use rule.compiled.finditer(text), etc.
+    compiled: Pattern = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self):
+        if not (1 <= self.weight <= 10):
+            raise ValueError(f"weight must be 1-10, got {self.weight}")
+        # Fail fast on bad regex AND cache the compiled object
+        object.__setattr__(self, "compiled", re.compile(self.pattern, re.IGNORECASE))
+
+
+@dataclass(frozen=True)
+class PatternMatch:
+    """A single (pattern, span, library) record used as evidence."""
+    library: str          # canonical library name (v3 — per DDD §4.1.2)
+    pattern: str          # regex source (for audit)
+    weight: int
+    text_span: str        # the substring that matched (first occurrence)
+    sentence_index: int = -1  # v4: which sentence the match came from
+                              # (internal — used by _subtract_sentence_score
+                              # for exact-sentence evidence filtering; NOT
+                              # included in to_dict() output)
+
+    def to_dict(self) -> Dict[str, Any]:
+        # v4: sentence_index INTENTIONALLY omitted — internal-only
+        return {
+            "library": self.library,
+            "pattern": self.pattern,
+            "weight": self.weight,
+            "text_span": self.text_span,
+        }
+```
+
+#### Step 2: replace `LIBRARY_PATTERNS` table
+
+Convert each entry to a `PatternRule`. Annotate `explicit` per the ADR-024 §6 table.
+
+Concrete decisions for the patterns currently identified as causing false positives:
+
+v3 NOTE on bare-token preference verbs: Codex correctly flagged that `use browser`, `use database`, `use ssh`, `use requests`, `use xml` are generic English nouns and should NOT be `explicit=True`. v3 keeps brand names (`selenium`, `playwright`, `appium`) inside preference-verb patterns because those tokens are library-specific identifiers, but removes the generic nouns. The bare nouns remain in the mention layer at lower weight.
+
+```python
+'SeleniumLibrary': [
+    # P1 — verbatim library identifiers (explicit)
+    # NOTE: 'selenium' is a brand/library name (not a generic English noun) so it
+    # stays inside the preference-verb pattern.
+    PatternRule(r'\b(use|using|with|via|through|prefer)\s+(selenium|seleniumlibrary|selenium\s*library)\b',
+                10, explicit=True, rationale="preference verb + selenium brand token"),
+    PatternRule(r'\bseleniumlibrary\b', 9, explicit=True, rationale="verbatim library name"),
+    PatternRule(r'\bselenium\b', 6, explicit=True, rationale="standalone selenium mention"),
+    PatternRule(r'\bwebdriver\b', 6, explicit=True, rationale="selenium-specific WebDriver term"),
+    PatternRule(r'\b(chromedriver|geckodriver|edgedriver|safaridriver)\b',
+                7, explicit=True, rationale="selenium drivers"),
+    PatternRule(r'\bselenium\s+grid\b', 8, explicit=True, rationale="selenium-specific tech"),
+    PatternRule(r'\bselenium\s+standalone\b', 7, explicit=True, rationale="selenium-specific tech"),
+    PatternRule(r'\bclassic\s+selenium\b', 7, explicit=True, rationale="selenium-specific phrasing"),
+    PatternRule(r'\bselenium\s+automation\b', 7, explicit=True, rationale="selenium-domain phrasing"),
+    PatternRule(r'\b(selenium\s+(2|3|4)|selenium2library)\b', 8, explicit=True, rationale="selenium version mention"),
+    PatternRule(r'\b(desired\s+capabilities|driver\s+capabilities)\b',
+                7, explicit=True, rationale="selenium Capabilities API"),
+    PatternRule(r'\b(create\s+webdriver|get\s+webelement)\b',
+                8, explicit=True, rationale="selenium keyword names that aren't generic NL"),
+    PatternRule(r'\btest\s+automation\s+with\s+selenium\b',
+                8, explicit=True, rationale="explicit phrasing"),
+    # Mention-only (NOT explicit) — kept for capability suggestion
+    PatternRule(r'\bopen\s+browser\b', 6, explicit=False,
+                rationale="REMOVED from explicit — generic NL verb that overlaps with SL keyword"),
+    PatternRule(r'\b(input\s+text|click\s+element|page\s+should\s+contain)\b',
+                6, explicit=False,
+                rationale="REMOVED from explicit — SL keyword names but also generic NL"),
+    PatternRule(r'\b(implicit|explicit)\s+wait\b',
+                6, explicit=False,
+                rationale="REMOVED from explicit — generic concept across web libraries"),
+],
+'Browser': [
+    # P1 — verbatim. v3: bare 'browser' DROPPED from preference verb (too generic
+    # — could mean a web browser app, not the RF Browser library). Only
+    # library-specific tokens remain.
+    PatternRule(r'\b(use|using|with|via|through|prefer)\s+(playwright|browserlibrary|browser\s*library|rfbrowser|robotframework[- ]browser|playwright[- ]core)\b',
+                10, explicit=True, rationale="preference verb + Browser-specific token (NO bare 'browser')"),
+    PatternRule(r'\bbrowser\s*library\b', 9, explicit=True, rationale="verbatim library name"),
+    PatternRule(r'\bplaywright\b', 9, explicit=True, rationale="verbatim Browser library underlying tech"),
+    PatternRule(r'\b(rfbrowser|robotframework[- ]browser|playwright[- ]core)\b',
+                9, explicit=True, rationale="verbatim package names"),
+    PatternRule(r'\bchromium\b', 9, explicit=True, rationale="v3: weight 9 (Playwright kernel — as specific as 'playwright', aligned with ADR §6)"),
+    PatternRule(r'\bwebkit\b', 9, explicit=True, rationale="v3: weight 9 (Playwright kernel — as specific as 'playwright')"),
+    # Bare 'browser' alone is mention-only (could be SL OR Browser OR generic NL)
+    PatternRule(r'\bbrowser\b', 4, explicit=False,
+                rationale="v3: bare 'browser' is too generic for explicit; kept in mention layer"),
+    # Mention-only — REMOVED from explicit
+    PatternRule(r'\bmodern\s+web\s+testing\b', 7, explicit=False, rationale="marketing copy"),
+    PatternRule(r'\bmodern\s+browser\s+automation\b', 8, explicit=False, rationale="marketing copy"),
+    PatternRule(r'\bcross[- ]browser\s+testing\b', 6, explicit=False, rationale="generic test type"),
+    PatternRule(r'\bnew\s+(browser|page|context)\b', 8, explicit=False,
+                rationale="REMOVED from explicit — Browser keyword names but also generic NL"),
+    PatternRule(r'\bfill\s+(text|secret)\b', 7, explicit=False,
+                rationale="REMOVED from explicit — Browser keyword name but also generic NL"),
+    PatternRule(r'\b(headless\s+browser|headless\s+chromium)\b', 6, explicit=False,
+                rationale="generic test config"),
+    PatternRule(r'\b(shadow\s+dom|web\s+components?)\b', 6, explicit=False,
+                rationale="modern web concept; not Browser-exclusive"),
+    PatternRule(r'\b(SPA|single\s+page\s+app(lication)?)\b', 5, explicit=False,
+                rationale="describes app architecture"),
+    PatternRule(r'\b(e2e|end.to.end)\s+(test|automat)', 5, explicit=False,
+                rationale="generic test type"),
+],
+'RequestsLibrary': [
+    # P1 — verbatim + preference-verb. v3: bare 'requests' DROPPED (Python has a
+    # 'requests' package; users often mean "make HTTP requests" not RequestsLibrary).
+    PatternRule(r'\b(use|using|with|via|through|prefer)\s+(requestslibrary|requests\s*library)\b',
+                10, explicit=True, rationale="preference verb + Requests-specific token (NO bare 'requests')"),
+    PatternRule(r'\brequestslibrary\b', 9, explicit=True, rationale="verbatim library name"),
+    # Bare 'requests' alone is mention-only
+    PatternRule(r'\brequests\b', 4, explicit=False,
+                rationale="v3: bare 'requests' could mean Python requests package or generic HTTP; kept in mention layer"),
+    # RL-specific keyword names with RL-specific session noun
+    PatternRule(r'\b(create\s+session|get\s+on\s+session|post\s+on\s+session)\b',
+                8, explicit=True, rationale="RL keyword names with 'session' qualifier"),
+    PatternRule(r'\b(status\s+should\s+be|request\s+should\s+be)\b',
+                7, explicit=True, rationale="RL-specific keyword phrasing"),
+    PatternRule(r'\b(GET|POST|PUT|DELETE|PATCH)\s+on\s+session\b',
+                7, explicit=True, rationale="HTTP-method + RL 'on session' qualifier — the qualifier makes it RL-specific"),
+    # Mention-only (v2: rest api testing + status code + bare HTTP methods moved from explicit=True)
+    PatternRule(r'\brest\s+api\s+testing\b', 7, explicit=False,
+                rationale="v2: REMOVED from explicit — domain marker, not library identifier"),
+    PatternRule(r'\bapi\s+automation\b', 6, explicit=False,
+                rationale="v2: REMOVED from explicit — domain marker"),
+    PatternRule(r'\bstatus\s+code\b', 5, explicit=False,
+                rationale="v2: REMOVED from explicit — generic HTTP term"),
+    PatternRule(r'\b(GET|POST|PUT|DELETE|PATCH)\s+request\b', 5, explicit=False,
+                rationale="v2: bare HTTP verb + request is domain-generic; only the 'on session' form is RL-specific"),
+    PatternRule(r'\bhttp\s+requests?\b', 5, explicit=False, rationale="generic HTTP term"),
+    PatternRule(r'\b(webservice|web\s+service)\b', 5, explicit=False, rationale="generic"),
+    PatternRule(r'\bmicroservice\b', 5, explicit=False, rationale="generic"),
+    PatternRule(r'\b(bearer\s+token|JWT|OAuth2?)\b', 5, explicit=False, rationale="auth concepts"),
+    PatternRule(r'\b(swagger|openapi)\b', 5, explicit=False, rationale="api-doc tooling"),
+    PatternRule(r'\b(graphql|gRPC|SOAP)\b', 5, explicit=False, rationale="API protocols"),
+    PatternRule(r'\b(webhook|callback\s+url)\b', 5, explicit=False, rationale="generic"),
+],
+'AppiumLibrary': [
+    # P1 — verbatim + preference-verb
+    PatternRule(r'\b(use|using|with|via|through|prefer)\s+(appium|appiumlibrary|appium\s*library)\b',
+                10, explicit=True, rationale="preference verb + Appium token"),
+    PatternRule(r'\bappium(?:library)?\b', 9, explicit=True, rationale="verbatim library / runtime name"),
+    PatternRule(r'\b(UIAutomator2?|XCUITest|Espresso)\b', 7, explicit=True,
+                rationale="Appium-specific runtime (UIAutomator/XCUITest/Espresso are Appium drivers)"),
+    # Mention-only (v2: mobile/android/ios domain markers + app/action verbs moved from explicit=True)
+    PatternRule(r'\bmobile\s+automation\b', 7, explicit=False,
+                rationale="v2: REMOVED from explicit — mobile automation is a domain, could be Appium, Detox, Maestro, etc."),
+    PatternRule(r'\bmobile\s+app\s+testing\b', 7, explicit=False,
+                rationale="v2: REMOVED from explicit — domain marker"),
+    PatternRule(r'\bandroid\s+testing\b', 6, explicit=False,
+                rationale="v2: REMOVED from explicit — platform, not library identifier"),
+    PatternRule(r'\bios\s+testing\b', 6, explicit=False,
+                rationale="v2: REMOVED from explicit — platform, not library identifier"),
+    PatternRule(r'\b(open\s+application|close\s+application)\b', 8, explicit=False,
+                rationale="Appium keyword names but generic NL"),
+    PatternRule(r'\b(tap|swipe|long\s+press|double\s+tap|flick|scroll|pinch)\b', 6, explicit=False,
+                rationale="mobile action verbs"),
+    PatternRule(r'\bdevice\b', 5, explicit=False, rationale="too generic"),
+    PatternRule(r'\b(emulator|simulator)\b', 5, explicit=False, rationale="generic"),
+    PatternRule(r'\b(native\s+app|hybrid\s+app|webview)\b', 6, explicit=False, rationale="generic mobile"),
+    PatternRule(r'\b(APK|IPA|bundle\s+id|package\s+name)\b', 6, explicit=False, rationale="mobile artifacts"),
+    PatternRule(r'\b(device\s+farm|BrowserStack|Sauce\s+Labs)\b', 5, explicit=False, rationale="cloud services"),
+    PatternRule(r'\b(iphone|ipad|tablet|smartphone)\b', 5, explicit=False, rationale="device names"),
+],
+'DatabaseLibrary': [
+    # P1 — verbatim + preference-verb. v3: bare 'database' DROPPED (generic domain noun).
+    PatternRule(r'\b(use|using|with|via|through|prefer)\s+(databaselibrary|database\s*library)\b',
+                10, explicit=True, rationale="preference verb + Database-specific token (NO bare 'database')"),
+    PatternRule(r'\bdatabaselibrary\b', 9, explicit=True, rationale="verbatim library name"),
+    PatternRule(r'\b(connect\s+to\s+database|execute\s+sql|call\s+stored\s+procedure)\b',
+                8, explicit=True, rationale="DatabaseLibrary keyword names"),
+    # Mention-only (v2: SQL fragments + DB engine names moved from explicit=True)
+    PatternRule(r'\b(SELECT|INSERT|UPDATE|DELETE)\s+(FROM|INTO|SET|\*)\b', 5, explicit=False,
+                rationale="v2: REMOVED from explicit — SQL is the user's domain; could be DatabaseLibrary or raw psycopg2-via-Python wrapper"),
+    PatternRule(r'\b(postgres(?:ql)?|mysql|mariadb|sqlite)\b', 5, explicit=False,
+                rationale="v2: REMOVED from explicit — DB engine name, not RF library identifier"),
+    PatternRule(r'\b(oracle|sql\s+server|mssql|mongodb)\b', 5, explicit=False,
+                rationale="v2: REMOVED from explicit — DB engine name, not RF library identifier"),
+    PatternRule(r'\bsql\s+testing\b', 6, explicit=False, rationale="generic SQL test type"),
+    PatternRule(r'\bdatabase\s+validation\b', 6, explicit=False, rationale="generic"),
+    PatternRule(r'\b(row\s+count|check\s+if\s+exists)\b', 7, explicit=False,
+                rationale="DB-keyword names but generic NL"),
+    PatternRule(r'\b(connection\s+string|DSN|ODBC)\b', 5, explicit=False, rationale="generic DB config"),
+    PatternRule(r'\bstored\s+procedure\b', 6, explicit=False, rationale="generic SQL concept"),
+    PatternRule(r'\b(CRUD|schema\s+migration)\b', 5, explicit=False, rationale="generic"),
+],
+'SSHLibrary': [
+    # P1 — verbatim + preference-verb. v3: bare 'ssh' DROPPED (protocol noun;
+    # 'use ssh to deploy' could mean ssh CLI or paramiko).
+    PatternRule(r'\b(use|using|with|via|through|prefer)\s+(sshlibrary|ssh\s*library)\b',
+                10, explicit=True, rationale="preference verb + SSH-specific token (NO bare 'ssh')"),
+    PatternRule(r'\bsshlibrary\b', 9, explicit=True, rationale="verbatim library name"),
+    # SSH-specific keyword names + protocols
+    PatternRule(r'\blogin\s+with\s+public\s+key\b',
+                7, explicit=True, rationale="SSHLibrary-specific keyword name"),
+    PatternRule(r'\b(sftp|scp)\b', 6, explicit=True, rationale="SSH-specific protocols"),
+    # Mention-only (v2: execute command, remote server, ssh into — all moved from True or remain False)
+    PatternRule(r'\bopen\s+connection\b', 7, explicit=False,
+                rationale="v2: REMOVED from explicit — overlaps with Telnet, Database, Browser keyword names"),
+    PatternRule(r'\b(execute\s+command|start\s+command)\b', 6, explicit=False,
+                rationale="generic command-execution terms"),
+    PatternRule(r'\b(get\s+file|put\s+file|get\s+directory|put\s+directory)\b',
+                6, explicit=False, rationale="generic file ops"),
+    PatternRule(r'\bssh\s+(into|to)\b', 6, explicit=False,
+                rationale="v2: action verb, not library identifier — could be sshpass, paramiko-script, etc."),
+    PatternRule(r'\bremote\s+server\s+commands?\b', 5, explicit=False, rationale="generic"),
+    PatternRule(r'\b(remote\s+(server|execution|machine|host))\b', 5, explicit=False, rationale="generic"),
+    PatternRule(r'\b(linux|unix)\s+(server|machine|system)\b', 5, explicit=False, rationale="OS-generic"),
+],
+'XML': [
+    # P1 — verbatim + preference-verb. Bare 'xml' already kept out of preference
+    # (XML is a file format, not a library identifier).
+    PatternRule(r'\b(use|using|with|via|through|prefer)\s+(xmllibrary|xml\s*library)\b',
+                10, explicit=True, rationale="preference verb + XML library-specific token (NO bare 'xml')"),
+    PatternRule(r'\bxmllibrary\b', 9, explicit=True, rationale="verbatim library name"),
+    # Mention-only (v2: parse xml, xml parsing/validation, XSD/XSLT/XPath all moved from True)
+    PatternRule(r'\bxml\s+parsing\b', 6, explicit=False,
+                rationale="v2: REMOVED from explicit — XML parsing is the user's task, not a library choice"),
+    PatternRule(r'\bxml\s+validation\b', 6, explicit=False, rationale="v2: same as above"),
+    PatternRule(r'\b(parse\s+xml|save\s+xml|log\s+element)\b', 7, explicit=False,
+                rationale="v2: XMLLibrary keyword names but also generic NL"),
+    PatternRule(r'\b(xslt|dtd|xsd)\b', 6, explicit=False,
+                rationale="v2: REMOVED from explicit — XML standards, not RF library identifier"),
+    PatternRule(r'\bxpath\s+(expression|query|selector)\b', 6, explicit=False,
+                rationale="v2: REMOVED from explicit — XPath is also used by SeleniumLibrary locators"),
+    PatternRule(r'\b(get\s+element\s+text|get\s+element\s+attribute)\b',
+                6, explicit=False, rationale="overlaps with other libs' keyword names"),
+    PatternRule(r'\b(namespace|element\s+tree|lxml)\b', 5, explicit=False, rationale="generic XML lib terms"),
+    PatternRule(r'\bxml\s+(file|document|response|config)\b', 5, explicit=False, rationale="generic XML mention"),
+    PatternRule(r'\b\bxml\b', 4, explicit=False, rationale="too generic; could mean XML file format"),
+],
+```
+
+#### Step 3: introduce `DetectionPolicy`
+
+```python
+@dataclass(frozen=True)
+class DetectionPolicy:
+    default_min_score: int = 5
+    conflict_min_score: int = 8
+    ambiguity_window: int = 4
+
+    @classmethod
+    def from_env(cls) -> "DetectionPolicy":
+        return cls(
+            default_min_score=int(os.getenv("ROBOTMCP_LIBRARY_DETECTION_MIN_SCORE", "5")),
+            conflict_min_score=int(os.getenv("ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD", "8")),
+            ambiguity_window=int(os.getenv("ROBOTMCP_LIBRARY_DETECTION_AMBIGUITY_WINDOW", "4")),
+        )
+```
+
+#### Step 4: introduce `PreferenceResolution` (v3 — 6 fields, canonical shape)
+
+v2 declared 4 fields (`library`, `evidence`, `conflicts`, `all_scores`) but Step 6's constructor passed 5 positional args plus `source="rule"` named arg — internally inconsistent. v3 uses the canonical 6-field shape from DDD §4.1.6:
+
+```python
+from typing import Literal
+
+@dataclass(frozen=True)
+class PreferenceResolution:
+    """Public output of detect_explicit_preference. v3 canonical shape:
+    6 fields used consistently across all 4 docs."""
+    library: Optional[str]                                # the chosen library, or None
+    source: Literal["rule", "sampling"]                   # provenance
+    evidence: List[Dict[str, Any]]                        # [{library, pattern, weight, text_span}]
+    conflicts: Dict[str, List[Dict[str, Any]]]            # group_name -> [{library, score, patterns_matched}]
+    all_scores: Dict[str, int]                            # full score map (diagnostics)
+    sampling_evidence: Optional[str] = None               # LLM rationale when source=sampling
+
+    @property
+    def is_decisive(self) -> bool:
+        return self.library is not None
+
+    @property
+    def has_conflicts(self) -> bool:
+        return bool(self.conflicts)
+```
+
+Canonical evidence-entry shape (v3 — used consistently in PRD/ADR/DDD/proposal): each evidence entry is `{library: str, pattern: str, weight: int, text_span: str}`. The list is flat (NOT grouped by library); the `library` field on each entry lets consumers filter or group as needed. This shape matches `PatternMatch.to_dict()` from Step 1.
+
+Canonical conflicts-entry shape: each conflict-group value is a list of `{library: str, score: int, patterns_matched: List[str]}`.
+
+#### Step 5: define `NEGATION_PHRASES`, `MIGRATION_PATTERNS`, `_LIBRARY_TOKENS` (v3 — fixed algorithm)
+
+v2 used `\b(?:not|...)\s+(?:using\s+)?(?P<target>\w+)`. Codex ran the Python and showed `target="use"` (not the library) for `"do not use Selenium"`. v3 abandons that approach in favour of a **two-step phrase-then-token-lookup**:
+
+```python
+# v4 — SINGLE regex with alternation, ordered longest-first. The regex engine's
+# left-to-right alternation guarantees the longest negation phrase wins at each
+# position. Each span fires exactly ONCE — no double-deduction.
+#
+# v3 used a Python list of phrases iterated with `for phrase in NEGATION_PHRASES`,
+# which fired both `\bdo\s+not\s+use\b` AND `\bdo\s+not\b` on the same span and
+# called `_subtract_sentence_score` twice. v3 worked by luck because `max(0, …)`
+# clamps at zero; v4 closes that hole.
+_NEGATION_REGEX: Pattern = re.compile(
+    r"\b(?:"
+    # Compound phrases (longest first — regex engine picks the longest match)
+    r"do\s+not\s+use|don't\s+use|"
+    r"not\s+using|without\s+using|stop\s+using|avoid\s+using|"
+    r"skip\s+using|exclude\s+using|"
+    # Simple phrases
+    r"do\s+not|don't|"
+    r"without|stop|avoid|exclude"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# v3 — migration patterns return SOURCE and DESTINATION text spans. Token
+# resolution happens via `_first_library_token_in()` so multi-word forms
+# like "Browser Library" or hyphenated "robotframework-browser" are handled
+# correctly. v2's `\w+` capture broke on hyphens and multi-word names.
+MIGRATION_PATTERNS: List[str] = [
+    r"\bmigrat(?:e|ion|ing)\b.+?\bfrom\b\s+(?P<src>.+?)\s+\bto\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+    r"\bswitch(?:ing)?\s+from\b\s+(?P<src>.+?)\s+\bto\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+    r"\binstead\s+of\b\s+(?P<src>.+?)\s+\b(?:use|with|via)\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+    r"\breplace\b\s+(?P<src>.+?)\s+\b(?:with|by|for)\b\s+(?P<dst>.+?)(?=[\s.,;!?]|$)",
+]
+
+# v3 — Library tokens for negation/migration target resolution.
+# v3 NOTE: this is the canonical map used by `_first_library_token_in()`.
+# Entries deliberately EXCLUDE generic English nouns ('browser', 'database',
+# 'ssh', 'requests', 'xml') because users writing "do not use ssh" usually
+# mean "do not use the SSH protocol" not "do not use SSHLibrary".
+_LIBRARY_TOKENS: Dict[str, List[str]] = {
+    "SeleniumLibrary": [
+        "selenium", "seleniumlibrary", r"selenium\s*library",
+        "selenium2library", "selenium3library",
+        "webdriver", "chromedriver", "geckodriver", "edgedriver", "safaridriver",
+    ],
+    "Browser": [
+        "playwright", "browserlibrary", r"browser\s*library",
+        "rfbrowser", r"robotframework[- ]browser", r"playwright[- ]core",
+        "chromium", "webkit",
+    ],
+    "RequestsLibrary": [
+        "requestslibrary", r"requests\s*library",
+    ],
+    "AppiumLibrary": [
+        "appium", "appiumlibrary", r"appium\s*library",
+    ],
+    "DatabaseLibrary": [
+        "databaselibrary", r"database\s*library",
+    ],
+    "SSHLibrary": [
+        "sshlibrary", r"ssh\s*library",
+    ],
+    "XML": [
+        "xmllibrary", r"xml\s*library",
+    ],
+}
+
+
+def _first_library_token_in(text: str) -> Optional[str]:
+    """Return the canonical library name of the FIRST library token found in
+    `text` (by character position). Returns None if no library token matches.
+    """
+    earliest: Optional[Tuple[str, int]] = None
+    for lib, tokens in _LIBRARY_TOKENS.items():
+        for token in tokens:
+            for m in re.finditer(rf"\b{token}\b", text, re.IGNORECASE):
+                if earliest is None or m.start() < earliest[1]:
+                    earliest = (lib, m.start())
+                break  # first match per token is enough
+    return earliest[0] if earliest else None
+
+
+def _build_sentence_spans(text: str) -> List[Tuple[int, int]]:
+    """v4: split `text` on `_SENTENCE_DELIMITERS` while preserving (start, end)
+    character positions so PatternMatch entries can record the sentence_index
+    they came from. Used by Step 1 + Step 2 of `detect_explicit_preference`.
+    """
+    spans: List[Tuple[int, int]] = []
+    pos = 0
+    delim_re = re.compile(_SENTENCE_DELIMITERS)
+    for m in delim_re.finditer(text):
+        if pos < m.start():
+            spans.append((pos, m.start()))
+        pos = m.end()
+    if pos < len(text):
+        spans.append((pos, len(text)))
+    return spans
+```
+
+#### Step 6: add `LibraryDetector.detect_explicit_preference` (v3 algorithm)
+
+```python
+from collections import defaultdict
+
+CONFLICT_GROUPS: Dict[str, Tuple[str, ...]] = {
+    "web_automation": ("Browser", "SeleniumLibrary"),
+}
+
+# v7 (IMPLEMENTED) — sentence punctuation OR paragraph break (2+ newlines).
+# Lineage:
+#   v3-v5: r"[.;!?,\n]+"      — single newline as boundary; orphaned negation
+#                               when target was on the next line
+#   v6:    r"[.;!?,]+"        — dropped \n; broke paragraph-separated text
+#                               (negation leaked across paragraphs)
+#   v7:    r"[.;!?,]+|\n\s*\n+" — single newline NOT a boundary (negation
+#                                  reaches across-line target); paragraph
+#                                  break IS a boundary (separates ideas)
+_SENTENCE_DELIMITERS = r"[.;!?,]+|\n\s*\n+"
+
+
+def detect_explicit_preference(
+    self,
+    text: str,
+    policy: Optional[DetectionPolicy] = None,
+) -> PreferenceResolution:
+    """Decisive library preference. v3 algorithm:
+      Step 1: compute raw explicit scores + collect matches
+      Step 2: sentence-scoped negation + migration (v3 phrase-based)
+      Step 3: conflict check on RAW scores BEFORE threshold filter
+      Step 4: threshold filter (post-conflict)
+      Step 5: pick winner
+    """
+    policy = policy or DetectionPolicy.from_env()
+    if not text:
+        return PreferenceResolution(
+            library=None, source="rule", evidence=[], conflicts={},
+            all_scores={}, sampling_evidence=None,
+        )
+
+    # === Step 1: compute raw explicit scores + collect matches ===
+    # v4: build sentence spans FIRST so each PatternMatch can record its
+    # source sentence_index for D7-safe evidence filtering.
+    sentence_spans = _build_sentence_spans(text)  # List[Tuple[int, int]]
+
+    def _sentence_index_for(pos: int) -> int:
+        for i, (start, end) in enumerate(sentence_spans):
+            if start <= pos < end:
+                return i
+        return -1
+
+    raw_scores: Dict[str, int] = defaultdict(int)
+    matches_by_lib: Dict[str, List[PatternMatch]] = defaultdict(list)
+    for lib, rules in self.LIBRARY_RULES.items():
+        for rule in rules:
+            if not rule.explicit:
+                continue
+            for m in rule.compiled.finditer(text):
+                raw_scores[lib] += rule.weight
+                if len(matches_by_lib[lib]) < 8:  # cap evidence
+                    matches_by_lib[lib].append(PatternMatch(
+                        library=lib,
+                        pattern=rule.pattern,
+                        weight=rule.weight,
+                        text_span=m.group(0),
+                        sentence_index=_sentence_index_for(m.start()),
+                    ))
+
+    # === Step 2: sentence-scoped negation + migration (v4) ===
+    # v4: reuse sentence_spans from Step 1 so the sentence_index threaded
+    # through _subtract_sentence_score matches the index recorded on each
+    # PatternMatch. Skip empty/whitespace-only sentences.
+    for sentence_index, (start, end) in enumerate(sentence_spans):
+        sent = text[start:end]
+        if not sent.strip():
+            continue
+
+        # 2a. Migration patterns (source-vs-destination)
+        # v3/v4: source and destination identified via _first_library_token_in()
+        # on the matched text spans, not by raw \w+ capture. Handles multi-word
+        # names like "Browser Library" and hyphenated forms.
+        #
+        # v4 KNOWN LIMITATION: "Migrate from X to Browser library" silently
+        # no-ops on the destination because _LIBRARY_TOKENS deliberately
+        # excludes bare `browser`. This is an intentional consequence of the
+        # bare-noun fix from v3 — `browser` alone is too generic for explicit
+        # detection. Workaround: phrase as "to playwright" or "to browserlibrary".
+        for pattern_src in MIGRATION_PATTERNS:
+            for m in re.finditer(pattern_src, sent, re.IGNORECASE):
+                src_lib = _first_library_token_in(m.group("src"))
+                dst_lib = _first_library_token_in(m.group("dst"))
+                if src_lib:
+                    self._subtract_sentence_score(
+                        raw_scores, matches_by_lib, sent, sentence_index, src_lib
+                    )
+                if dst_lib:
+                    raw_scores[dst_lib] += 5  # destination bonus
+
+        # 2b. Single-library negation — SINGLE ALTERNATION REGEX (v4)
+        # v4 algorithm:
+        #   1. Single regex `_NEGATION_REGEX` matches negation phrases
+        #      (longest-first alternation guarantees each span fires once)
+        #   2. For each non-overlapping match, look in the rest of the sentence
+        #   3. Identify the first library token in that suffix
+        #   4. Subtract that library's contribution from raw_scores
+        for m in _NEGATION_REGEX.finditer(sent):
+            remaining = sent[m.end():]
+            target_lib = _first_library_token_in(remaining)
+            if target_lib:
+                self._subtract_sentence_score(
+                    raw_scores, matches_by_lib, sent, sentence_index, target_lib
+                )
+
+    # === Step 3: CONFLICT CHECK ON RAW SCORES (BEFORE threshold filter) ===
+    conflicts: Dict[str, List[Dict[str, Any]]] = {}
+    for group_name, members in CONFLICT_GROUPS.items():
+        libs_with_signal = [lib for lib in members if raw_scores.get(lib, 0) > 0]
+        if len(libs_with_signal) < 2:
+            continue
+        ranked = sorted(libs_with_signal, key=lambda l: raw_scores[l], reverse=True)
+        if raw_scores[ranked[0]] - raw_scores[ranked[1]] <= policy.ambiguity_window:
+            conflicts[group_name] = [
+                {
+                    "library": lib,
+                    "score": raw_scores[lib],
+                    "patterns_matched": [pm.pattern for pm in matches_by_lib[lib]],
+                }
+                for lib in ranked
+            ]
+
+    if conflicts:
+        return PreferenceResolution(
+            library=None, source="rule", evidence=[], conflicts=conflicts,
+            all_scores=dict(raw_scores), sampling_evidence=None,
+        )
+
+    # === Step 4: threshold filter (post-conflict) ===
+    candidates: Dict[str, int] = {}
+    for lib, score in raw_scores.items():
+        threshold = (policy.conflict_min_score
+                     if self._in_conflict_group(lib)
+                     else policy.default_min_score)
+        if score >= threshold:
+            candidates[lib] = score
+
+    if not candidates:
+        return PreferenceResolution(
+            library=None, source="rule", evidence=[], conflicts={},
+            all_scores=dict(raw_scores), sampling_evidence=None,
+        )
+
+    # === Step 5: pick winner ===
+    winner = max(candidates, key=candidates.get)
+    return PreferenceResolution(
+        library=winner, source="rule",
+        evidence=[pm.to_dict() for pm in matches_by_lib[winner]],
+        conflicts={}, all_scores=dict(raw_scores), sampling_evidence=None,
+    )
+
+
+def _in_conflict_group(self, library: str) -> bool:
+    return any(library in members for members in CONFLICT_GROUPS.values())
+
+
+def _subtract_sentence_score(
+    self,
+    raw_scores: Dict[str, int],
+    matches_by_lib: Dict[str, List[PatternMatch]],
+    sentence: str,
+    sentence_index: int,
+    library: str,
+) -> None:
+    """Subtract all explicit-pattern contributions for `library` that match
+    `sentence`. Also strip evidence that came FROM the negated sentence by
+    matching on `sentence_index`, not substring inclusion.
+
+    v4 (D7 fix): v3 used `pm.text_span.lower() not in sentence.lower()`
+    which could corrupt evidence from sibling sentences containing the same
+    library token. v4 filters by exact sentence membership via the
+    `sentence_index` field set on PatternMatch at scoring time.
+    """
+    deduction = 0
+    for rule in self.LIBRARY_RULES.get(library, []):
+        if not rule.explicit:
+            continue
+        if rule.compiled.search(sentence):
+            deduction += rule.weight
+    if deduction:
+        raw_scores[library] = max(0, raw_scores[library] - deduction)
+        # v4: exact-sentence filtering — only drops evidence from THIS sentence
+        matches_by_lib[library] = [
+            pm for pm in matches_by_lib[library]
+            if pm.sentence_index != sentence_index
+        ]
+```
+
+**v3 walkthrough: `"do not use Selenium, instead use Playwright"`** (the scenario v2 broke):
+
+Step 1 — raw scores across full text:
+- `\b(use|using|...)\s+selenium\b` → SL +10
+- `\bselenium\b` → SL +6
+- `\b(use|using|...)\s+playwright\b` → Browser +10
+- `\bplaywright\b` → Browser +9
+- Result: `raw_scores = {SL: 16, Browser: 19}`
+
+Step 2 — sentences after splitting on `[.;!?,\n]+`:
+- Sentence 1: `"do not use Selenium"`
+- Sentence 2: `" instead use Playwright"`
+
+Sentence 1 processing:
+- 2a Migration: no migration phrase fires
+- 2b Negation: `\bdo\s+not\s+use\b` matches at position 0-11
+  - `remaining = " Selenium"`
+  - `_first_library_token_in(" Selenium")` → `SeleniumLibrary`
+  - `_subtract_sentence_score(SL, sentence="do not use Selenium")`
+  - SL patterns matching this sentence: `\b(use...)\s+selenium\b` (+10) and `\bselenium\b` (+6) → deduction = 16
+  - SL: 16 − 16 = 0
+
+Sentence 2 processing:
+- 2a Migration: no phrase fires (no "from X to Y" / "instead of X" / "switch from X" / "replace X with")
+  - Note: "instead use" is NOT "instead OF X use Y" — migration regex correctly doesn't match.
+- 2b Negation: no negation phrase fires (sentence 2 has no negation words)
+- Browser score unchanged at 19
+
+Step 3 — conflict check:
+- `libs_with_signal = ["Browser"]` (SL=0 excluded)
+- Only one library → no conflict
+
+Step 4 — threshold filter:
+- Browser=19 ≥ conflict_min_score=8 → candidate
+
+Step 5 — winner: **Browser** ✓ (matches documented expected outcome)
+
+**v3 walkthrough: `"Migrate the test suite from Selenium to Playwright"`**:
+
+Step 1 — raw scores:
+- `\bselenium\b` → SL +6
+- `\bplaywright\b` → Browser +9
+- Result: `raw_scores = {SL: 6, Browser: 9}`
+
+Step 2 — single sentence (no comma/period):
+- 2a Migration: `\bmigrat...from\s+(?P<src>.+?)\s+to\s+(?P<dst>.+?)(?=[\s.,;!?]|$)` matches
+  - `src = "Selenium"`, `dst = "Playwright"`
+  - `_first_library_token_in("Selenium")` → `SeleniumLibrary`
+  - `_first_library_token_in("Playwright")` → `Browser`
+  - Subtract SL contributions in sentence (deduction = 6) → SL: 0
+  - Browser bonus +5 → Browser: 14
+- 2b Negation: no negation phrase
+
+Step 3 — only Browser has signal → no conflict
+Step 4 — Browser=14 ≥ 8 → candidate
+Step 5 — winner: **Browser** ✓
+
+**v3 walkthrough: `"Test both selenium and playwright sites and compare"`** (the AC-5 conflict case):
+
+Step 1 — raw scores: SL=6, Browser=9
+Step 2 — no migration or negation fires
+Step 3 — conflict check: both > 0, diff=3 ≤ 4 → **conflict fires** → returns None + conflicts ✓
+
+**v3 algorithm verified empirically (2026-05-29)**: a Python simulation of the v3 algorithm (NEGATION_PHRASES + MIGRATION_PATTERNS + `_first_library_token_in` + sentence delimiter `[.;!?,\n]+`) was run against all six PRD acceptance scenarios and produced the documented outcomes:
+
+```
+"do not use Selenium, instead use Playwright"      → Browser            ✓
+"Migrate the test suite from Selenium to Playwright" → Browser           ✓
+"Test both selenium and playwright sites and compare" → None + conflict ✓
+"Use playwright to test demoshop"                  → Browser            ✓
+"Test e-commerce site: open browser, add items..." → None               ✓
+"Run a Selenium test"                              → None (SL=6 < 8)    ✓
+```
+
+Initial raw scores for the first case: `{SL: 16, Browser: 19}` (the v2 problem); after v3 sentence-scoped negation the SL contributions in the first clause are subtracted: `{SL: 0, Browser: 19}` → Browser wins. This is the specific scenario v2 broke and v3 fixes.
+
+#### Step 7: preserve `_compiled_patterns` test-surface compatibility (v3 — real contract)
+
+**v2 was wrong.** v2 proposed `__iter__` yielding 4 values; Codex showed the real tests at `tests/integration/test_nlp_improvements.py:569-576` do:
+
+```python
+raw_browser = any(
+    p.findall("migrate from selenium to browser library for modern testing")
+    for p, _ in library_detector._compiled_patterns.get("Browser", [])
+)
+```
+
+The test:
+1. Destructures with `for p, _ in ...` — requires **exactly 2 items per entry**. `__iter__` yielding 4 would raise `ValueError: too many values to unpack`.
+2. Calls `p.findall(...)` — `p` MUST be a compiled regex (`re.Pattern`), not a `PatternRule`.
+
+v3 honours both requirements by keeping `_compiled_patterns` EXACTLY as today (`Dict[str, List[Tuple[Pattern, int]]]`) and storing the rich annotations in a parallel `_rules_metadata` attribute:
+
+```python
+# v4: LIBRARY_RULES_DEFAULT is the module-level constant carrying the v4
+# pattern table from Step 2. Declared here so LibraryDetector.__init__ can
+# reference it. v3 used the name without declaring it.
+LIBRARY_RULES_DEFAULT: Dict[str, List[PatternRule]] = {
+    "SeleniumLibrary": [...],   # the Step 2 table
+    "Browser":         [...],
+    "RequestsLibrary": [...],
+    "AppiumLibrary":   [...],
+    "DatabaseLibrary": [...],
+    "SSHLibrary":      [...],
+    "XML":             [...],
+}
+
+
+class LibraryDetector:
+    """Singleton. Holds two parallel pattern stores:
+      - _compiled_patterns: legacy (Pattern, int) tuples for test-fixture compat
+      - _rules_metadata:    rich PatternRule entries used by the new
+                             detect_explicit_preference() path
+    """
+
+    LIBRARY_RULES: Dict[str, List[PatternRule]]   # source of truth
+    # v4: NEGATION_PHRASES replaced by _NEGATION_REGEX (single alternation)
+
+    def __init__(
+        self,
+        rules: Optional[Dict[str, List[PatternRule]]] = None,
+        policy: Optional[DetectionPolicy] = None,
+    ):
+        self.LIBRARY_RULES = rules if rules is not None else LIBRARY_RULES_DEFAULT
+        self.policy = policy or DetectionPolicy.from_env()
+
+        # v3: TWO parallel stores.
+        # _compiled_patterns: legacy 2-tuple shape — preserves the test
+        # contract verified at test_nlp_improvements.py:569-576 where the
+        # fixture does `for p, _ in entries: p.findall(...)`. p MUST be a
+        # compiled re.Pattern (NOT PatternRule).
+        self._compiled_patterns: Dict[str, List[Tuple[Pattern, int]]] = {
+            lib: [(rule.compiled, rule.weight) for rule in rules_list]
+            for lib, rules_list in self.LIBRARY_RULES.items()
+        }
+        # _rules_metadata: rich PatternRule entries used by the new explicit-
+        # preference path. Keyed by library, same ordering as _compiled_patterns
+        # so the i-th tuple in _compiled_patterns corresponds to the i-th
+        # PatternRule in _rules_metadata. New code uses this; existing tests
+        # use _compiled_patterns.
+        self._rules_metadata: Dict[str, List[PatternRule]] = {
+            lib: list(rules_list)
+            for lib, rules_list in self.LIBRARY_RULES.items()
+        }
+```
+
+Critically, `PatternRule` does NOT need an `__iter__` — the legacy tests never see `PatternRule` objects. They only ever read `_compiled_patterns`, which is plain `(Pattern, int)` tuples. The new code paths (`detect_explicit_preference`, `_subtract_sentence_score`, etc.) read `LIBRARY_RULES` or `_rules_metadata` directly to get the `explicit` and `rationale` fields.
+
+This is the minimal, contract-faithful approach. No backward-compat shims, no surprising iteration behaviour.
+
+#### Step 6: keep back-compat `detect()` method
+
+```python
+def detect(self, text: str, min_score: int = None) -> Optional[str]:
+    """Backwards-compatible wrapper. Returns the detected library or None.
+
+    Prefer ``detect_explicit_preference`` for new code — it returns the
+    full PreferenceResolution including evidence and conflicts.
+    """
+    policy = DetectionPolicy.from_env()
+    if min_score is not None:
+        policy = dataclasses.replace(policy, default_min_score=min_score)
+    return self.detect_explicit_preference(text, policy).library
+```
+
+### 3.2 `nlp_processor.py` — wire new entry point
+
+**Class name fix**: the actual class at `nlp_processor.py:31` is `NaturalLanguageProcessor`, NOT `NLPProcessor` (v1 used the wrong name).
+
+Update `NaturalLanguageProcessor._detect_explicit_library_preference` and `analyze_scenario`:
+
+```python
+# v5 IMPLEMENTED (race-free — no self._last_resolution stash on the
+# module-level NaturalLanguageProcessor singleton). Caller passes the
+# resolution through as a local variable.
+def _resolve_explicit_library_preference(
+    self, scenario_text: str
+):
+    """Return the full PreferenceResolution (library + evidence + conflicts
+    + provenance). Returns None on ImportError fallback."""
+    if not scenario_text:
+        return None
+    try:
+        from robotmcp.utils.library_detection import get_library_detector
+        return get_library_detector().detect_explicit_preference(scenario_text)
+    except ImportError:
+        return None
+
+
+def _detect_explicit_library_preference(
+    self, scenario_text: str
+) -> Optional[str]:
+    """Back-compat shim used by existing tests; returns just the library name."""
+    resolution = self._resolve_explicit_library_preference(scenario_text)
+    if resolution and resolution.library:
+        return resolution.library
+    return self._fallback_detect_library_preference(scenario_text)
+```
+
+And in `analyze_scenario` (in the analysis-block builder), the resolution is
+threaded through as a local — NOT stashed on `self`:
+
+```python
+# v5: race-free — resolution is a local variable scoped to one analyze_scenario
+# call. Stashing `self._last_resolution` on the module-level singleton would
+# corrupt under concurrent requests; v5 deliberately avoids that pattern.
+resolution = self._resolve_explicit_library_preference(normalized_scenario)
+explicit_library_preference = resolution.library if resolution else None
+
+analysis_block = self._build_analysis_block(
+    actions=actions,
+    required_capabilities=required_capabilities,
+    explicit_library_preference=explicit_library_preference,
+    resolution=resolution,
+    session_type=session_type,
+)
+```
+
+Inside `_build_analysis_block`:
+
+```python
+analysis_block = {
+    "action_count": len(actions),
+    "complexity": self._assess_complexity(actions),
+    "estimated_steps": len(actions) * 2,
+    "suggested_libraries": required_capabilities,  # NOTE: from _determine_capabilities, NOT LibraryDetector
+    "explicit_library_preference": explicit_library_preference,
+    "preference_source": "rule",  # v2: provenance field; sampling override may overwrite to "sampling"
+    "detected_session_type": session_type,
+}
+# Add evidence / conflicts when present (additive — empty fields omitted)
+if resolution is not None:
+    if resolution.evidence:
+        analysis_block["explicit_library_evidence"] = list(resolution.evidence)
+    if resolution.conflicts:
+        # v5 (D3 fix): PreferenceResolution.conflicts entries are ALREADY
+        # dicts with {library, score, patterns_matched} keys. v4 had a
+        # tuple-unpacking emit `for lib, score, patterns in conflict_list`
+        # which was incompatible with the dict-shaped resolution. v5 passes
+        # the dict entries through unchanged.
+        analysis_block["library_preference_conflicts"] = {
+            group: list(entries) for group, entries in resolution.conflicts.items()
+        }
+```
+
+#### 3.2.1 Sampling override coherence (v3 — both override sites + correct env var)
+
+v2 mentioned only `server.py:1866-1880`. v3 covers BOTH override sites (Codex found the second one):
+
+**Site A — analyze_scenario response override** (`server.py:1860-1881`):
+Modifies `analysis["explicit_library_preference"]` returned to the MCP caller.
+
+**Site B — session aggregate override** (`server.py:1961-1972`):
+Modifies `session.explicit_library_preference` on the `ExecutionSession` instance.
+
+Both are gated by `is_sampling_enabled()` which reads the **`ROBOTMCP_USE_SAMPLING`** env var at `sampling.py:23` (v2 wrongly wrote `ROBOTMCP_USE_SAMPLING_FOR_NLP`).
+
+```python
+# Site A — server.py:1860-1881 patch (v5 IMPLEMENTED)
+# v5 (Codex round-4 finding): drop the `primary_library` fallback.
+# `primary_library` is the LLM's "main detected library" (a recommendation,
+# not a user-stated preference). Only `library_preference` semantically maps
+# to `explicit_library_preference`. Mixing the two corrupted the meaning of
+# the field under sampling.
+if sampling_result.get("library_preference"):
+    analysis["explicit_library_preference"] = sampling_result["library_preference"]
+    # provenance + clear rule-based evidence/conflicts (per ADR-024 §11)
+    analysis["preference_source"] = "sampling"
+    analysis.pop("explicit_library_evidence", None)
+    analysis.pop("library_preference_conflicts", None)
+    if "rationale" in sampling_result:
+        analysis["sampling_evidence"] = sampling_result["rationale"]
+# else: preference_source stays "rule" from the analysis_block builder above
+```
+
+```python
+# Site B — server.py:1961-1972 patch (NEW in v3)
+llm_lib_pref = await sample_detect_library_preference(ctx, scenario)
+if llm_lib_pref:
+    session.explicit_library_preference = llm_lib_pref
+    # v3: provenance marker on the session so downstream consumers (e.g.,
+    # _filter_keywords_by_session_library) can tell rule-based from sampling.
+    session.preference_source = "sampling"   # NEW attribute on ExecutionSession
+    logger.info(f"LLM sampling detected library preference: {llm_lib_pref}")
+```
+
+Session-aggregate evidence is NOT populated under sampling (the sampling result returns a string, not a structured evidence list). Consumers that need evidence should read it from the analyze_scenario response (Site A) not the session aggregate.
+
+### 3.3 `session_models.py` — single source of truth (v4: + `preference_source` field)
+
+**v4 (D4 fix)**: v3 wrote `session.preference_source = "sampling"` in the sampling override block (§3.2.1 Site B) but never declared the attribute on `ExecutionSession`. v4 adds the field explicitly:
+
+```python
+# In session_models.py — ExecutionSession dataclass (existing class, add field):
+@dataclass
+class ExecutionSession:
+    # ... existing fields ...
+    explicit_library_preference: Optional[str] = None
+    preference_source: Optional[str] = "rule"  # v4: NEW — "rule" | "sampling"
+    # ... existing fields ...
+```
+
+Default `"rule"` because the rule-based detector is always the initial path; sampling overrides set this to `"sampling"` per §3.2.1 Site B. Downstream consumers (the 8 listed in PRD §2) can read `session.preference_source` to distinguish rule-based vs LLM-driven preferences when needed.
+
+Update `ExecutionSession.detect_explicit_library_preference`:
+
+```python
+def detect_explicit_library_preference(self, scenario_text: str) -> Optional[str]:
+    """Detect explicit library preference using LibraryDetector (single source of truth).
+    Sets `self.preference_source = "rule"` (default) — sampling override path
+    is handled separately in server.py:1961-1972 per §3.2.1 Site B.
+    """
+    if not scenario_text:
+        return None
+    try:
+        from robotmcp.utils.library_detection import get_library_detector
+        resolution = get_library_detector().detect_explicit_preference(scenario_text)
+        self.preference_source = "rule"  # v4: explicit provenance
+        return resolution.library
+    except ImportError:
+        return self._fallback_detect_library(scenario_text)
+```
+
+The `_fallback_detect_library` private method stays as the import-failure backup but is no longer the primary path.
+
+### 3.4 New test file
+
+`tests/unit/test_explicit_library_detection_fix.py` covers PRD AC-1 through AC-7 + negation + migration + sampling override coherence = **10 new tests** (v2 reconciled the v1 count from 25/30 down to the PRD AC-8 target). Tests are parametrised where it reduces duplication; the count is of distinct ACs covered, with parametrisation expanding to ~30 individual test invocations.
+
+```python
+import os
+from unittest.mock import patch
+
+import pytest
+
+from robotmcp.utils.library_detection import (
+    DetectionPolicy,
+    LibraryDetector,
+    PreferenceResolution,
+    get_library_detector,
+)
+
+
+class TestReportedReproducer:
+    """The exact scenario from the user report."""
+
+    def test_demoshop_open_browser_no_explicit(self):
+        d = get_library_detector()
+        scenario = (
+            "Test e-commerce website https://demoshop.makrocode.de: "
+            "open browser, add items to shopping cart, verify items, "
+            "complete checkout, and close browser"
+        )
+        r = d.detect_explicit_preference(scenario)
+        assert r.library is None, (
+            f"'open browser' is generic NL and must NOT trigger explicit "
+            f"SL preference. Got {r.library} from {r.evidence}"
+        )
+
+    def test_demoshop_evidence_empty(self):
+        d = get_library_detector()
+        scenario = (
+            "Test e-commerce website https://demoshop.makrocode.de: "
+            "open browser, add items to shopping cart, verify items"
+        )
+        r = d.detect_explicit_preference(scenario)
+        assert r.evidence == []
+
+
+class TestGenericNLPhrasesDoNotTrigger:
+    """Pure NL phrases that overlap with keyword names must NOT
+    fire explicit preference."""
+
+    @pytest.mark.parametrize("scenario", [
+        "click element by id submit",
+        "Page should contain Welcome text",
+        "Input text into the username field",
+        "Open new page in browser context",
+        "Test the checkout flow on an SPA",
+        "Tap the menu button on the home screen",
+    ])
+    def test_generic_nl_no_explicit(self, scenario):
+        d = get_library_detector()
+        r = d.detect_explicit_preference(scenario)
+        assert r.library is None, (
+            f"NL phrase {scenario!r} should NOT trigger explicit detection; "
+            f"got {r.library}"
+        )
+
+
+class TestTrulyExplicitDetected:
+    @pytest.mark.parametrize("scenario,expected", [
+        ("Use playwright to test the checkout flow", "Browser"),
+        ("Use Selenium to test the login form", "SeleniumLibrary"),
+        ("with SeleniumLibrary, open the page", "SeleniumLibrary"),
+        ("Test using browserlibrary against demoshop", "Browser"),
+        ("Use requestslibrary to call /api/users", "RequestsLibrary"),
+        ("With AppiumLibrary, open the mobile app", "AppiumLibrary"),
+        ("Use database library to validate the inventory table", "DatabaseLibrary"),
+        ("Use ssh library to deploy", "SSHLibrary"),
+        ("Use XML library to validate the response", "XML"),
+        ("Run Selenium 4 against the site", "SeleniumLibrary"),
+        ("chromedriver and the chromedriver path", "SeleniumLibrary"),
+        ("Test using chromium and webkit", "Browser"),
+    ])
+    def test_explicit_detected(self, scenario, expected):
+        d = get_library_detector()
+        r = d.detect_explicit_preference(scenario)
+        assert r.library == expected, (
+            f"{scenario!r}: expected {expected}, got {r.library}"
+        )
+
+    def test_evidence_populated_when_detected(self):
+        d = get_library_detector()
+        r = d.detect_explicit_preference("Use playwright to test")
+        assert r.evidence, "evidence must be populated when library detected"
+        assert any("playwright" in e["pattern"] for e in r.evidence)
+
+
+class TestConflicts:
+    """Within-conflict-group ambiguity returns None + surfaces conflict.
+    v2: tests verify the RAW-SCORE-BEFORE-THRESHOLD ordering (without it
+    the SL=6 / Browser=9 pair would be filtered before the conflict check)."""
+
+    def test_both_selenium_and_playwright_returns_none_with_conflict(self):
+        d = get_library_detector()
+        # Selenium raw = 6 (\bselenium\b), Browser raw = 9 (\bplaywright\b).
+        # Both > 0, |9 - 6| = 3 <= ambiguity_window (4) → conflict.
+        # v1 algorithm: SL=6 filtered before conflict check (threshold 8) →
+        # Browser sole survivor → no conflict → Browser wrongly returned.
+        # v2 algorithm: conflict check on RAW scores → None + conflicts.
+        r = d.detect_explicit_preference(
+            "Test both selenium and playwright sites and compare"
+        )
+        assert r.library is None, (
+            f"Conflict-on-raw-scores must detect this case; got {r.library}"
+        )
+        assert "web_automation" in r.conflicts
+        # v4 (D3 fix): conflicts entries are dicts, not tuples — extract via key
+        libs = {entry["library"] for entry in r.conflicts["web_automation"]}
+        assert libs == {"Browser", "SeleniumLibrary"}
+
+    def test_migration_resolves_to_destination(self):
+        """v2: PRD AC-4 — migration patterns subtract source, add to destination."""
+        d = get_library_detector()
+        r = d.detect_explicit_preference(
+            "Migrate the test suite from Selenium to Playwright"
+        )
+        assert r.library == "Browser", (
+            "'migrate ... from Selenium to Playwright' should resolve to "
+            f"Browser; got {r.library}"
+        )
+        # No conflict — Selenium was negated; only Browser above threshold
+        assert "web_automation" not in r.conflicts
+
+    def test_negation_across_sentences(self):
+        """v2: sentence-scoped negation should NOT zero both libs in
+        'do not use Selenium, instead use Playwright'."""
+        d = get_library_detector()
+        r = d.detect_explicit_preference(
+            "do not use Selenium, instead use Playwright"
+        )
+        # Sentence 1: negation hits Selenium. Sentence 2: positive Playwright.
+        # Result: Browser wins.
+        assert r.library == "Browser", (
+            f"Sentence-scoped negation should leave Browser intact; got {r.library}"
+        )
+
+
+class TestThresholdsTunable:
+    def test_default_min_score_5_for_non_conflict(self):
+        d = get_library_detector()
+        # A library outside the web_automation conflict group with a
+        # single weight-6 hit should still trigger (XML doesn't conflict
+        # with any other library in current setup)
+        r = d.detect_explicit_preference("xml parsing of the response")
+        assert r.library == "XML"
+
+    def test_conflict_threshold_8_blocks_single_weight_6(self):
+        d = get_library_detector()
+        # Just "selenium" alone is weight 6 → in conflict group → blocked
+        r = d.detect_explicit_preference("Run a Selenium test")
+        # Weight 6 < conflict_min_score 8 → None
+        assert r.library is None
+
+    def test_conflict_threshold_8_passes_weight_9(self):
+        d = get_library_detector()
+        # "playwright" is weight 9 → passes conflict threshold
+        r = d.detect_explicit_preference("Run a playwright test")
+        assert r.library == "Browser"
+
+    def test_env_var_lowers_threshold(self, monkeypatch):
+        monkeypatch.setenv("ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD", "5")
+        # Need a fresh policy / detector since policy is read at call time
+        d = LibraryDetector()
+        r = d.detect_explicit_preference("Run a Selenium test")
+        assert r.library == "SeleniumLibrary"
+
+
+class TestBackwardsCompatibility:
+    """Existing detect() / detect_all() entry points keep working."""
+
+    def test_detect_returns_string_or_none(self):
+        d = get_library_detector()
+        assert d.detect("use playwright") == "Browser"
+        assert d.detect("xyz") is None
+
+    def test_get_scores_unchanged_for_mention_layer(self):
+        d = get_library_detector()
+        scores = d.get_scores("open browser")
+        # Mention layer keeps the 'open browser' pattern at weight 6
+        # for SeleniumLibrary (used for suggested_libraries advisory)
+        assert scores.get("SeleniumLibrary", 0) >= 6
+
+
+class TestEvidenceShape:
+    def test_evidence_includes_pattern_and_text_span(self):
+        d = get_library_detector()
+        r = d.detect_explicit_preference("Use playwright for the demoshop test")
+        assert r.evidence
+        first = r.evidence[0]
+        assert "pattern" in first
+        assert "text_span" in first
+        assert "weight" in first
+        assert "playwright" in first["text_span"].lower()
+
+
+class TestAnalyzeScenarioResponse:
+    """End-to-end via the MCP wrapper — fields surface correctly.
+    v2: class name fix — NaturalLanguageProcessor (not NLPProcessor)."""
+
+    @pytest.mark.asyncio
+    async def test_response_omits_evidence_when_no_detection(self):
+        from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+        nlp = NaturalLanguageProcessor()
+        result = await nlp.analyze_scenario(
+            "Test e-commerce website https://demoshop.makrocode.de: "
+            "open browser, add items, complete checkout",
+            context="web",
+        )
+        analysis = result["analysis"]
+        assert analysis["explicit_library_preference"] is None
+        assert analysis["preference_source"] == "rule"  # v2 field
+        # Evidence/conflicts ABSENT (not present-but-empty)
+        assert "explicit_library_evidence" not in analysis
+        assert "library_preference_conflicts" not in analysis
+
+    @pytest.mark.asyncio
+    async def test_response_includes_evidence_on_explicit_detection(self):
+        from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+        nlp = NaturalLanguageProcessor()
+        result = await nlp.analyze_scenario(
+            "Use playwright to test the demoshop checkout flow",
+            context="web",
+        )
+        analysis = result["analysis"]
+        assert analysis["explicit_library_preference"] == "Browser"
+        assert analysis["preference_source"] == "rule"  # v2 field
+        assert "explicit_library_evidence" in analysis
+        assert any("playwright" in e["text_span"].lower()
+                   for e in analysis["explicit_library_evidence"])
+
+
+class TestSamplingOverrideCoherence:
+    """v3: when sampling overrides preference, evidence/conflicts are cleared
+    and preference_source is 'sampling'. Uses correct env var ROBOTMCP_USE_SAMPLING."""
+
+    @pytest.mark.asyncio
+    async def test_sampling_clears_rule_evidence(self, monkeypatch):
+        # Mock the sampling path to return a library decision
+        async def fake_sampling(*args, **kwargs):
+            return {
+                "library_preference": "SeleniumLibrary",
+                "rationale": "Detected via LLM",
+            }
+        # v3: patch at the real import path (robotmcp.utils.sampling)
+        monkeypatch.setattr(
+            "robotmcp.utils.sampling.sample_analyze_scenario", fake_sampling
+        )
+        # v3: correct env var name (sampling.py:23 reads ROBOTMCP_USE_SAMPLING)
+        monkeypatch.setenv("ROBOTMCP_USE_SAMPLING", "1")
+        # Invoke analyze_scenario via the MCP server wrapper
+        from robotmcp.server import analyze_scenario
+        result = await analyze_scenario(
+            "Use playwright to test demoshop",
+            context="web",
+        )
+        analysis = result["analysis"]
+        assert analysis["explicit_library_preference"] == "SeleniumLibrary"
+        assert analysis["preference_source"] == "sampling"
+        assert "explicit_library_evidence" not in analysis
+        assert "library_preference_conflicts" not in analysis
+        assert analysis.get("sampling_evidence") == "Detected via LLM"
+```
+
+#### Existing tests requiring updates (PRD §AC-8)
+
+The following existing tests assert false-positive behaviour and need updating to match v2:
+
+| Test file:line (estimate) | What it asserts (old) | New expectation |
+|---|---|---|
+| `tests/unit/test_library_detection.py` | "open browser" → SeleniumLibrary | "open browser" alone → None |
+| `tests/unit/test_library_detection.py` | "click element" → SeleniumLibrary | "click element" alone → None |
+| `tests/unit/test_session_models_library_preference.py` | session auto-configures SL on "open browser" | session does NOT auto-configure (None preference) |
+| `tests/unit/test_nlp_processor.py` (if such assertion exists) | "input text" triggers explicit SL | "input text" alone → None |
+| `tests/integration/test_nlp_improvements.py:103-104,571-576` | inspects `_compiled_patterns` directly | NO UPDATE NEEDED — `_compiled_patterns` preserved per Step 7 |
+
+Estimated: 3-5 existing test assertions updated (exact count after grep against v2 implementation). All updates align with the v1→v2 semantic change ("explicit" now means "user said so").
+
+---
+
+## 4. Migration Plan
+
+### Phase 1 — Internal refactor (this proposal)
+
+1. Add `PatternRule` dataclass with `explicit` annotation.
+2. Convert `LIBRARY_PATTERNS` table entries one by one — keep behaviour byte-for-byte by setting `explicit=True` for every existing pattern initially.
+3. Add `detect_explicit_preference` method.
+4. Verify all existing tests pass (no behaviour change yet).
+5. Then re-annotate the keyword-name patterns to `explicit=False` per the ADR-024 §6 table.
+6. Run existing tests + new test file. Expected: new tests pass; some existing tests that asserted "click element triggers SL" need updating to assert mention-only behaviour.
+
+### Phase 2 — Surface evidence/conflicts in response
+
+7. Update `nlp_processor.analyze_scenario` to add `explicit_library_evidence` + `library_preference_conflicts` fields.
+8. Update `session_models.detect_explicit_library_preference` to call the new method.
+
+### Phase 3 — Documentation
+
+9. Update `analyze_scenario` MCP tool docstring to mention the new optional fields.
+10. Release notes entry.
+
+### Phase 4 — Cleanup (separate follow-up PR)
+
+11. Remove `_fallback_detect_library_preference` after one release if no import-failure regression is reported.
+12. Migrate any remaining tuple-form patterns to the dataclass form.
+
+---
+
+## 5. Test Matrix (v3 — honest count)
+
+v2 claimed "10 distinct test functions" but the matrix summed to 18. v3 honestly counts both.
+
+| Test class | PRD AC coverage | Distinct test functions | Parametrised invocations |
+|---|---|---|---|
+| `TestReportedReproducer` | AC-1 | 2 | 2 |
+| `TestGenericNLPhrasesDoNotTrigger` | AC-6 (9 phrases) | 1 | 9 |
+| `TestTrulyExplicitDetected` | AC-2, AC-3, AC-7 | 2 (one parametrised + evidence check) | 13 |
+| `TestConflicts` | AC-4, AC-5 + sentence-scoped negation | 3 | 3 |
+| `TestThresholdsTunable` | FR-2, FR-3 + env-var contract | 4 | 4 |
+| `TestBackwardsCompatibility` | NFR-1, NFR-5 (`_compiled_patterns`) | 2 | 2 |
+| `TestEvidenceShape` | FR-5 | 1 | 1 |
+| `TestAnalyzeScenarioResponse` | end-to-end AC-1, AC-2 | 2 | 2 |
+| `TestSamplingOverrideCoherence` | FR-7 (v3) | 1 | 1 |
+
+**Test counts (v3 honest)**:
+- **18 distinct test functions** across 9 classes.
+- **37 invocations** after parametrisation expansion.
+- **3-5 existing test assertions updated** (see §3.4 table).
+
+PRD AC-8 v3 (updated) refers to "approximately 18 new tests" matching this matrix.
+
+---
+
+## 6. Performance Impact
+
+The detector runs once per `analyze_scenario` call. v2 dropped v1's unsupported "≤60µs per call" claim. The requirement is:
+
+- **No measurable regression** vs the current baseline in `tests/benchmarks/test_library_detection_bench.py`.
+- The detector keeps the existing per-call complexity envelope. Added work per call:
+  - Conditional check on `rule.explicit` (constant per pattern).
+  - Sentence splitting via single `re.split` per call.
+  - Sentence-scoped negation + migration scan: O(S × (N_negation + N_migration × M_patterns)) where S = sentences, N_* = pattern counts (small constants), M_patterns = library pattern count. Bounded; sentences typically ≤ 5 for scenarios.
+- Negation/migration replace the v1 single forward-window sweep — comparable cost, more correct semantics.
+
+Validation: run `pytest tests/benchmarks/test_library_detection_bench.py` before and after; the benchmark assertion windows are not changed.
+
+---
+
+## 7. Risks + Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Some users RELIED on the false-positive auto-config for Selenium | Medium | Document the behaviour change in release notes; provide migration steps (use `library_name="SeleniumLibrary"` on tool calls). |
+| Conflict threshold of 8 is too strict | Low-Medium | `ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD` env var lets operators tune down to 5 or less. |
+| Some tests assume the old behaviour and would break | High (necessary breakage) | Update those tests — they were pinning the bug. Document each updated test in the PR commit message. |
+| `PatternRule` adoption breaks downstream consumers reading the table | Low | The table format isn't public API. Internal-only consumption via `get_library_detector()`. |
+
+---
+
+## 8. Out of Scope
+
+- LLM-based detection — exists as opt-in (`sample_analyze_scenario`); unchanged.
+- Auto-import policy in `ExecutionSession.configure_from_scenario` — fixed indirectly; no code change to the importer.
+- Field rename of `explicit_library_preference` — the name is correct after the fix.
+- `_determine_capabilities` tightening — its broader inclusion is acceptable.
+
+---
+
+## 9. Validation Plan (v4 — reconciled to §5 matrix)
+
+1. **Reproducer**: re-run the user's exact `analyze_scenario` call. Expected: `explicit_library_preference: None`.
+2. **Test suite**: full unit suite (`uv run pytest tests/unit/`) — expect **18 new distinct test functions** (~37 invocations after parametrisation) + **3-5 modified tests** asserting false-positive behaviour. Pass count up by ~15-18 net. (v3 wording "~30 new + ~3 modified" was stale; v4 matches the §5 honest matrix count.)
+3. **Synthetic corpus**: run on 20 scenarios (10 truly explicit, 10 pure NL). Compute precision/recall. Expected: precision on NL → None ≥ 95%; recall on explicit ≥ 100%.
+4. **Manual smoke**: try 5 user-style scenarios live via the MCP server. Spot-check behaviour.
+5. **v4 algorithm verification**: confirm the empirical Python verification (proposal §3.1 Step 6 walkthroughs) passes against the implemented code — run the 8 marquee + edge-case scenarios as integration tests.
+
+---
+
+## 10. Effort Estimate
+
+- Code: half-day (~3-4 hours of focused work).
+- Tests: half-day.
+- Documentation update + release notes: 1 hour.
+- Review cycles (Codex/Claude subagent): 2-3 hours including iteration.
+- **Total**: ~1.5 engineering days for a single-engineer single-PR delivery.
+
+---
+
+## 11. Related Documents
+
+- PRD: `docs/prd/analyze_scenario_explicit_library_prd.md`
+- ADR-024: `docs/adr/ADR-024-explicit-library-detection-confidence.md`
+- DDD: `docs/ddd/library_preference_bounded_context.md`
+- Implementation will land in a single PR named: `fix(nlp): explicit library preference — preference vs mention split (ADR-024)`
+
+---
+
+## 12. Downstream Consumer Compatibility (NEW in v2)
+
+PRD §2 enumerates 8 places that read `explicit_library_preference`. v1 documented only 3. v2 verifies each consumer continues to work with the v2 response shape:
+
+| Consumer (file:lines) | Reads | v2 status |
+|---|---|---|
+| `server.py:2037` `_filter_keywords_by_session_library` | `analysis.explicit_library_preference` (str or None) | **Compatible** — same key, same type; v2 returns None in more cases (intended) |
+| `session_models.py:787` `ExecutionSession.configure_from_scenario` | Same field | **Compatible** — receives None for noise scenarios; skips auto-import (correct behaviour) |
+| `library_recommender.py:111-166` | Same field; uses as primary recommendation hint | **Compatible** — when None, falls back to capability-based recommendations |
+| `library_recommender.py:310-321` | Same field; excludes the "other library" | **Compatible** — when None, no exclusion (intended) |
+| `adapter_factory.py:131-140` | Same field; selects adapter (Browser vs SL) | **Compatible** — when None, default adapter selection |
+| `keyword_executor.py:1901-1914` | Hardcodes `Open Browser` keyword check: when `pref.startswith("selenium")` → SL; when `pref.startswith("browser")` → Browser; when neither → falls through to `_get_library_for_keyword(keyword)`. v3 verified: this is the ONLY explicit-preference branch in keyword_executor — not the general "library_name= fallback" v2 wrongly described. | **Compatible** — when None, neither branch fires, normal library resolution proceeds. |
+| `browser_plugin.py:314-321,379-390` | Same field; suppresses Browser auto-init when SL is preferred | **Compatible** — when None, Browser plugin behaves normally |
+| `selenium_plugin.py:202-208` | Same field; eagerly initializes SL | **Compatible** — when None, no eager init |
+
+**New optional response fields** (`explicit_library_evidence`, `library_preference_conflicts`, `preference_source`, `sampling_evidence`) are ignored by all 8 consumers — they read only `explicit_library_preference`. No consumer needs updating.
+
+**Behavioural change**: scenarios that previously triggered false-positive auto-config now produce None. Users who depended on the false positive will need to:
+- Pass `library_name="SeleniumLibrary"` (or whichever) explicitly on subsequent tool calls, OR
+- Rephrase the scenario to use a preference verb (`"Use Selenium to test..."`).
+
+This is documented in PRD §10 (Risks) and the implementation PR will include a release-notes entry under `docs/RELEASE_NOTES.md`.
+
+---
+
+## 15. Round-3 review findings + resolutions (v4)
+
+| # | Round-3 finding (v3) | Resolution in v4 |
+|---|---|---|
+| D1 | NEGATION_PHRASES iterated as Python list — both `\bdo\s+not\s+use\b` and `\bdo\s+not\b` fired on same span, double-deducting | §3.1 Step 5: replaced list iteration with single `_NEGATION_REGEX` alternation, longest-first. Regex engine guarantees one match per span. **Verified empirically against 9 scenarios including D1 edge cases.** |
+| D2 | INV-4 was trivial `max(0, x-d)` idempotence — wouldn't catch D1 | DDD §7 INV-4 replaced with deduction-sum equality (catches D1) |
+| D3 | DDD §4.1.6 conflicts type was tuple-of-three; PRD/ADR/proposal used dict-of-dicts | DDD §4.1.6 updated to `Dict[str, List[Dict[str, Any]]]`; proposal TestConflicts updated to unpack `entry["library"]` not `entry[0]` |
+| D4 | `session.preference_source` written but never declared on `ExecutionSession` | §3.3: field added explicitly as `preference_source: Optional[str] = "rule"` on the dataclass |
+| D5 | Test count §9 said "~30 + ~3" but §5 said "18 distinct" | §9 updated to match §5: "18 new + 3-5 modified" |
+| D6 | Multi-word migration `"to Browser library"` silently no-ops | §3.1 Step 5: documented as KNOWN LIMITATION (intentional consequence of bare-noun fix) |
+| D7 | `_subtract_sentence_score` used fragile substring check `text_span.lower() not in sentence.lower()` | §3.1 Step 1: `PatternMatch.sentence_index: int = -1` field added; `_subtract_sentence_score` filters by `pm.sentence_index != sentence_index` (exact membership, not substring) |
+| D8 | `Literal["rule", "sampling"]` declared but not imported | §3.1 Step 1: `from typing import ..., Literal, ...` added to imports |
+| F5 | `LIBRARY_RULES_DEFAULT` referenced in Step 7 but never declared | §3.1 Step 7: explicit module-level declaration added before `LibraryDetector` class |
+
+---
+
+## 14. Round-2 review findings + resolutions (v3)
+
+| # | Codex finding (v2 round 2) | Resolution in v3 |
+|---|---|---|
+| B1 | v2 negation regex captured `target="use"` not the library; "do not use Selenium, instead use Playwright" left both libs intact | §3.1 Step 5: phrase-list `NEGATION_PHRASES` + `_first_library_token_in()` two-step approach; sentence delimiter now `[.;!?,\n]+` (includes comma) |
+| B2 | v2's `PatternRule.__iter__` yielding 4 values breaks `for p, _ in _compiled_patterns; p.findall(...)` at `test_nlp_improvements.py:571-576` | §3.1 Step 7: dual stores — `_compiled_patterns` keeps `(Pattern, int)` tuples; new code reads `_rules_metadata` (parallel `PatternRule` list) |
+| B3 | `use browser`, `use database`, `use ssh`, `use requests` still flagged `explicit=True` (generic English nouns) | §3.1 Step 2: bare-noun tokens dropped from preference-verb patterns; only library-specific tokens (`playwright`, `seleniumlibrary`, `appium`, etc.) remain |
+| B4 | DDD prose says mention layer diagnostic-only but §5 diagram still shows `MentionScorer` → capability list | DDD §5 diagram fixed (separate doc edit) |
+| C1 | `PreferenceResolution` declared with 4 fields but constructed with 5 + named `source="rule"` | §3.1 Step 4: canonical 6-field shape `(library, source, evidence, conflicts, all_scores, sampling_evidence)` |
+| C2 | `rule.compiled.finditer()` used but `compiled` never declared on `PatternRule` | §3.1 Step 1: `compiled: Pattern = field(init=False)` set in `__post_init__` |
+| C3 | `_TOKEN_TO_LIBRARY` incomplete; migration regex `\w+` breaks hyphens & multi-word | §3.1 Step 5: `_LIBRARY_TOKENS` map + `_first_library_token_in()`; migration regex uses `.+?` capture with `_first_library_token_in()` resolution |
+| C5 | Sampling test patches wrong target and uses non-existent `ROBOTMCP_USE_SAMPLING_FOR_NLP` env var | §3.4: patches `robotmcp.utils.sampling.sample_analyze_scenario`; uses `ROBOTMCP_USE_SAMPLING` (verified at `sampling.py:23`) |
+| C6 | Scope table says 3 files but §3.2.1 patches `server.py` | §3 scope table: 4 files |
+| C7 | Test matrix totals 18 but text says 10 distinct | §5: honestly 18 distinct functions, 37 invocations |
+| E1 | ADR §3.3 claims `CONFLICT_GROUPS` module-level at `library_detection.py:240-242` (actually local in `get_conflicting_detections()`) | ADR §3.3 corrected (separate doc edit) |
+| E3 | Sampling override has TWO sites (`server.py:1860-1881` AND `1961-1972`); v2 missed second | §3.2.1: both sites documented; Site B patches `session.explicit_library_preference` + adds `session.preference_source` |
+| E4 | `keyword_executor.py:1901-1914` actually checks `Open Browser` keyword + `pref.startswith("selenium" \| "browser")` — NOT library_name= fallback | §12: corrected description |
+
+---
+
+## 13. Round-1 review findings + resolutions (v2)
+
+| # | Codex finding | Resolution in v2 |
+|---|---|---|
+| 1 | Pattern table wrongly annotated `explicit=True` for domain markers | §3.1: `rest api testing`, `mobile automation`, `android/ios testing`, SQL fragments, DB engine names, XPath/XSD/XSLT, bare `xml` all moved to `explicit=False` |
+| 2 | 80-char forward window for negation breaks `"do not use Selenium, instead use Playwright"` | §3.1 Step 5: replaced with sentence-scoped `NEGATION_PATTERNS` + `MIGRATION_PATTERNS` |
+| 3 | Conflict-vs-threshold ordering makes AC-5 impossible | §3.1 Step 6: conflict check now runs on RAW scores BEFORE threshold filter |
+| 4 | Class name `NLPProcessor` wrong | §3.2, §3.4: corrected to `NaturalLanguageProcessor` |
+| 5 | Test count inconsistent (25 vs 30) | §3.4 + §5: reconciled to 10 distinct tests, ~37 parametrised invocations |
+| 6 | AC-5 test logic was unreachable under v1 algorithm | §3.4 `TestConflicts`: rewrote to assert v2 algorithm |
+| 7 | Existing-test updates not listed | §3.4: 3-5 tests enumerated with file:line locations |
+| 8 | `_compiled_patterns` test surface compat not handled | §3.1 Step 7: dedicated section + `__iter__` for tuple-unpacking compat |
+| 9 | Performance claim "≤60µs" unsupported | §6: replaced with "no measurable regression vs benchmark" |
+| 10 | Sampling override coherence undefined | §3.2.1: clear evidence + conflicts, set `preference_source: "sampling"` |
+| 11 | 5 of 8 downstream consumers not documented | §12 NEW: full compatibility table for all 8 consumers |
+| 12 | Migration patterns absent from v1 | §3.1 Step 5: `MIGRATION_PATTERNS` constant + sentence-scoped application |

--- a/src/robotmcp/components/nlp_processor.py
+++ b/src/robotmcp/components/nlp_processor.py
@@ -234,9 +234,23 @@ class NaturalLanguageProcessor:
             
             # Determine required capabilities
             required_capabilities = self._determine_capabilities(normalized_scenario, context)
-            
-            # Detect explicit library preferences
-            explicit_library_preference = self._detect_explicit_library_preference(normalized_scenario)
+
+            # v5: resolve explicit library preference ONCE via PreferenceResolver.
+            # The resolution is a local — no shared state on self (Codex round-4
+            # flagged _last_resolution as a race-condition risk under the
+            # module-level NaturalLanguageProcessor singleton).
+            #
+            # v7 (Codex round-6 C1 follow-on): pass the RAW scenario, not the
+            # normalized text. `_normalize_text` collapses `\s+` → single space,
+            # which destroys the paragraph-break information the v7 detector
+            # relies on (`_SENTENCE_DELIMITERS` matches `\n\s*\n+` paragraph
+            # breaks). Without this fix, "Do not use this approach\n\nUse
+            # Playwright for the test." gets normalized into one line and the
+            # negation reaches across the paragraph break. The detector handles
+            # its own normalization internally (case-insensitive matching,
+            # explicit sentence/paragraph splitting); raw input is correct here.
+            resolution = self._resolve_explicit_library_preference(scenario)
+            explicit_library_preference = resolution.library if resolution else None
             session_type = self._detect_session_type(normalized_scenario, context)
             
             # Build structured scenario
@@ -269,14 +283,13 @@ class NaturalLanguageProcessor:
                     "expected_outcomes": structured_scenario.expected_outcomes,
                     "required_capabilities": structured_scenario.required_capabilities
                 },
-                "analysis": {
-                    "action_count": len(actions),
-                    "complexity": self._assess_complexity(actions),
-                    "estimated_steps": len(actions) * 2,  # Rough estimate
-                    "suggested_libraries": required_capabilities,
-                    "explicit_library_preference": explicit_library_preference,
-                    "detected_session_type": session_type
-                }
+                "analysis": self._build_analysis_block(
+                    actions=actions,
+                    required_capabilities=required_capabilities,
+                    explicit_library_preference=explicit_library_preference,
+                    resolution=resolution,
+                    session_type=session_type,
+                ),
             }
             
         except Exception as e:
@@ -650,17 +663,34 @@ class NaturalLanguageProcessor:
         return verifications
     
     def _detect_explicit_library_preference(self, scenario_text: str) -> Optional[str]:
-        """Detect explicit library preference using centralized LibraryDetector."""
-        try:
-            from robotmcp.utils.library_detection import detect_library_preference
-            detected = detect_library_preference(scenario_text, min_score=5)
-            if detected:
-                return detected
-        except ImportError:
-            pass
+        """Detect explicit library preference using centralized LibraryDetector.
 
-        # Fallback to local patterns for backward compatibility
-        return self._fallback_detect_library_preference(scenario_text)
+        v5: routes through `detect_explicit_preference()` (the conservative,
+        sentence-scoped path) instead of the old `detect_library_preference()`
+        (broad mention-layer path). Returns just the library name for
+        backward compatibility with existing test fixtures.
+        """
+        # v7 (Codex round-6 C3): mirror the v6 D-session-fallback fix from
+        # session_models.py. A `None` from the v6 detector is a deliberate
+        # abstain (no explicit signal, ambiguity, or conflict). Falling back
+        # to `_fallback_detect_library_preference` re-introduces broad
+        # substring false-positives ("Parse the XML response..." → "XML";
+        # "Use requests for the API call" → "RequestsLibrary"). v7 only
+        # falls back when the underlying detector can't even RUN — never
+        # when it deliberately abstains.
+        resolution = None
+        try:
+            resolution = self._resolve_explicit_library_preference(scenario_text)
+        except Exception as e:
+            logger.debug(f"detect_explicit_preference unavailable: {e}")
+            # Hard failure to run → fall back (preserves original behaviour
+            # only when the library can't load at all).
+            return self._fallback_detect_library_preference(scenario_text)
+
+        if resolution and resolution.library:
+            return resolution.library
+        # v7: deliberate abstain — return None. NOT the broad fallback.
+        return None
 
     def _fallback_detect_library_preference(self, scenario_text: str) -> Optional[str]:
         """Fallback library preference detection using local patterns."""
@@ -702,7 +732,75 @@ class NaturalLanguageProcessor:
             return "RequestsLibrary"
 
         return None
-    
+
+    def _resolve_explicit_library_preference(self, scenario_text: str):
+        """v5: return the full PreferenceResolution (library + evidence +
+        conflicts + provenance) for the new explicit-preference path.
+
+        Returns None if the LibraryDetector module is unavailable (fallback
+        path). The caller is responsible for reading `.library`, `.evidence`,
+        `.conflicts`, `.source`, and `.sampling_evidence` from the returned
+        resolution.
+
+        Note: this is the race-free entry point. v4 stashed `self._last_resolution`
+        for the analyze_scenario emit; that pattern is unsafe under the
+        module-level NaturalLanguageProcessor singleton (server.py creates one
+        instance and shares it across concurrent requests).
+        """
+        if not scenario_text:
+            return None
+        try:
+            from robotmcp.utils.library_detection import get_library_detector
+            return get_library_detector().detect_explicit_preference(scenario_text)
+        except ImportError:
+            return None
+
+    def _build_analysis_block(
+        self,
+        *,
+        actions,
+        required_capabilities,
+        explicit_library_preference,
+        resolution,
+        session_type: str,
+    ) -> Dict[str, Any]:
+        """v5: emit the analyze_scenario analysis block with the new optional
+        fields (`preference_source`, `explicit_library_evidence`,
+        `library_preference_conflicts`). Additive — existing callers reading
+        only the original fields see no change.
+        """
+        block: Dict[str, Any] = {
+            "action_count": len(actions),
+            "complexity": self._assess_complexity(actions),
+            "estimated_steps": len(actions) * 2,
+            "suggested_libraries": required_capabilities,
+            "explicit_library_preference": explicit_library_preference,
+            "detected_session_type": session_type,
+        }
+        if resolution is None:
+            return block
+
+        # v5: provenance — always emit when resolution is populated.
+        block["preference_source"] = resolution.source
+
+        # Evidence (only when rule-based; sampling clears these at server-side).
+        if resolution.evidence:
+            block["explicit_library_evidence"] = list(resolution.evidence)
+
+        # Conflicts (dict-of-dicts shape per ADR-024 §3.4 and DDD §4.1.6 v5).
+        if resolution.conflicts:
+            # Resolution conflicts already have the canonical shape
+            # {library, score, patterns_matched}. Pass-through unchanged.
+            block["library_preference_conflicts"] = {
+                group: list(entries) for group, entries in resolution.conflicts.items()
+            }
+
+        # Sampling rationale (only present after Site A override per ADR-024 §11).
+        if resolution.sampling_evidence:
+            block["sampling_evidence"] = resolution.sampling_evidence
+
+        return block
+
     def _detect_session_type(self, scenario: str, context: str) -> str:
         """Detect session type using centralized session models detection."""
         try:

--- a/src/robotmcp/models/session_models.py
+++ b/src/robotmcp/models/session_models.py
@@ -131,6 +131,11 @@ class ExecutionSession:
     explicit_library_preference: Optional[str] = (
         None  # For scenario-based explicit preferences
     )
+    # v5 (ADR-024 §11): provenance of explicit_library_preference. "rule" for
+    # rule-based detection (default); "sampling" when an LLM sampling override
+    # writes the field via server.py:1961-1972. Lets downstream consumers
+    # distinguish deterministic detection from LLM-inferred preference.
+    preference_source: Optional[str] = "rule"
     scenario_text: Optional[str] = None  # Store original scenario for re-analysis
     auto_configured: bool = False  # Track if session was auto-configured
     context_mode: bool = False  # Track if session uses full RF context mode
@@ -575,15 +580,30 @@ class ExecutionSession:
             return None
 
         try:
-            from robotmcp.utils.library_detection import detect_library_preference
-            result = detect_library_preference(scenario_text, min_score=5)
-            if result:
+            # v5: route through the new explicit-preference path
+            # (sentence-scoped negation, conflict surfacing) rather than the
+            # legacy mention-layer detect(). Also tags the session's
+            # preference_source as "rule" for downstream consumers.
+            from robotmcp.utils.library_detection import (
+                detect_explicit_library_preference as _detect_explicit,
+            )
+            resolution = _detect_explicit(scenario_text)
+            if resolution and resolution.library:
+                self.preference_source = "rule"
                 logger.info(
-                    f"Detected explicit {result} preference in scenario (via LibraryDetector)"
+                    f"Detected explicit {resolution.library} preference in scenario (via LibraryDetector v5)"
                 )
-                return result
-            # If LibraryDetector found nothing, try fallback
-            return self._fallback_detect_library(scenario_text)
+                return resolution.library
+            # v6 (Codex round-5 D-session-fallback): v5 returning None means
+            # the detector deliberately abstained (no explicit signal, or
+            # ambiguity / conflict). v5 used to fall through to the broad
+            # `_fallback_detect_library` substring heuristic here, which
+            # re-introduced false-positive "explicit" preferences at the
+            # session-aggregate level (e.g. "Parse the XML response from the
+            # API" → XML, contradicting analyze_scenario's null). The fallback
+            # now fires ONLY on ImportError, never on a deliberate None.
+            self.preference_source = "rule"
+            return None
         except ImportError:
             # Fallback to simple detection if LibraryDetector not available
             logger.debug("LibraryDetector not available, using fallback detection")

--- a/src/robotmcp/server.py
+++ b/src/robotmcp/server.py
@@ -1867,14 +1867,22 @@ async def analyze_scenario(
                 analysis = result.get("analysis", {})
                 if sampling_result.get("session_type"):
                     analysis["detected_session_type"] = sampling_result["session_type"]
-                if sampling_result.get("primary_library"):
-                    analysis["explicit_library_preference"] = sampling_result[
-                        "primary_library"
-                    ]
+                # v5 (ADR-024 §11 — sampling override coherence Site A):
+                # ONLY `library_preference` writes to `explicit_library_preference`.
+                # `primary_library` is the LLM's "main library detected"
+                # (a recommendation), not the user-stated explicit preference,
+                # so it is no longer mapped to the explicit field. When the
+                # override fires, evidence/conflicts are cleared and
+                # preference_source flips to "sampling".
                 if sampling_result.get("library_preference"):
                     analysis["explicit_library_preference"] = sampling_result[
                         "library_preference"
                     ]
+                    analysis["preference_source"] = "sampling"
+                    analysis.pop("explicit_library_evidence", None)
+                    analysis.pop("library_preference_conflicts", None)
+                    if sampling_result.get("rationale"):
+                        analysis["sampling_evidence"] = sampling_result["rationale"]
                 if sampling_result.get("detected_context"):
                     analysis["detected_context"] = sampling_result["detected_context"]
                 result["analysis"] = analysis
@@ -1968,6 +1976,10 @@ async def analyze_scenario(
             llm_lib_pref = await sample_detect_library_preference(ctx, scenario)
             if llm_lib_pref:
                 session.explicit_library_preference = llm_lib_pref
+                # v5 (ADR-024 §11 — sampling override coherence Site B):
+                # tag the session aggregate's provenance so downstream
+                # consumers can distinguish rule-based from LLM-driven.
+                session.preference_source = "sampling"
                 logger.info(f"LLM sampling detected library preference: {llm_lib_pref}")
             llm_session_type = await sample_detect_session_type(ctx, scenario, context)
             if llm_session_type:

--- a/src/robotmcp/utils/library_detection.py
+++ b/src/robotmcp/utils/library_detection.py
@@ -1,255 +1,836 @@
-"""Centralized library detection from scenario text."""
+"""Centralized library detection from scenario text.
 
-import re
+v5 (ADR-024): adds a layered model:
+  - MENTION layer (legacy `get_scores`, `detect`): broad pattern scoring used
+    for diagnostics and capability hints. Unchanged behaviour for callers.
+  - PREFERENCE layer (new `detect_explicit_preference`): conservative,
+    evidence-based. Only patterns annotated `explicit=True` contribute.
+    Implements sentence-scoped negation/migration with conflict surfacing.
+
+The mention layer keeps its existing test contract:
+`_compiled_patterns: Dict[str, List[Tuple[re.Pattern, int]]]` — verified by
+`tests/integration/test_nlp_improvements.py:565-580`.
+"""
+
+from __future__ import annotations
+
 import logging
-from typing import Dict, List, Optional, Tuple
+import os
+import re
 from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Pattern, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Value objects (per ADR-024 §3.5, §4.1.6 and DDD §4.1)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PatternRule:
+    """A single annotated regex pattern."""
+
+    pattern: str
+    weight: int
+    explicit: bool
+    rationale: str
+
+    compiled: Pattern = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not (1 <= self.weight <= 10):
+            raise ValueError(f"weight must be 1-10, got {self.weight}")
+        object.__setattr__(self, "compiled", re.compile(self.pattern, re.IGNORECASE))
+
+
+@dataclass(frozen=True)
+class PatternMatch:
+    """A single pattern-match record used as evidence."""
+
+    library: str
+    pattern: str
+    weight: int
+    text_span: str
+    sentence_index: int = -1  # internal; not surfaced in to_dict
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "library": self.library,
+            "pattern": self.pattern,
+            "weight": self.weight,
+            "text_span": self.text_span,
+        }
+
+
+@dataclass(frozen=True)
+class DetectionPolicy:
+    """Operator-tunable thresholds."""
+
+    default_min_score: int = 5
+    conflict_min_score: int = 8
+    ambiguity_window: int = 4
+
+    @classmethod
+    def from_env(cls) -> "DetectionPolicy":
+        return cls(
+            default_min_score=int(
+                os.getenv("ROBOTMCP_LIBRARY_DETECTION_MIN_SCORE", "5")
+            ),
+            conflict_min_score=int(
+                os.getenv("ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD", "8")
+            ),
+            ambiguity_window=int(
+                os.getenv("ROBOTMCP_LIBRARY_DETECTION_AMBIGUITY_WINDOW", "4")
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PreferenceResolution:
+    """Public output of detect_explicit_preference."""
+
+    library: Optional[str]
+    source: Literal["rule", "sampling"]
+    evidence: List[Dict[str, Any]]
+    conflicts: Dict[str, List[Dict[str, Any]]]
+    all_scores: Dict[str, int]
+    sampling_evidence: Optional[str] = None
+
+    @property
+    def is_decisive(self) -> bool:
+        return self.library is not None
+
+    @property
+    def has_conflicts(self) -> bool:
+        return bool(self.conflicts)
+
+
+# =============================================================================
+# Module-level constants (CONFLICT_GROUPS promoted from local per ADR-024 §3.3)
+# =============================================================================
+
+
+CONFLICT_GROUPS: Dict[str, Tuple[str, ...]] = {
+    "web_automation": ("Browser", "SeleniumLibrary"),
+}
+
+
+# v7 (Codex round-6 C1): sentence delimiter is sentence punctuation
+# (.;!?,) OR a paragraph break (2+ consecutive newlines with optional
+# whitespace between). v6 dropped `\n` entirely to fix the orphaning bug
+# ("do not use\nPlaywright" → None correct), but went too far: paragraph-
+# separated text now leaked negation across paragraphs. Example v6 bug:
+#   "Do not use this approach\n\nUse Playwright for the test."
+#   → v6 single sentence: negation finds "Playwright" in remaining text →
+#     subtracts Browser score → returns None (WRONG; user said do-not-use-
+#     this-approach, NOT do-not-use-Playwright).
+#
+# v7 keeps single-newline as NON-boundary (preserves the v6 negation fix)
+# while making double-newline (paragraph break) a boundary (restores
+# paragraph-scope semantics). Newline boundary inside a paragraph is still
+# enforced at the EXPLICIT PATTERN level via `[^\S\n]+` in LIBRARY_RULES_DEFAULT.
+#
+# Lineage:
+#   v5: r"[.;!?,\n]+"         (\n was hard boundary — orphaned negation)
+#   v6: r"[.;!?,]+"           (no \n — fixed orphaning; broke paragraphs)
+#   v7: r"[.;!?,]+|\n\s*\n+"  (sentence punct OR paragraph break — both work)
+_SENTENCE_DELIMITERS = r"[.;!?,]+|\n\s*\n+"
+
+
+# v5: SINGLE negation regex with alternation, longest-first. Each negation
+# span fires exactly ONCE (regex engine's left-to-right alternation guarantees
+# longest match wins). v4 list-iteration caused double-deduction (round-3 D1).
+# v5 restores standalone `skip` (round-4 regression).
+_NEGATION_REGEX: Pattern = re.compile(
+    r"\b(?:"
+    # Compound phrases (longer first)
+    r"do\s+not\s+use|don't\s+use|"
+    r"not\s+using|without\s+using|stop\s+using|avoid\s+using|"
+    r"skip\s+using|exclude\s+using|"
+    # Simple phrases
+    r"do\s+not|don't|"
+    r"without|stop|avoid|skip|exclude"  # v5: skip restored
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+# v5: migration patterns. `(?P<src>.+?)` / `(?P<dst>.+?)` plus
+# `_first_library_token_in()` to resolve canonical library names.
+# v6 (Codex round-5 D-multiword-migration): destination lookahead changed from
+# (?=[\s.,;!?]|$) to (?=[.,;!?\n]|$). v5 stopped capture at the first
+# whitespace, so "Migrate from Selenium to Requests library" captured
+# dst='Requests' — and `_first_library_token_in("Requests")` returned None
+# because bare `requests` is deliberately excluded from `_LIBRARY_TOKENS`
+# (too generic). Requests/Database/SSH/XML migrations all failed silently.
+# v6 captures up to the next sentence-punctuation/newline/EOL, then lets
+# `_first_library_token_in()` resolve the canonical library — which DOES
+# match the multi-word forms (`requests\s*library`, `database\s*library`, etc.).
+# Source capture changes the same way so multi-word source names work too
+# ("Migrate from Selenium Library to Browser Library").
+MIGRATION_PATTERNS: List[str] = [
+    r"\bmigrat(?:e|ion|ing)\b.+?\bfrom\b\s+(?P<src>.+?)\s+\bto\b\s+(?P<dst>.+?)(?=[.,;!?\n]|$)",
+    r"\bswitch(?:ing)?\s+from\b\s+(?P<src>.+?)\s+\bto\b\s+(?P<dst>.+?)(?=[.,;!?\n]|$)",
+    r"\binstead\s+of\b\s+(?P<src>.+?)\s+\b(?:use|with|via)\b\s+(?P<dst>.+?)(?=[.,;!?\n]|$)",
+    r"\breplace\b\s+(?P<src>.+?)\s+\b(?:with|by|for)\b\s+(?P<dst>.+?)(?=[.,;!?\n]|$)",
+]
+
+
+# v5: library-token map for negation/migration target resolution. Deliberately
+# EXCLUDES generic English nouns (`browser`, `database`, `ssh`, `requests`,
+# `xml`) because users writing "do not use ssh" usually mean the SSH protocol,
+# not SSHLibrary. Brand names (`selenium`, `playwright`, `appium`) kept.
+_LIBRARY_TOKENS: Dict[str, List[str]] = {
+    "SeleniumLibrary": [
+        "selenium",
+        "seleniumlibrary",
+        r"selenium\s*library",
+        "selenium2library",
+        "selenium3library",
+        "webdriver",
+        "chromedriver",
+        "geckodriver",
+        "edgedriver",
+        "safaridriver",
+    ],
+    "Browser": [
+        "playwright",
+        "browserlibrary",
+        r"browser\s*library",
+        "rfbrowser",
+        r"robotframework[- ]browser",
+        r"playwright[- ]core",
+        "chromium",
+        "webkit",
+    ],
+    "RequestsLibrary": ["requestslibrary", r"requests\s*library"],
+    "AppiumLibrary": ["appium", "appiumlibrary", r"appium\s*library"],
+    "DatabaseLibrary": ["databaselibrary", r"database\s*library"],
+    "SSHLibrary": ["sshlibrary", r"ssh\s*library"],
+    "XML": ["xmllibrary", r"xml\s*library"],
+}
+
+
+def _first_library_token_in(text: str) -> Optional[str]:
+    """Return the canonical library name of the FIRST library token in `text`.
+
+    Returns None if no library token matches.
+    """
+    earliest: Optional[Tuple[str, int]] = None
+    for lib, tokens in _LIBRARY_TOKENS.items():
+        for token in tokens:
+            m = re.search(rf"\b{token}\b", text, re.IGNORECASE)
+            if m and (earliest is None or m.start() < earliest[1]):
+                earliest = (lib, m.start())
+    return earliest[0] if earliest else None
+
+
+def _build_sentence_spans(text: str) -> List[Tuple[int, int]]:
+    """Split `text` on `_SENTENCE_DELIMITERS` while preserving (start, end)
+    character positions so PatternMatch entries can record the sentence_index.
+    """
+    spans: List[Tuple[int, int]] = []
+    pos = 0
+    delim_re = re.compile(_SENTENCE_DELIMITERS)
+    for m in delim_re.finditer(text):
+        if pos < m.start():
+            spans.append((pos, m.start()))
+        pos = m.end()
+    if pos < len(text):
+        spans.append((pos, len(text)))
+    return spans
+
+
+# =============================================================================
+# Pattern table (LIBRARY_RULES_DEFAULT — v5 source of truth)
+# =============================================================================
+
+# v5: each entry annotated with explicit/rationale. `explicit=True` patterns
+# contribute to detect_explicit_preference; `explicit=False` patterns remain
+# in the mention layer (`get_scores`). The classification policy: explicit
+# means verbatim library/runtime/driver identifier OR preference-verb idiom
+# bound to a library-specific token. Generic domain markers stay non-explicit.
+#
+# v5 NOTE on bare-token preference verbs: brand names (`selenium`, `playwright`,
+# `appium`) stay inside preference-verb patterns. Generic English nouns
+# (`browser`, `database`, `ssh`, `requests`, `xml`) are NOT in preference-verb
+# patterns — too ambiguous.
+#
+# v5 NOTE on newlines: preference-verb patterns use `[^\S\n]+` instead of
+# `\s+` so multi-line text "do not use\nSelenium" doesn't match `use selenium`
+# across the line break (newline acts as sentence boundary).
+
+LIBRARY_RULES_DEFAULT: Dict[str, List[PatternRule]] = {
+    "SeleniumLibrary": [
+        PatternRule(
+            r"\b(use|using|with|via|through|prefer)[^\S\n]+(selenium|seleniumlibrary|selenium[^\S\n]*library)\b",
+            10, True, "preference verb + selenium brand token",
+        ),
+        PatternRule(r"\bseleniumlibrary\b", 9, True, "verbatim library name"),
+        PatternRule(r"\bselenium\b", 6, True, "standalone selenium mention"),
+        PatternRule(r"\bwebdriver\b", 6, True, "selenium-specific WebDriver term"),
+        PatternRule(
+            r"\b(chromedriver|geckodriver|edgedriver|safaridriver)\b",
+            7, True, "selenium drivers",
+        ),
+        PatternRule(r"\bselenium\s+grid\b", 8, True, "selenium-specific tech"),
+        PatternRule(r"\bselenium\s+standalone\b", 7, True, "selenium-specific tech"),
+        PatternRule(r"\bclassic\s+selenium\b", 7, True, "selenium-specific phrasing"),
+        PatternRule(r"\bselenium\s+automation\b", 7, True, "selenium-domain phrasing"),
+        PatternRule(
+            r"\b(selenium\s+(2|3|4)|selenium2library|selenium3library)\b",
+            8, True, "selenium version mention",
+        ),
+        PatternRule(
+            r"\b(desired\s+capabilities|driver\s+capabilities)\b",
+            7, True, "selenium Capabilities API",
+        ),
+        PatternRule(
+            r"\b(create\s+webdriver|get\s+webelement)\b",
+            8, True, "selenium-specific keywords",
+        ),
+        PatternRule(
+            r"\btest\s+automation\s+with\s+selenium\b",
+            8, True, "explicit phrasing",
+        ),
+        # Mention-only (NOT explicit) — generic NL that overlaps with SL keyword names
+        PatternRule(
+            r"\bopen\s+browser\b", 6, False,
+            "REMOVED from explicit — generic NL verb that overlaps with SL keyword",
+        ),
+        PatternRule(
+            r"\b(input\s+text|click\s+element|page\s+should\s+contain)\b", 6, False,
+            "REMOVED from explicit — SL keyword names but also generic NL",
+        ),
+        PatternRule(
+            r"\b(implicit|explicit)\s+wait\b", 6, False,
+            "REMOVED from explicit — generic concept across web libraries",
+        ),
+    ],
+    "Browser": [
+        PatternRule(
+            r"\b(use|using|with|via|through|prefer)[^\S\n]+(playwright|browserlibrary|browser[^\S\n]*library|rfbrowser|robotframework[- ]browser|playwright[- ]core)\b",
+            10, True, "preference verb + Browser-specific token (no bare 'browser')",
+        ),
+        PatternRule(r"\bbrowser\s*library\b", 9, True, "verbatim library name"),
+        PatternRule(r"\bplaywright\b", 9, True, "verbatim Browser library tech"),
+        PatternRule(
+            r"\b(rfbrowser|robotframework[- ]browser|playwright[- ]core)\b",
+            9, True, "verbatim package names",
+        ),
+        PatternRule(r"\bchromium\b", 9, True, "Playwright kernel (as specific as 'playwright')"),
+        PatternRule(r"\bwebkit\b", 9, True, "Playwright kernel"),
+        # Mention-only
+        PatternRule(
+            r"\bbrowser\b", 4, False,
+            "bare 'browser' too generic for explicit; kept in mention layer",
+        ),
+        PatternRule(r"\bmodern\s+web\s+testing\b", 7, False, "marketing copy"),
+        PatternRule(r"\bmodern\s+browser\s+automation\b", 8, False, "marketing copy"),
+        PatternRule(r"\bcross[- ]browser\s+testing\b", 6, False, "generic test type"),
+        PatternRule(
+            r"\bnew\s+(browser|page|context)\b", 8, False,
+            "Browser keyword names but also generic NL",
+        ),
+        PatternRule(r"\bfill\s+(text|secret)\b", 7, False, "Browser keyword name"),
+        PatternRule(
+            r"\b(headless\s+browser|headless\s+chromium)\b", 6, False,
+            "generic test config",
+        ),
+        PatternRule(
+            r"\b(shadow\s+dom|web\s+components?)\b", 6, False,
+            "modern web concept; not Browser-exclusive",
+        ),
+        PatternRule(
+            r"\b(SPA|single\s+page\s+app(lication)?)\b", 5, False,
+            "describes app architecture",
+        ),
+        PatternRule(r"\b(e2e|end.to.end)\s+(test|automat)", 5, False, "generic test type"),
+    ],
+    "RequestsLibrary": [
+        PatternRule(
+            r"\b(use|using|with|via|through|prefer)[^\S\n]+(requestslibrary|requests[^\S\n]*library)\b",
+            10, True, "preference verb + Requests-specific (no bare 'requests')",
+        ),
+        PatternRule(r"\brequestslibrary\b", 9, True, "verbatim library name"),
+        PatternRule(
+            r"\b(create\s+session|get\s+on\s+session|post\s+on\s+session)\b",
+            8, True, "RL keyword names with 'session' qualifier",
+        ),
+        PatternRule(
+            r"\b(status\s+should\s+be|request\s+should\s+be)\b",
+            7, True, "RL-specific keyword phrasing",
+        ),
+        PatternRule(
+            r"\b(GET|POST|PUT|DELETE|PATCH)\s+on\s+session\b",
+            7, True, "HTTP-method + RL 'on session' qualifier",
+        ),
+        # Mention-only
+        PatternRule(r"\brequests\b", 4, False, "bare 'requests' too generic"),
+        PatternRule(r"\brest\s+api\s+testing\b", 7, False, "domain marker"),
+        PatternRule(r"\bapi\s+automation\b", 6, False, "domain marker"),
+        PatternRule(r"\bstatus\s+code\b", 5, False, "generic HTTP term"),
+        PatternRule(
+            r"\b(GET|POST|PUT|DELETE|PATCH)\s+request\b", 5, False,
+            "bare HTTP verb + request — domain-generic",
+        ),
+        PatternRule(r"\bhttp\s+requests?\b", 5, False, "generic HTTP term"),
+        PatternRule(r"\b(webservice|web\s+service)\b", 5, False, "generic"),
+        PatternRule(r"\bmicroservice\b", 5, False, "generic"),
+        PatternRule(r"\b(bearer\s+token|JWT|OAuth2?)\b", 5, False, "auth concepts"),
+        PatternRule(r"\b(swagger|openapi)\b", 5, False, "api-doc tooling"),
+        PatternRule(r"\b(graphql|gRPC|SOAP)\b", 5, False, "API protocols"),
+        PatternRule(r"\b(webhook|callback\s+url)\b", 5, False, "generic"),
+    ],
+    "AppiumLibrary": [
+        PatternRule(
+            r"\b(use|using|with|via|through|prefer)[^\S\n]+(appium|appiumlibrary|appium[^\S\n]*library)\b",
+            10, True, "preference verb + Appium token",
+        ),
+        PatternRule(r"\bappium(?:library)?\b", 9, True, "verbatim library / runtime name"),
+        PatternRule(
+            r"\b(UIAutomator2?|XCUITest|Espresso)\b",
+            7, True, "Appium-specific runtime",
+        ),
+        # Mention-only
+        PatternRule(r"\bmobile\s+automation\b", 7, False, "domain marker"),
+        PatternRule(r"\bmobile\s+app\s+testing\b", 7, False, "domain marker"),
+        PatternRule(r"\bandroid\s+testing\b", 6, False, "platform, not library identifier"),
+        PatternRule(r"\bios\s+testing\b", 6, False, "platform, not library identifier"),
+        PatternRule(r"\b(open\s+application|close\s+application)\b", 8, False, "keyword names"),
+        PatternRule(
+            r"\b(tap|swipe|long\s+press|double\s+tap|flick|scroll|pinch)\b",
+            6, False, "mobile action verbs",
+        ),
+        PatternRule(r"\bdevice\b", 5, False, "too generic"),
+        PatternRule(r"\b(emulator|simulator)\b", 5, False, "generic"),
+        PatternRule(r"\b(native\s+app|hybrid\s+app|webview)\b", 6, False, "generic mobile"),
+        PatternRule(r"\b(APK|IPA|bundle\s+id|package\s+name)\b", 6, False, "mobile artifacts"),
+        PatternRule(
+            r"\b(device\s+farm|BrowserStack|Sauce\s+Labs)\b", 5, False, "cloud services",
+        ),
+        PatternRule(r"\b(iphone|ipad|tablet|smartphone)\b", 5, False, "device names"),
+    ],
+    "DatabaseLibrary": [
+        PatternRule(
+            r"\b(use|using|with|via|through|prefer)[^\S\n]+(databaselibrary|database[^\S\n]*library)\b",
+            10, True, "preference verb + Database-specific (no bare 'database')",
+        ),
+        PatternRule(r"\bdatabaselibrary\b", 9, True, "verbatim library name"),
+        PatternRule(
+            r"\b(connect\s+to\s+database|execute\s+sql|call\s+stored\s+procedure)\b",
+            8, True, "DatabaseLibrary keyword names",
+        ),
+        # Mention-only
+        PatternRule(
+            r"\b(SELECT|INSERT|UPDATE|DELETE)\s+(FROM|INTO|SET|\*)\b",
+            5, False, "SQL is user's domain, not library identifier",
+        ),
+        PatternRule(
+            r"\b(postgres(?:ql)?|mysql|mariadb|sqlite)\b",
+            5, False, "DB engine name, not RF library identifier",
+        ),
+        PatternRule(
+            r"\b(oracle|sql\s+server|mssql|mongodb)\b",
+            5, False, "DB engine name, not RF library identifier",
+        ),
+        PatternRule(r"\bsql\s+testing\b", 6, False, "generic SQL test type"),
+        PatternRule(r"\bdatabase\s+validation\b", 6, False, "generic"),
+        PatternRule(
+            r"\b(row\s+count|check\s+if\s+exists)\b",
+            7, False, "DB-keyword names but generic NL",
+        ),
+        PatternRule(r"\b(connection\s+string|DSN|ODBC)\b", 5, False, "generic DB config"),
+        PatternRule(r"\bstored\s+procedure\b", 6, False, "generic SQL concept"),
+        PatternRule(r"\b(CRUD|schema\s+migration)\b", 5, False, "generic"),
+    ],
+    "SSHLibrary": [
+        PatternRule(
+            r"\b(use|using|with|via|through|prefer)[^\S\n]+(sshlibrary|ssh[^\S\n]*library)\b",
+            10, True, "preference verb + SSH-specific (no bare 'ssh')",
+        ),
+        PatternRule(r"\bsshlibrary\b", 9, True, "verbatim library name"),
+        PatternRule(
+            r"\blogin\s+with\s+public\s+key\b",
+            7, True, "SSHLibrary-specific keyword name",
+        ),
+        PatternRule(r"\b(sftp|scp)\b", 6, True, "SSH-specific protocols"),
+        # Mention-only
+        PatternRule(
+            r"\bopen\s+connection\b", 7, False,
+            "overlaps with Telnet, Database, Browser keyword names",
+        ),
+        PatternRule(
+            r"\b(execute\s+command|start\s+command)\b",
+            6, False, "generic command-execution",
+        ),
+        PatternRule(
+            r"\b(get\s+file|put\s+file|get\s+directory|put\s+directory)\b",
+            6, False, "generic file ops",
+        ),
+        PatternRule(
+            r"\bssh\s+(into|to)\b", 6, False,
+            "action verb, not library identifier",
+        ),
+        PatternRule(r"\bremote\s+server\s+commands?\b", 5, False, "generic"),
+        PatternRule(
+            r"\b(remote\s+(server|execution|machine|host))\b", 5, False, "generic",
+        ),
+        PatternRule(
+            r"\b(linux|unix)\s+(server|machine|system)\b", 5, False, "OS-generic",
+        ),
+    ],
+    "XML": [
+        PatternRule(
+            r"\b(use|using|with|via|through|prefer)[^\S\n]+(xmllibrary|xml[^\S\n]*library)\b",
+            10, True, "preference verb + XML library-specific (no bare 'xml')",
+        ),
+        PatternRule(r"\bxmllibrary\b", 9, True, "verbatim library name"),
+        # Mention-only
+        PatternRule(r"\bxml\s+parsing\b", 6, False, "XML parsing is user's task"),
+        PatternRule(r"\bxml\s+validation\b", 6, False, "domain marker"),
+        PatternRule(
+            r"\b(parse\s+xml|save\s+xml|log\s+element)\b",
+            7, False, "XMLLibrary keyword names but also generic NL",
+        ),
+        PatternRule(
+            r"\b(xslt|dtd|xsd)\b", 6, False,
+            "XML standards, not RF library identifier",
+        ),
+        PatternRule(
+            r"\bxpath\s+(expression|query|selector)\b",
+            6, False, "XPath also used by SeleniumLibrary locators",
+        ),
+        PatternRule(
+            r"\b(get\s+element\s+text|get\s+element\s+attribute)\b",
+            6, False, "overlaps with other libs' keyword names",
+        ),
+        PatternRule(
+            r"\b(namespace|element\s+tree|lxml)\b",
+            5, False, "generic XML lib terms",
+        ),
+        PatternRule(
+            r"\bxml\s+(file|document|response|config)\b",
+            5, False, "generic XML mention",
+        ),
+        PatternRule(r"\bxml\b", 4, False, "bare xml could mean file format"),
+    ],
+}
+
+
+# =============================================================================
+# LibraryDetector
+# =============================================================================
 
 
 class LibraryDetector:
     """Centralized library detection from scenario text.
 
-    Consolidates detection logic that was previously duplicated in:
-    - nlp_processor.py
-    - session_models.py
+    Two-store internal design:
+      - _compiled_patterns: legacy Dict[lib, List[Tuple[Pattern, int]]] for
+        existing test contract at tests/integration/test_nlp_improvements.py
+        (lines 565-580). Mention-layer driver.
+      - LIBRARY_RULES: new Dict[lib, List[PatternRule]] for the explicit
+        preference layer (detect_explicit_preference).
     """
 
-    # Weighted patterns for explicit library detection
-    # Format: (pattern, weight) - higher weight = stronger signal
+    # Legacy class attribute kept for backward-compat — derived from LIBRARY_RULES.
+    # Older callers may reference LibraryDetector.LIBRARY_PATTERNS.
     LIBRARY_PATTERNS: Dict[str, List[Tuple[str, int]]] = {
-        'SeleniumLibrary': [
-            (r'\b(use|using|with|via|through)\s+(selenium|seleniumlibrary|selenium\s*library)\b', 10),
-            (r'\btest\s+automation\s+with\s+selenium\b', 8),
-            (r'\bseleniumlibrary\b', 9),
-            (r'\bselenium\b', 6),  # Standalone mention — catches "Selenium test", "run Selenium", etc.
-            (r'\bwebdriver\b', 6),
-            (r'\bselenium\s+grid\b', 8),
-            (r'\bselenium\s+standalone\b', 7),
-            (r'\bclassic\s+selenium\b', 7),
-            (r'\bselenium\s+automation\b', 7),
-            (r'\b(chromedriver|geckodriver|edgedriver|safaridriver)\b', 7),
-            (r'\bopen\s+browser\b', 6),
-            (r'\b(create\s+webdriver|get\s+webelement)\b', 8),
-            (r'\b(selenium\s+(2|3|4)|selenium2library)\b', 8),
-            (r'\b(implicit|explicit)\s+wait\b', 6),
-            (r'\b(input\s+text|click\s+element|page\s+should\s+contain)\b', 6),
-            (r'\b(desired\s+capabilities|driver\s+capabilities)\b', 7),
-        ],
-        'Browser': [
-            (r'\b(use|using|with|via|through)\s+(browser|browserlibrary|browser\s*library|playwright)\b', 10),
-            (r'\bbrowser\s*library\b', 9),
-            (r'\bplaywright\b', 9),
-            (r'\bmodern\s+web\s+testing\b', 7),
-            (r'\bmodern\s+browser\s+automation\b', 8),
-            (r'\bcross[- ]browser\s+testing\b', 6),
-            (r'\bchromium\b', 7),
-            (r'\bwebkit\b', 7),
-            (r'\bnew\s+(browser|page|context)\b', 8),
-            (r'\bfill\s+(text|secret)\b', 7),
-            (r'\b(rfbrowser|robotframework-browser)\b', 9),
-            (r'\b(headless\s+browser|headless\s+chromium)\b', 6),
-            (r'\b(shadow\s+dom|web\s+components?)\b', 6),
-            (r'\b(SPA|single\s+page\s+app(lication)?)\b', 5),
-            (r'\b(e2e|end.to.end)\s+(test|automat)', 5),
-        ],
-        'RequestsLibrary': [
-            (r'\b(use|using|with)\s+(requests|requestslibrary|requests\s*library)\b', 10),
-            (r'\brequestslibrary\b', 9),
-            (r'\brest\s+api\s+testing\b', 7),
-            (r'\bhttp\s+requests?\b', 5),
-            (r'\bapi\s+automation\b', 6),
-            (r'\b(create\s+session|get\s+on\s+session|post\s+on\s+session)\b', 8),
-            (r'\b(status\s+should\s+be|request\s+should\s+be)\b', 7),
-            (r'\b(GET|POST|PUT|DELETE|PATCH)\s+(request|on\s+session)\b', 7),
-            (r'\b(webservice|web\s+service)\b', 5),
-            (r'\bmicroservice\b', 5),
-            (r'\b(bearer\s+token|JWT|OAuth2?)\b', 5),
-            (r'\b(swagger|openapi)\b', 5),
-            (r'\b(graphql|gRPC|SOAP)\b', 5),
-            (r'\b(webhook|callback\s+url)\b', 5),
-            (r'\bstatus\s+code\b', 5),
-        ],
-        'AppiumLibrary': [
-            (r'\b(use|using|with)\s+(appium|appiumlibrary|appium\s*library)\b', 10),
-            (r'\bappiumlibrary\b', 9),
-            (r'\bmobile\s+automation\b', 7),
-            (r'\bandroid\s+testing\b', 6),
-            (r'\bios\s+testing\b', 6),
-            (r'\bmobile\s+app\s+testing\b', 7),
-            (r'\b(open\s+application|close\s+application)\b', 8),
-            (r'\b(tap|swipe|long\s+press|double\s+tap|flick)\b', 6),
-            (r'\b(emulator|simulator)\b', 5),
-            (r'\b(native\s+app|hybrid\s+app|webview)\b', 6),
-            (r'\b(APK|IPA|bundle\s+id|package\s+name)\b', 6),
-            (r'\b(device\s+farm|BrowserStack|Sauce\s+Labs)\b', 5),
-            (r'\b(UIAutomator2?|XCUITest|Espresso)\b', 7),
-            (r'\b(iphone|ipad|tablet|smartphone)\b', 5),
-        ],
-        'DatabaseLibrary': [
-            (r'\b(use|using|with)\s+(database|databaselibrary|database\s*library)\b', 10),
-            (r'\bdatabaselibrary\b', 9),
-            (r'\bsql\s+testing\b', 6),
-            (r'\bdatabase\s+validation\b', 6),
-            (r'\b(connect\s+to\s+database|execute\s+sql|call\s+stored\s+procedure)\b', 8),
-            (r'\b(row\s+count|check\s+if\s+exists)\b', 7),
-            (r'\b(postgres(ql)?|mysql|mariadb|sqlite)\b', 5),
-            (r'\b(oracle|sql\s+server|mssql|mongodb)\b', 5),
-            (r'\b(connection\s+string|DSN|ODBC)\b', 5),
-            (r'\bstored\s+procedure\b', 6),
-            (r'\b(CRUD|schema\s+migration)\b', 5),
-            (r'\b(SELECT|INSERT|UPDATE|DELETE)\s+(FROM|INTO|SET)\b', 5),
-        ],
-        'SSHLibrary': [
-            (r'\b(use|using|with)\s+(ssh|sshlibrary|ssh\s*library)\b', 10),
-            (r'\bsshlibrary\b', 9),
-            (r'\bremote\s+server\s+commands?\b', 5),
-            (r'\b(open\s+connection|login\s+with\s+public\s+key)\b', 7),
-            (r'\b(execute\s+command|start\s+command)\b', 6),
-            (r'\b(get\s+file|put\s+file|get\s+directory|put\s+directory)\b', 6),
-            (r'\b(sftp|scp)\b', 6),
-            (r'\b(remote\s+(server|execution|machine))\b', 5),
-            (r'\b(linux|unix)\s+(server|machine|system)\b', 5),
-        ],
-        'XML': [
-            (r'\b(use|using|with)\s+xml\s*library\b', 10),
-            (r'\bxml\s+parsing\b', 6),
-            (r'\bxml\s+validation\b', 6),
-            (r'\b(parse\s+xml|save\s+xml|log\s+element)\b', 7),
-            (r'\b(get\s+element\s+text|get\s+element\s+attribute)\b', 6),
-            (r'\b(xslt|dtd|xsd)\b', 6),
-            (r'\b(namespace|element\s+tree|lxml)\b', 5),
-            (r'\bxml\s+(file|document|response|config)\b', 5),
-            (r'\bxpath\s+(expression|query|selector)\b', 6),
-        ],
+        lib: [(rule.pattern, rule.weight) for rule in rules]
+        for lib, rules in LIBRARY_RULES_DEFAULT.items()
     }
 
-    # Minimum score required for detection
     DEFAULT_MIN_SCORE = 5
 
-    # Negation patterns that indicate the user does NOT want a library
+    # Legacy negation patterns — preserved for backward compat in `get_scores`
+    # (mention layer). The new explicit-preference path uses _NEGATION_REGEX
+    # + sentence-scoped algorithm.
     NEGATION_PATTERNS = [
-        re.compile(r'\b(not|don\'t|do\s+not|without|stop|avoid)\s+(?:using\s+)?', re.IGNORECASE),
-        re.compile(r'\b(instead\s+of|migrate\s+from|replace|replacing|move\s+away\s+from)\s+', re.IGNORECASE),
+        re.compile(
+            r"\b(not|don't|do\s+not|without|stop|avoid|skip|exclude)\s+(?:using\s+)?",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"\b(instead\s+of|migrate\s+from|replace|replacing|move\s+away\s+from)\s+",
+            re.IGNORECASE,
+        ),
     ]
 
-    def __init__(self, min_score: int = None):
+    def __init__(
+        self,
+        min_score: Optional[int] = None,
+        rules: Optional[Dict[str, List[PatternRule]]] = None,
+        policy: Optional[DetectionPolicy] = None,
+    ) -> None:
         """Initialize LibraryDetector.
 
         Args:
-            min_score: Minimum score required for library detection
+            min_score: Legacy threshold for `detect`/`get_scores` (mention layer).
+            rules: Optional override for LIBRARY_RULES (v5 — preference layer).
+            policy: Optional DetectionPolicy override.
         """
         self.min_score = min_score or self.DEFAULT_MIN_SCORE
-        self._compiled_patterns: Dict[str, List[Tuple[re.Pattern, int]]] = {}
-        self._compile_patterns()
+        self.LIBRARY_RULES = rules if rules is not None else LIBRARY_RULES_DEFAULT
+        self.policy = policy or DetectionPolicy.from_env()
 
-    def _compile_patterns(self) -> None:
-        """Pre-compile regex patterns for performance."""
-        for lib, patterns in self.LIBRARY_PATTERNS.items():
-            self._compiled_patterns[lib] = [
-                (re.compile(pattern, re.IGNORECASE), weight)
-                for pattern, weight in patterns
-            ]
+        # _compiled_patterns: legacy 2-tuple shape — preserves
+        # tests/integration/test_nlp_improvements.py:565-580 contract
+        # (for p, _ in entries: p.findall(...)).
+        self._compiled_patterns: Dict[str, List[Tuple[Pattern, int]]] = {
+            lib: [(rule.compiled, rule.weight) for rule in rules_list]
+            for lib, rules_list in self.LIBRARY_RULES.items()
+        }
 
-    def detect(self, text: str, min_score: int = None) -> Optional[str]:
-        """Detect explicit library preference from text.
+    # ------------------------------------------------------------------
+    # Mention layer (legacy API — unchanged behaviour)
+    # ------------------------------------------------------------------
 
-        Args:
-            text: Scenario text to analyze
-            min_score: Override minimum score threshold
+    def detect(self, text: str, min_score: Optional[int] = None) -> Optional[str]:
+        """Detect library preference via mention-layer scoring (legacy).
 
-        Returns:
-            Library name if detected with sufficient confidence, None otherwise
+        New callers should prefer `detect_explicit_preference()`.
         """
         if not text:
             return None
-
         scores = self.get_scores(text)
-
         if not scores:
             return None
-
         threshold = min_score or self.min_score
         best_lib, best_score = max(scores.items(), key=lambda x: x[1])
-
         if best_score >= threshold:
-            logger.debug(f"Detected library preference: {best_lib} (score: {best_score})")
+            logger.debug(
+                f"Detected library preference: {best_lib} (score: {best_score})"
+            )
             return best_lib
-
         return None
 
     def get_scores(self, text: str) -> Dict[str, int]:
-        """Get detection scores for all libraries.
-
-        Args:
-            text: Scenario text to analyze
-
-        Returns:
-            Dictionary of library names to scores
-        """
+        """Mention-layer scores (ALL patterns regardless of explicit flag)."""
         if not text:
             return {}
-
         text_lower = text.lower()
         scores: Dict[str, int] = defaultdict(int)
-
         for lib, patterns in self._compiled_patterns.items():
             for pattern, weight in patterns:
                 matches = len(pattern.findall(text_lower))
                 if matches > 0:
                     scores[lib] += matches * weight
-
-        # Check for negation context
+        # Legacy negation handling (unchanged from pre-v5)
         for lib_name, score in list(scores.items()):
             if score > 0:
                 for neg_pattern in self.NEGATION_PATTERNS:
                     for pattern_str, weight in self.LIBRARY_PATTERNS.get(lib_name, []):
-                        combined = neg_pattern.pattern + r'.*?' + pattern_str
+                        combined = neg_pattern.pattern + r".*?" + pattern_str
                         if re.search(combined, text, re.IGNORECASE):
                             scores[lib_name] = max(0, scores[lib_name] - weight * 2)
                             break
-
         return dict(scores)
 
-    def detect_all(self, text: str, min_score: int = None) -> List[Tuple[str, int]]:
-        """Detect all libraries above threshold, sorted by score.
-
-        Args:
-            text: Scenario text to analyze
-            min_score: Override minimum score threshold
-
-        Returns:
-            List of (library_name, score) tuples, sorted by score descending
-        """
+    def detect_all(
+        self, text: str, min_score: Optional[int] = None
+    ) -> List[Tuple[str, int]]:
+        """Mention-layer multi-library detection (legacy)."""
         scores = self.get_scores(text)
         threshold = min_score or self.min_score
-
         detected = [(lib, score) for lib, score in scores.items() if score >= threshold]
         return sorted(detected, key=lambda x: -x[1])
 
     def get_conflicting_detections(self, text: str) -> Dict[str, List[str]]:
-        """Detect if conflicting libraries are mentioned.
-
-        Args:
-            text: Scenario text to analyze
-
-        Returns:
-            Dictionary of conflict groups to detected libraries
-        """
-        CONFLICT_GROUPS = {
-            'web_automation': ['Browser', 'SeleniumLibrary'],
-        }
-
+        """Legacy conflict surface (mention layer)."""
         scores = self.get_scores(text)
-        conflicts = {}
-
+        conflicts: Dict[str, List[str]] = {}
         for group_name, group_libs in CONFLICT_GROUPS.items():
             detected = [lib for lib in group_libs if scores.get(lib, 0) > 0]
             if len(detected) > 1:
                 conflicts[group_name] = detected
-
         return conflicts
+
+    # ------------------------------------------------------------------
+    # Preference layer (v5 — explicit detection)
+    # ------------------------------------------------------------------
+
+    def detect_explicit_preference(
+        self, text: str, policy: Optional[DetectionPolicy] = None
+    ) -> PreferenceResolution:
+        """Conservative explicit-preference detection.
+
+        Algorithm (per ADR-024 §3.3, proposal v5 §3.1 Step 6):
+          1. Build sentence spans + compute raw explicit scores + collect matches.
+          2. Sentence-scoped negation (single _NEGATION_REGEX, longest-first
+             alternation; phrase-based with _first_library_token_in lookup)
+             + migration (source/destination resolution).
+          3. CONFLICT CHECK on raw scores BEFORE threshold filter.
+          4. Threshold filter (conflict_min_score for in-group libs,
+             default_min_score for out-of-group).
+          5. Pick winner.
+        """
+        p = policy or self.policy
+        empty = PreferenceResolution(
+            library=None,
+            source="rule",
+            evidence=[],
+            conflicts={},
+            all_scores={},
+            sampling_evidence=None,
+        )
+        if not text:
+            return empty
+
+        sentence_spans = _build_sentence_spans(text)
+
+        def sentence_index_for(pos: int) -> int:
+            for i, (start, end) in enumerate(sentence_spans):
+                if start <= pos < end:
+                    return i
+            return -1
+
+        # === Step 1: raw scores + matches ===
+        raw_scores: Dict[str, int] = defaultdict(int)
+        matches_by_lib: Dict[str, List[PatternMatch]] = defaultdict(list)
+        for lib, rules in self.LIBRARY_RULES.items():
+            for rule in rules:
+                if not rule.explicit:
+                    continue
+                for m in rule.compiled.finditer(text):
+                    raw_scores[lib] += rule.weight
+                    if len(matches_by_lib[lib]) < 8:
+                        matches_by_lib[lib].append(
+                            PatternMatch(
+                                library=lib,
+                                pattern=rule.pattern,
+                                weight=rule.weight,
+                                text_span=m.group(0),
+                                sentence_index=sentence_index_for(m.start()),
+                            )
+                        )
+
+        # === Step 2: sentence-scoped negation + migration ===
+        for sentence_index, (start, end) in enumerate(sentence_spans):
+            sent = text[start:end]
+            if not sent.strip():
+                continue
+            # 2a. Migration patterns
+            for pattern_src in MIGRATION_PATTERNS:
+                for m in re.finditer(pattern_src, sent, re.IGNORECASE):
+                    src_lib = _first_library_token_in(m.group("src"))
+                    dst_lib = _first_library_token_in(m.group("dst"))
+                    if src_lib:
+                        self._subtract_sentence_score(
+                            raw_scores, matches_by_lib, sent, sentence_index, src_lib
+                        )
+                    if dst_lib:
+                        raw_scores[dst_lib] += 5
+            # 2b. Single-library negation (SINGLE regex alternation)
+            for m in _NEGATION_REGEX.finditer(sent):
+                remaining = sent[m.end():]
+                target_lib = _first_library_token_in(remaining)
+                if target_lib:
+                    self._subtract_sentence_score(
+                        raw_scores, matches_by_lib, sent, sentence_index, target_lib
+                    )
+
+        # === Step 3: conflict check on RAW scores ===
+        conflicts: Dict[str, List[Dict[str, Any]]] = {}
+        for group_name, members in CONFLICT_GROUPS.items():
+            libs_with_signal = [
+                lib for lib in members if raw_scores.get(lib, 0) > 0
+            ]
+            if len(libs_with_signal) < 2:
+                continue
+            ranked = sorted(
+                libs_with_signal, key=lambda l: raw_scores[l], reverse=True
+            )
+            if raw_scores[ranked[0]] - raw_scores[ranked[1]] <= p.ambiguity_window:
+                conflicts[group_name] = [
+                    {
+                        "library": lib,
+                        "score": raw_scores[lib],
+                        "patterns_matched": [pm.pattern for pm in matches_by_lib[lib]],
+                    }
+                    for lib in ranked
+                ]
+
+        if conflicts:
+            return PreferenceResolution(
+                library=None,
+                source="rule",
+                evidence=[],
+                conflicts=conflicts,
+                all_scores=dict(raw_scores),
+                sampling_evidence=None,
+            )
+
+        # === Step 4: threshold filter ===
+        candidates: Dict[str, int] = {}
+        for lib, score in raw_scores.items():
+            threshold = (
+                p.conflict_min_score
+                if self._in_conflict_group(lib)
+                else p.default_min_score
+            )
+            if score >= threshold:
+                candidates[lib] = score
+
+        if not candidates:
+            return PreferenceResolution(
+                library=None,
+                source="rule",
+                evidence=[],
+                conflicts={},
+                all_scores=dict(raw_scores),
+                sampling_evidence=None,
+            )
+
+        # === Step 5: winner ===
+        winner = max(candidates, key=candidates.get)
+        return PreferenceResolution(
+            library=winner,
+            source="rule",
+            evidence=[pm.to_dict() for pm in matches_by_lib[winner]],
+            conflicts={},
+            all_scores=dict(raw_scores),
+            sampling_evidence=None,
+        )
+
+    def _in_conflict_group(self, library: str) -> bool:
+        return any(library in members for members in CONFLICT_GROUPS.values())
+
+    def _subtract_sentence_score(
+        self,
+        raw_scores: Dict[str, int],
+        matches_by_lib: Dict[str, List[PatternMatch]],
+        sentence: str,
+        sentence_index: int,
+        library: str,
+    ) -> None:
+        """Subtract sentence-local explicit contributions for `library` and
+        strip evidence whose `sentence_index` matches.
+        """
+        # v6 (Codex round-5 D-repeated-token): count OCCURRENCES, not "did
+        # this rule match at all". v5 used `rule.compiled.search(sentence)`
+        # which fired once per rule regardless of how many times the pattern
+        # appeared in the sentence. Step 1 (raw scoring) uses `finditer` and
+        # adds weight per occurrence, so subtraction must mirror that. Without
+        # this fix, "do not use Playwright Playwright" scored Browser=28 but
+        # only deducted 19 → Browser=9 wins despite the negation.
+        deduction = 0
+        for rule in self.LIBRARY_RULES.get(library, []):
+            if not rule.explicit:
+                continue
+            occurrences = len(rule.compiled.findall(sentence))
+            if occurrences:
+                deduction += rule.weight * occurrences
+        if deduction:
+            raw_scores[library] = max(0, raw_scores[library] - deduction)
+            matches_by_lib[library] = [
+                pm
+                for pm in matches_by_lib[library]
+                if pm.sentence_index != sentence_index
+            ]
 
 
 # Module-level singleton for convenience
@@ -265,13 +846,13 @@ def get_library_detector() -> LibraryDetector:
 
 
 def detect_library_preference(text: str, min_score: int = 5) -> Optional[str]:
-    """Convenience function to detect library preference.
-
-    Args:
-        text: Scenario text to analyze
-        min_score: Minimum score threshold
-
-    Returns:
-        Library name if detected, None otherwise
-    """
+    """Convenience function (legacy — uses mention-layer detect)."""
     return get_library_detector().detect(text, min_score)
+
+
+def detect_explicit_library_preference(text: str) -> PreferenceResolution:
+    """v5 convenience: returns the full PreferenceResolution for the new
+    preference-layer path. Use this instead of `detect()` when you need
+    evidence/conflicts/source provenance.
+    """
+    return get_library_detector().detect_explicit_preference(text)

--- a/tests/unit/test_explicit_library_detection_fix.py
+++ b/tests/unit/test_explicit_library_detection_fix.py
@@ -1,0 +1,763 @@
+"""Tests for the v5 explicit library preference detection.
+
+Covers PRD AC-1..AC-7 + sentence-scoped negation/migration + sampling
+override coherence + sentence_index evidence filtering + race-free
+invocation under the module-level NaturalLanguageProcessor singleton.
+
+See:
+- docs/prd/analyze_scenario_explicit_library_prd.md
+- docs/adr/ADR-024-explicit-library-detection-confidence.md
+- docs/proposals/explicit_library_detection_fix_proposal.md (v5)
+"""
+
+import asyncio
+
+import pytest
+
+from robotmcp.utils.library_detection import (
+    DetectionPolicy,
+    LibraryDetector,
+    PatternMatch,
+    PatternRule,
+    PreferenceResolution,
+    detect_explicit_library_preference,
+    get_library_detector,
+)
+
+
+# =============================================================================
+# AC-1 — reported reproducer
+# =============================================================================
+
+
+class TestReportedReproducer:
+    """The exact scenario from the 2026-05-29 user report."""
+
+    SCENARIO = (
+        "Test e-commerce website https://demoshop.makrocode.de: "
+        "open browser, add items to shopping cart, verify items, "
+        "complete checkout, and close browser"
+    )
+
+    def test_no_explicit_preference(self):
+        r = get_library_detector().detect_explicit_preference(self.SCENARIO)
+        assert r.library is None, (
+            f"'open browser' is generic NL and must NOT trigger explicit "
+            f"SL preference. Got {r.library} from {r.evidence}"
+        )
+
+    def test_evidence_empty(self):
+        r = get_library_detector().detect_explicit_preference(self.SCENARIO)
+        assert r.evidence == []
+
+    def test_no_conflicts(self):
+        r = get_library_detector().detect_explicit_preference(self.SCENARIO)
+        assert r.conflicts == {}
+
+    def test_source_is_rule(self):
+        r = get_library_detector().detect_explicit_preference(self.SCENARIO)
+        assert r.source == "rule"
+
+
+# =============================================================================
+# AC-2/AC-3/AC-7 — truly explicit detection
+# =============================================================================
+
+
+class TestTrulyExplicitDetected:
+    @pytest.mark.parametrize(
+        "scenario,expected",
+        [
+            ("Use playwright to test the checkout flow", "Browser"),
+            ("Use Selenium to test the login form", "SeleniumLibrary"),
+            ("with SeleniumLibrary, open the page", "SeleniumLibrary"),
+            ("Test using browserlibrary against demoshop", "Browser"),
+            ("Use requestslibrary to call /api/users", "RequestsLibrary"),
+            ("With AppiumLibrary, open the mobile app", "AppiumLibrary"),
+            (
+                "Use database library to validate the inventory table",
+                "DatabaseLibrary",
+            ),
+            ("Use ssh library to deploy", "SSHLibrary"),
+            ("Use XML library to validate the response", "XML"),
+            ("Run Selenium 4 against the site", "SeleniumLibrary"),
+            ("Test using chromium and webkit", "Browser"),
+        ],
+    )
+    def test_explicit_detected(self, scenario, expected):
+        r = get_library_detector().detect_explicit_preference(scenario)
+        assert r.library == expected, (
+            f"{scenario!r}: expected {expected}, got {r.library}"
+        )
+        assert r.source == "rule"
+
+    def test_evidence_populated(self):
+        r = get_library_detector().detect_explicit_preference(
+            "Use playwright to test"
+        )
+        assert r.evidence, "evidence must be populated when library detected"
+        assert any("playwright" in e["text_span"].lower() for e in r.evidence)
+        # Each evidence entry has the canonical 4-key shape (PRD §FR-5)
+        first = r.evidence[0]
+        assert set(first.keys()) == {"library", "pattern", "weight", "text_span"}
+
+
+# =============================================================================
+# AC-6 — generic NL phrases must NOT trigger explicit detection
+# =============================================================================
+
+
+class TestGenericNLPhrasesDoNotTrigger:
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            "click element by id submit",
+            "Page should contain Welcome text",
+            "Input text into the username field",
+            "Open new page in browser context",
+            "Execute command on the remote server",
+            "Open application on the device",
+            "Check if exists and verify row count",
+            "Verify status code returned by service",
+            "Parse the XML response from the API",
+            # v5 — bare-noun preference verbs no longer explicit
+            "use browser to load the page",
+            "use database for the test",
+            "use ssh for deployment",
+            "use requests for the API call",
+            "use xml for the config",
+        ],
+    )
+    def test_no_explicit(self, scenario):
+        r = get_library_detector().detect_explicit_preference(scenario)
+        assert r.library is None, (
+            f"NL phrase {scenario!r} should NOT trigger explicit detection; "
+            f"got {r.library}"
+        )
+
+
+# =============================================================================
+# AC-4 + sentence-scoped negation
+# =============================================================================
+
+
+class TestNegationAndMigration:
+    def test_migration_resolves_to_destination(self):
+        """AC-4 — migration subtracts source, adds to destination."""
+        r = get_library_detector().detect_explicit_preference(
+            "Migrate the test suite from Selenium to Playwright"
+        )
+        assert r.library == "Browser"
+        assert "web_automation" not in r.conflicts
+
+    def test_negation_across_comma_clauses(self):
+        """Round-3 marquee: 'do not use X, instead use Y' must resolve to Y."""
+        r = get_library_detector().detect_explicit_preference(
+            "do not use Selenium, instead use Playwright"
+        )
+        assert r.library == "Browser"
+
+    def test_both_libraries_negated_to_none(self):
+        """Round-3 D1 edge case: two negation spans, both target SL → None."""
+        r = get_library_detector().detect_explicit_preference(
+            "do not use Selenium and stop the SeleniumLibrary"
+        )
+        assert r.library is None
+
+    def test_skip_negation_restored(self):
+        """Round-4 D-skip regression: standalone `skip` must fire negation."""
+        r = get_library_detector().detect_explicit_preference(
+            "skip selenium and use playwright"
+        )
+        assert r.library == "Browser"
+
+    def test_negation_phrase_does_not_double_deduct(self):
+        """Round-3 D1: single span fires once even though both
+        \\bdo\\s+not\\s+use\\b and \\bdo\\s+not\\b are in the alternation.
+        """
+        # If double-deduction occurred, SL score would underflow before
+        # max(0, ...) clamps it. Add a second sentence with positive SL
+        # signal to detect underflow.
+        r = get_library_detector().detect_explicit_preference(
+            "do not use Selenium. Then run selenium for diagnostic."
+        )
+        # First sentence negates: SL 16 → 0.
+        # Second sentence: `\bselenium\b` (+6).
+        # Net: SL = 6 (not 0 from double-deduction).
+        assert r.all_scores.get("SeleniumLibrary", 0) >= 6
+
+
+# =============================================================================
+# AC-5 — within-conflict-group ambiguity
+# =============================================================================
+
+
+class TestConflicts:
+    def test_both_selenium_and_playwright_returns_none_with_conflict(self):
+        """AC-5 — conflict check on RAW scores BEFORE threshold filter."""
+        r = get_library_detector().detect_explicit_preference(
+            "Test both selenium and playwright sites and compare"
+        )
+        assert r.library is None
+        assert "web_automation" in r.conflicts
+        # Round-3 D3: conflicts entries are DICTS, not tuples
+        libs = {entry["library"] for entry in r.conflicts["web_automation"]}
+        assert libs == {"Browser", "SeleniumLibrary"}
+        # Canonical shape: {library, score, patterns_matched}
+        entry = r.conflicts["web_automation"][0]
+        assert set(entry.keys()) == {"library", "score", "patterns_matched"}
+
+
+# =============================================================================
+# Threshold tunability
+# =============================================================================
+
+
+class TestThresholdsTunable:
+    def test_default_min_score_for_non_conflict_library(self):
+        # XML is outside the web_automation conflict group → default threshold 5
+        r = get_library_detector().detect_explicit_preference(
+            "Use XML library to validate"
+        )
+        assert r.library == "XML"
+
+    def test_conflict_threshold_blocks_single_weight_6(self):
+        # Lone "selenium" mention is weight 6; conflict threshold is 8 → blocked
+        r = get_library_detector().detect_explicit_preference(
+            "Run a Selenium test"
+        )
+        assert r.library is None
+
+    def test_conflict_threshold_passes_weight_9(self):
+        # "playwright" verbatim is weight 9 → passes conflict threshold of 8
+        r = get_library_detector().detect_explicit_preference(
+            "Run a playwright test"
+        )
+        assert r.library == "Browser"
+
+    def test_env_var_lowers_threshold(self, monkeypatch):
+        monkeypatch.setenv("ROBOTMCP_LIBRARY_DETECTION_CONFLICT_THRESHOLD", "5")
+        d = LibraryDetector()  # fresh detector reads env at construction
+        r = d.detect_explicit_preference("Run a Selenium test")
+        assert r.library == "SeleniumLibrary"
+
+
+# =============================================================================
+# Backwards-compatibility — legacy entry points still work
+# =============================================================================
+
+
+class TestBackwardsCompatibility:
+    def test_legacy_detect_returns_string_or_none(self):
+        d = get_library_detector()
+        # legacy mention-layer `detect()` may still fire for old NL phrases
+        # since it does NOT use the explicit flag. The new path is the one
+        # users should call.
+        assert isinstance(d.detect("use playwright"), str)
+        assert d.detect("xyzabc nonsense") is None
+
+    def test_compiled_patterns_test_contract_preserved(self):
+        """v5 — `for p, _ in _compiled_patterns: p.findall(...)` must work."""
+        d = get_library_detector()
+        b = d._compiled_patterns.get("Browser", [])
+        assert b, "Browser must have at least one compiled pattern"
+        # Existing fixture pattern: for p, _ in entries: p.findall(...)
+        ok = any(
+            p.findall("playwright is great")
+            for p, _ in b
+        )
+        assert ok
+
+    def test_compiled_patterns_entries_are_2_tuples(self):
+        d = get_library_detector()
+        for lib, entries in d._compiled_patterns.items():
+            for e in entries:
+                assert isinstance(e, tuple) and len(e) == 2, (
+                    f"{lib} entry must be a 2-tuple (Pattern, int); got {e!r}"
+                )
+
+
+# =============================================================================
+# Evidence shape
+# =============================================================================
+
+
+class TestEvidenceShape:
+    def test_evidence_includes_required_fields(self):
+        r = get_library_detector().detect_explicit_preference(
+            "Use playwright for the demoshop test"
+        )
+        assert r.evidence
+        first = r.evidence[0]
+        assert "library" in first
+        assert "pattern" in first
+        assert "weight" in first
+        assert "text_span" in first
+        assert first["library"] == "Browser"
+
+
+# =============================================================================
+# End-to-end through analyze_scenario
+# =============================================================================
+
+
+def _run(coro):
+    """Helper: run an async coroutine in a fresh event loop (avoids
+    `asyncio.get_event_loop()` deprecation warning under Python 3.13).
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class TestAnalyzeScenarioResponse:
+    def _analyze(self, scenario):
+        from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+        nlp = NaturalLanguageProcessor()
+        return _run(nlp.analyze_scenario(scenario, context="web"))
+
+    def test_response_omits_evidence_when_no_detection(self):
+        result = self._analyze(
+            "Test e-commerce website https://demoshop.makrocode.de: "
+            "open browser, add items, complete checkout"
+        )
+        analysis = result["analysis"]
+        assert analysis["explicit_library_preference"] is None
+        assert analysis["preference_source"] == "rule"
+        assert "explicit_library_evidence" not in analysis
+        assert "library_preference_conflicts" not in analysis
+
+    def test_response_includes_evidence_on_explicit_detection(self):
+        result = self._analyze(
+            "Use playwright to test the demoshop checkout flow"
+        )
+        analysis = result["analysis"]
+        assert analysis["explicit_library_preference"] == "Browser"
+        assert analysis["preference_source"] == "rule"
+        assert "explicit_library_evidence" in analysis
+        assert any(
+            "playwright" in e["text_span"].lower()
+            for e in analysis["explicit_library_evidence"]
+        )
+
+    def test_response_includes_conflicts_on_ambiguity(self):
+        result = self._analyze(
+            "Test both selenium and playwright sites and compare"
+        )
+        analysis = result["analysis"]
+        assert analysis["explicit_library_preference"] is None
+        assert "library_preference_conflicts" in analysis
+        assert "web_automation" in analysis["library_preference_conflicts"]
+
+
+# =============================================================================
+# Race-free invocation (round-4 finding: no _last_resolution on singleton)
+# =============================================================================
+
+
+class TestNoSharedState:
+    """Round-4 finding: the proposal v4 stashed self._last_resolution on a
+    module-level NaturalLanguageProcessor singleton — race condition under
+    concurrent requests. v5 returns the resolution as a local variable.
+    Verify by interleaving two analyses on the SAME nlp instance and
+    checking each call returns its own correct evidence.
+    """
+
+    def test_interleaved_analyses_no_state_bleed(self):
+        from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+        nlp = NaturalLanguageProcessor()
+
+        async def run_two():
+            r1 = await nlp.analyze_scenario(
+                "Use playwright to test demoshop", context="web"
+            )
+            r2 = await nlp.analyze_scenario(
+                "Use Selenium to test the login form", context="web"
+            )
+            return r1, r2
+
+        r1, r2 = _run(run_two())
+        a1, a2 = r1["analysis"], r2["analysis"]
+        assert a1["explicit_library_preference"] == "Browser"
+        assert a2["explicit_library_preference"] == "SeleniumLibrary"
+        # Evidence in each result references the right library
+        assert any(
+            e["library"] == "Browser"
+            for e in a1.get("explicit_library_evidence", [])
+        )
+        assert any(
+            e["library"] == "SeleniumLibrary"
+            for e in a2.get("explicit_library_evidence", [])
+        )
+
+
+# =============================================================================
+# sentence_index evidence filtering (round-3 D7)
+# =============================================================================
+
+
+class TestSentenceIndexEvidenceFiltering:
+    """Round-3 D7: when negation in sentence N drops SL evidence, evidence
+    from sentence M (M != N) must be preserved.
+    """
+
+    def test_multi_sentence_partial_negation_preserves_other_evidence(self):
+        d = get_library_detector()
+        r = d.detect_explicit_preference(
+            "Use Selenium for login. We do not use Selenium for checkout"
+        )
+        # Sentence 1 positive: SL = +16. Sentence 2 negation: subtract sentence-2
+        # SL = -16. Total raw: SL = 0. Then sentence 1 evidence preserved
+        # because its sentence_index != sentence 2's index.
+        # But raw_scores[SL] = 0 means SL won't pass threshold → library None.
+        # Wait actually that's not what we want — let me reconsider.
+        # The negation subtracts only sentence-2-local SL contributions = 16.
+        # raw_scores[SL] = 16 (sentence 1) + 16 (sentence 2) - 16 = 16.
+        # SL ≥ 8 → returns SL.
+        assert r.library == "SeleniumLibrary"
+        # Verify evidence still has at least one matching SL match
+        assert any(
+            e["library"] == "SeleniumLibrary" for e in r.evidence
+        )
+
+
+# =============================================================================
+# Sampling override coherence (round-4 finding: drop primary_library fallback)
+# =============================================================================
+
+
+# =============================================================================
+# v6 — Codex round-5 critical findings (4 bugs, all fixed in v6)
+# =============================================================================
+
+
+class TestV6SessionFallbackBug:
+    """Codex round-5 D-session-fallback: session_models.py used to fall back to
+    `_fallback_detect_library` (broad substring heuristic) when v5 returned
+    None, which re-introduced false-positive explicit preferences at the
+    session aggregate level. v6 only falls back on ImportError.
+    """
+
+    def test_session_does_not_force_xml_on_parse_xml_response(self):
+        from robotmcp.models.session_models import ExecutionSession
+        s = ExecutionSession(session_id="t1")
+        detected = s.detect_explicit_library_preference(
+            "Parse the XML response from the API"
+        )
+        assert detected is None, (
+            f"Session aggregate must NOT call generic fallback on None; "
+            f"got {detected}"
+        )
+
+    def test_session_does_not_force_api_lib_on_generic_api_scenario(self):
+        from robotmcp.models.session_models import ExecutionSession
+        s = ExecutionSession(session_id="t2")
+        # "api" is generic — v5/v6 should not flag a library, and the
+        # session must not bypass v6 with the legacy substring heuristic.
+        detected = s.detect_explicit_library_preference(
+            "Verify the api returns 200"
+        )
+        assert detected is None
+
+    def test_session_preserves_real_explicit_detection(self):
+        from robotmcp.models.session_models import ExecutionSession
+        s = ExecutionSession(session_id="t3")
+        # Genuine explicit signal must still resolve
+        detected = s.detect_explicit_library_preference(
+            "Use playwright to test the checkout"
+        )
+        assert detected == "Browser"
+        assert s.preference_source == "rule"
+
+
+class TestV6NewlineNegation:
+    """Codex round-5 D-newline-negation: v5 had `\\n` in sentence delimiter so
+    'do not use\\nPlaywright' split into 2 sentences and negation couldn't
+    find its target. v6 drops `\\n` from sentence delimiter; newline boundary
+    is enforced at the explicit-pattern level via `[^\\S\\n]+` instead.
+    """
+
+    @pytest.mark.parametrize(
+        "scenario,expected",
+        [
+            ("do not use\nPlaywright", None),
+            ("do not use\nAppium", None),
+            ("do not use\nRequestsLibrary", None),
+            ("do not use\nSeleniumLibrary", None),
+        ],
+    )
+    def test_newline_negation(self, scenario, expected):
+        r = get_library_detector().detect_explicit_preference(scenario)
+        assert r.library == expected, (
+            f"{scenario!r}: expected {expected}, got {r.library}"
+        )
+
+    def test_preference_verb_does_not_match_across_newline(self):
+        """The `\\b(use|...)\\b[^\\S\\n]+(playwright|...)\\b` weight-10
+        preference verb pattern must NOT fire across a newline (because
+        `[^\\S\\n]+` excludes newline). The standalone `\\bplaywright\\b`
+        weight-9 pattern still fires legitimately — that's by design.
+        """
+        d = get_library_detector()
+        r = d.detect_explicit_preference("use\nplaywright")
+        # `playwright` standalone alone scores 9 — passes conflict-group
+        # threshold 8 → Browser. Verify the +10 preference verb did NOT fire.
+        assert r.library == "Browser"
+        # If the preference verb fired, score would be 19; v6 must show 9.
+        assert r.all_scores.get("Browser") == 9
+
+
+class TestV6RepeatedTokenDeduction:
+    """Codex round-5 D-repeated-token: `_subtract_sentence_score` used
+    `rule.compiled.search(sentence)` (once per rule) instead of counting
+    occurrences. 'do not use Playwright Playwright' under-deducted, so
+    Browser=9 survived threshold despite negation.
+    """
+
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            "do not use Playwright Playwright",
+            "do not use RequestsLibrary RequestsLibrary",
+            "do not use SeleniumLibrary SeleniumLibrary",
+            "do not use playwright playwright playwright",
+        ],
+    )
+    def test_repeated_token_negation(self, scenario):
+        r = get_library_detector().detect_explicit_preference(scenario)
+        assert r.library is None, (
+            f"Repeated-token negation must clamp score to 0; got {r.library} "
+            f"with scores {r.all_scores}"
+        )
+
+
+class TestV6MultiwordMigration:
+    """Codex round-5 D-multiword-migration: v5 destination capture stopped at
+    first whitespace, so 'to Requests library' captured 'Requests' (bare token
+    deliberately excluded from _LIBRARY_TOKENS). v6 captures up to next
+    sentence punctuation, letting `_first_library_token_in` resolve canonical.
+    """
+
+    @pytest.mark.parametrize(
+        "scenario,expected",
+        [
+            ("Migrate from Selenium to Requests library", "RequestsLibrary"),
+            ("Migrate from Selenium to Database library", "DatabaseLibrary"),
+            ("Migrate from Browser to SSH library", "SSHLibrary"),
+            ("Migrate from Selenium to XML library", "XML"),
+            # Single-word destinations still work
+            ("Migrate from Selenium to Playwright", "Browser"),
+            ("Migrate from Selenium to Browser library", "Browser"),
+        ],
+    )
+    def test_multiword_migration_destination(self, scenario, expected):
+        r = get_library_detector().detect_explicit_preference(scenario)
+        assert r.library == expected, (
+            f"{scenario!r}: expected {expected}, got {r.library}"
+        )
+
+
+# =============================================================================
+# v7 — Codex round-6 findings
+# =============================================================================
+
+
+class TestV7ParagraphBoundary:
+    """Codex round-6 C1: v6's `_SENTENCE_DELIMITERS = r"[.;!?,]+"` dropped
+    `\\n` entirely to fix D-newline-negation, but paragraph-separated text
+    then leaked negation across paragraphs. v7 makes `\\n\\s*\\n+` (paragraph
+    break) a boundary while keeping single `\\n` as NON-boundary (so v6's
+    `"do not use\\nPlaywright"` fix stays intact).
+    """
+
+    @pytest.mark.parametrize(
+        "scenario,expected",
+        [
+            # Paragraph break separates negation from following positive signal
+            (
+                "Do not use this approach\n\nUse Playwright for the test.",
+                "Browser",
+            ),
+            (
+                "Avoid that pattern\n\nWith SeleniumLibrary, open the page.",
+                "SeleniumLibrary",
+            ),
+            (
+                "Stop the current setup\n\nUse playwright for the rewrite",
+                "Browser",
+            ),
+        ],
+    )
+    def test_paragraph_break_scopes_negation(self, scenario, expected):
+        r = get_library_detector().detect_explicit_preference(scenario)
+        assert r.library == expected, (
+            f"Paragraph break must scope negation; "
+            f"got {r.library} (scores: {r.all_scores})"
+        )
+
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            # Single newline must STILL not split (v6 fix preserved)
+            "do not use\nPlaywright",
+            "do not use\nAppium",
+            "do not use\nSeleniumLibrary",
+            "do not use\nRequestsLibrary",
+        ],
+    )
+    def test_single_newline_not_a_boundary(self, scenario):
+        r = get_library_detector().detect_explicit_preference(scenario)
+        assert r.library is None, (
+            f"Single newline must NOT split sentence — negation must reach "
+            f"the target on the next line. Got {r.library}."
+        )
+
+
+class TestV7ParagraphBoundaryEndToEnd:
+    """Codex round-6 C1 follow-on: `_normalize_text` collapsed `\\n\\n` to a
+    single space, destroying the paragraph-break signal the v7 detector
+    relies on. v7 passes the RAW scenario (not normalized) to the
+    resolver inside `analyze_scenario`. This test exercises the full
+    public path, which is what production consumers actually hit.
+    """
+
+    def test_paragraph_break_works_through_analyze_scenario(self):
+        from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+        nlp = NaturalLanguageProcessor()
+        result = _run(
+            nlp.analyze_scenario(
+                "Do not use this approach\n\nUse Playwright for the test.",
+                context="web",
+            )
+        )
+        assert (
+            result["analysis"]["explicit_library_preference"] == "Browser"
+        ), (
+            "Paragraph-break scoped negation must survive analyze_scenario's "
+            "_normalize_text step (v7 fix: detector now sees raw input)."
+        )
+
+
+class TestV7NlpProcessorAbstainNoFallback:
+    """Codex round-6 C3: `NaturalLanguageProcessor._detect_explicit_library_preference()`
+    used to fall back to the broad substring heuristic when v6 returned None,
+    re-introducing the bug the same way v5 did at the session level. v7 mirrors
+    the v6 session_models fix: fall back ONLY on Exception, never on
+    deliberate None.
+    """
+
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            "Parse the XML response from the API",  # was → XML via fallback
+            "Use requests for the API call",  # was → RequestsLibrary
+            "use database for the test",
+            "use ssh for deployment",
+            "use xml for the config",
+        ],
+    )
+    def test_nlp_processor_does_not_fall_back_on_abstain(self, scenario):
+        from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+        nlp = NaturalLanguageProcessor()
+        result = nlp._detect_explicit_library_preference(scenario)
+        assert result is None, (
+            f"v7 fix: helper must mirror session_models — no broad fallback "
+            f"on deliberate None. Got {result!r}"
+        )
+
+    def test_nlp_processor_still_returns_genuine_explicit(self):
+        from robotmcp.components.nlp_processor import NaturalLanguageProcessor
+        nlp = NaturalLanguageProcessor()
+        assert (
+            nlp._detect_explicit_library_preference("Use playwright to test")
+            == "Browser"
+        )
+        assert (
+            nlp._detect_explicit_library_preference(
+                "Use SeleniumLibrary for the test"
+            )
+            == "SeleniumLibrary"
+        )
+
+
+class TestSamplingOverrideCoherence:
+    """v5 (ADR-024 §11): Site A only maps sampling.library_preference into
+    explicit_library_preference. primary_library is NOT mapped (it's a
+    recommendation, not user-stated preference). When override fires,
+    evidence/conflicts are cleared and preference_source flips to 'sampling'.
+    """
+
+    def test_only_library_preference_writes_to_explicit_field(self, monkeypatch):
+        """v5 sampling Site A: primary_library alone does NOT override the
+        explicit field; only library_preference does."""
+
+        async def fake_sampling(ctx, scenario, context):
+            return {
+                "primary_library": "SeleniumLibrary",
+                # NO library_preference key → explicit field should stay
+                # whatever the rule-based detector produced.
+            }
+
+        monkeypatch.setattr(
+            "robotmcp.utils.sampling.sample_analyze_scenario", fake_sampling
+        )
+        monkeypatch.setattr(
+            "robotmcp.utils.sampling.is_sampling_enabled", lambda: True
+        )
+
+        # Use a scenario that the rule-based detector resolves to Browser
+        from robotmcp.server import analyze_scenario as analyze_tool
+
+        # @mcp.tool decorator wraps in FastMCP FunctionTool — call .fn for
+        # the underlying coroutine.
+        class _FakeCtx:
+            pass
+
+        result = _run(
+            analyze_tool.fn(
+                scenario="Use playwright to test demoshop",
+                context="web",
+                session_id="test_sampling_no_override",
+                ctx=_FakeCtx(),
+            )
+        )
+        analysis = result["analysis"]
+        # primary_library alone did NOT override — Browser still set, rule-based
+        assert analysis["explicit_library_preference"] == "Browser"
+        assert analysis["preference_source"] == "rule"
+
+    def test_library_preference_overrides_and_clears_evidence(self, monkeypatch):
+        async def fake_sampling(ctx, scenario, context):
+            return {
+                "library_preference": "SeleniumLibrary",
+                "rationale": "Detected via LLM",
+            }
+
+        monkeypatch.setattr(
+            "robotmcp.utils.sampling.sample_analyze_scenario", fake_sampling
+        )
+        monkeypatch.setattr(
+            "robotmcp.utils.sampling.is_sampling_enabled", lambda: True
+        )
+
+        from robotmcp.server import analyze_scenario as analyze_tool
+
+        class _FakeCtx:
+            pass
+
+        result = _run(
+            analyze_tool.fn(
+                scenario="Use playwright to test demoshop",
+                context="web",
+                session_id="test_sampling_override",
+                ctx=_FakeCtx(),
+            )
+        )
+        analysis = result["analysis"]
+        assert analysis["explicit_library_preference"] == "SeleniumLibrary"
+        assert analysis["preference_source"] == "sampling"
+        assert "explicit_library_evidence" not in analysis
+        assert "library_preference_conflicts" not in analysis
+        assert analysis.get("sampling_evidence") == "Detected via LLM"


### PR DESCRIPTION
## Summary

Fixes the user-reported defect (2026-05-29) where `analyze_scenario` returned `explicit_library_preference: "SeleniumLibrary"` for scenarios that never mention SeleniumLibrary:

```json
{
  "scenario": "Test e-commerce website https://demoshop.makrocode.de: open browser, add items to shopping cart, verify items, complete checkout, and close browser",
  "context": "web"
}
```
→ pre-fix: `"SeleniumLibrary"` ❌ → **post-fix: `null` ✓**

Root cause: a generic `\bopen\s+browser\b` weight-6 pattern alone cleared `min_score=5` in `library_detection.py`, despite the user not mentioning Selenium at all. The downstream cascade then auto-loaded SeleniumLibrary into the session, filtered Browser library out of `find_keywords` results, etc.

## Implementation (per ADR-024)

**New explicit-preference layer** in `library_detection.py` (`detect_explicit_preference`) alongside the legacy mention layer (`get_scores`). Patterns annotated `explicit=True/False`; only `explicit=True` contributes to preference scoring.

Key algorithm pieces:
- **Sentence-scoped negation/migration** via single `_NEGATION_REGEX` alternation (longest-first) + `_first_library_token_in()` two-step lookup
- **Paragraph-aware delimiter** `[.;!?,]+|\n\s*\n+` — single `\n` keeps negation contiguous; `\n\n` scopes it
- **Repeated-token deduction** via `findall` (was `search`, under-subtracted)
- **Multi-word migration destinations** (`to Browser library`, `to Requests library`) resolved via `_first_library_token_in()` on the captured destination
- **Conflict surfacing on raw scores BEFORE threshold** (dict shape `[{library, score, patterns_matched}]`)
- **`PreferenceResolution` value object** with `source: Literal["rule", "sampling"]` + evidence + conflicts
- **Brand-only preference verbs**: `selenium`/`playwright`/`appium` only; generic nouns (`browser`/`database`/`ssh`/`requests`/`xml`) excluded

**Session aggregate coherence** (`session_models.py`):
- No more broad-fallback on deliberate None (was the v5 round-5 D-session-fallback bug)
- New `preference_source` field for provenance

**NLP processor wiring** (`nlp_processor.py`):
- Race-free `_resolve_explicit_library_preference()` returns local PreferenceResolution
- Raw scenario passes to resolver (preserves paragraph breaks before `_normalize_text` collapse)
- New optional response fields: `preference_source`, `explicit_library_evidence`, `library_preference_conflicts`, `sampling_evidence`

**Sampling override coherence** (`server.py`):
- Site A: only `library_preference` writes to `explicit_library_preference`; `primary_library` fallback dropped (LLM recommendation ≠ user-stated preference)
- Site B: sets `session.preference_source="sampling"`

## Test plan

- [x] 83 new tests in `tests/unit/test_explicit_library_detection_fix.py`
- [x] Full unit suite: 6249 passed, 1 skipped, 0 failures
- [x] E2E via 3 LLM clients (Claude direct, Codex CLI via MCP, opencode via MCP) — all return `null` for the reported scenario
- [x] E2E paragraph-break case `"Do not use this approach\n\nUse Playwright for the test."` → `Browser` via all 3 CLIs
- [x] Downstream cascade verified fixed: opencode's `libraries_loaded` is `["BuiltIn"]` post-fix (was `["SeleniumLibrary", "BuiltIn"]` pre-fix)

## Review history

Seven rounds of Codex adversarial review (v1 → v7), each round finding issues the previous fix introduced. Final round-7 verdict: **PRODUCTION-READY YES**. Each design doc carries the full revision history.

## Out of scope (follow-up)

**C2 — Sampling Site B session-coherence**: when sampling overrides `session.explicit_library_preference` after `configure_from_scenario` already ran, `session.loaded_libraries` and `search_order` stay on the rule-based pick. Pre-existing architectural concern (not introduced by this PR); documented in proposal v7 history for a separate ADR/PR.

## Files changed

- `src/robotmcp/utils/library_detection.py` (~+750 / -200)
- `src/robotmcp/components/nlp_processor.py` (+142)
- `src/robotmcp/models/session_models.py` (+30)
- `src/robotmcp/server.py` (+15)
- `tests/unit/test_explicit_library_detection_fix.py` (+763, 83 tests)
- `docs/adr/ADR-024-explicit-library-detection-confidence.md` (new)
- `docs/prd/analyze_scenario_explicit_library_prd.md` (new)
- `docs/ddd/library_preference_bounded_context.md` (new)
- `docs/proposals/explicit_library_detection_fix_proposal.md` (new)
- `docs/issues/analyze_scenario_e2e_cross_cli_report.md` (new)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)