### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you are using Robot Framework to build an AI-powered test automation bridge that generates real Robot Framework tests from natural language descriptions.  We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [LOW] Pydantic AI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
   What it means: The project uses Pydantic AI in code but ships no agent-guidance doc (AGENTS. 
2. [LOW] Tool has no description
   File: src/robotmcp/domains/memory/adapters/fastmcp_adapter.py
   What it means: An MCP server publishes each tool's description to connecting clients as the text a model uses to decide whether to call the tool.

3. [LOW] Tool has no description
   File: src/robotmcp/domains/memory/adapters/fastmcp_adapter.py
   What it means: An MCP server publishes each tool's description to connecting clients as the text a model uses to decide whether to call the tool.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)